### PR TITLE
Add storage engine, catalog, executor — real SQL works

### DIFF
--- a/apps/engine/lib/engine.ex
+++ b/apps/engine/lib/engine.ex
@@ -2,4 +2,5 @@ defmodule Engine do
   defdelegate ping, to: Engine.Native
   defdelegate parse_sql(sql), to: Engine.Native
   defdelegate parse_sql_ast(sql), to: Engine.Native
+  defdelegate execute_sql(sql), to: Engine.Native
 end

--- a/apps/engine/lib/engine/native.ex
+++ b/apps/engine/lib/engine/native.ex
@@ -4,4 +4,5 @@ defmodule Engine.Native do
   def ping(), do: :erlang.nif_error(:nif_not_loaded)
   def parse_sql(_sql), do: :erlang.nif_error(:nif_not_loaded)
   def parse_sql_ast(_sql), do: :erlang.nif_error(:nif_not_loaded)
+  def execute_sql(_sql), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/apps/wire/lib/wire/connection.ex
+++ b/apps/wire/lib/wire/connection.ex
@@ -123,15 +123,13 @@ defmodule Wire.Connection do
     send_ready(socket)
   end
 
-  # --- Query dispatch (Phase 0 — hardcoded responses) ---
+  # --- Query dispatch — routes to Rust engine via NIF ---
 
   defp run_query(sql) do
     normalized = sql |> String.downcase() |> String.trim_trailing(";") |> String.trim()
 
+    # Handle built-in functions that need BEAM-side responses
     cond do
-      normalized == "select 1" ->
-        {:rows, [{"?column?", 23}], [["1"]], "SELECT 1"}
-
       normalized == "select version()" ->
         v = "pgrx 0.1.0 on BEAM/OTP 27 + Rust — PostgreSQL 18.0 compatible"
         {:rows, [{"version", 25}], [[v]], "SELECT 1"}
@@ -139,14 +137,34 @@ defmodule Wire.Connection do
       normalized == "select current_database()" ->
         {:rows, [{"current_database", 25}], [["pgrx"]], "SELECT 1"}
 
-      String.starts_with?(normalized, "set ") ->
-        {:command, "SET"}
-
       normalized == "" ->
         {:command, "EMPTY"}
 
       true ->
-        {:error, "not yet implemented: " <> String.slice(sql, 0, 60)}
+        case Engine.execute_sql(sql) do
+          {:ok, json} ->
+            result = Jason.decode!(json)
+            columns = Enum.map(result["columns"], fn [name, oid] -> {name, oid} end)
+            rows = result["rows"]
+            tag = result["tag"]
+
+            if columns == [] and rows == [] do
+              {:command, tag}
+            else
+              text_rows =
+                Enum.map(rows, fn row ->
+                  Enum.map(row, fn
+                    nil -> nil
+                    val -> val
+                  end)
+                end)
+
+              {:rows, columns, text_rows, tag}
+            end
+
+          {:error, msg} ->
+            {:error, msg}
+        end
     end
   end
 
@@ -165,8 +183,12 @@ defmodule Wire.Connection do
   defp send_data_row(s, vals) do
     fields =
       for v <- vals, into: <<>> do
-        bytes = to_string(v)
-        <<byte_size(bytes)::32, bytes::binary>>
+        case v do
+          nil -> <<-1::signed-32>>
+          val ->
+            bytes = to_string(val)
+            <<byte_size(bytes)::32, bytes::binary>>
+        end
       end
 
     payload = <<length(vals)::16, fields::binary>>

--- a/native/engine/Cargo.lock
+++ b/native/engine/Cargo.lock
@@ -98,10 +98,12 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 name = "engine"
 version = "0.1.0"
 dependencies = [
+ "parking_lot",
  "pg_query",
  "rustler",
  "serde",
  "serde_json",
+ "serial_test",
 ]
 
 [[package]]
@@ -149,6 +151,41 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -297,6 +334,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +383,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +438,12 @@ dependencies = [
  "serde_json",
  "thiserror",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "prettyplease"
@@ -455,6 +530,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
@@ -555,6 +639,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,10 +709,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "syn"

--- a/native/engine/Cargo.toml
+++ b/native/engine/Cargo.toml
@@ -13,3 +13,7 @@ rustler = "0.35"
 pg_query = "6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+parking_lot = "0.12"
+
+[dev-dependencies]
+serial_test = "3"

--- a/native/engine/src/catalog.rs
+++ b/native/engine/src/catalog.rs
@@ -1,0 +1,141 @@
+use crate::types::TypeOid;
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+/// Global catalog — lightweight in-memory metadata store.
+/// No MVCC, no heap storage, no vacuum. Just a RwLock'd HashMap.
+static CATALOG: LazyLock<RwLock<Catalog>> = LazyLock::new(|| RwLock::new(Catalog::new()));
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Column {
+    pub name: String,
+    pub type_oid: TypeOid,
+    pub nullable: bool,
+    pub primary_key: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Table {
+    pub name: String,
+    pub schema: String,
+    pub columns: Vec<Column>,
+}
+
+struct Catalog {
+    tables: HashMap<String, Table>,
+    next_oid: u32,
+}
+
+impl Catalog {
+    fn new() -> Self {
+        Self {
+            tables: HashMap::new(),
+            next_oid: 16384,
+        }
+    }
+}
+
+/// Fully qualified table name.
+fn fqn(schema: &str, name: &str) -> String {
+    format!("{}.{}", schema, name)
+}
+
+pub fn create_table(table: Table) -> Result<(), String> {
+    let mut cat = CATALOG.write();
+    let key = fqn(&table.schema, &table.name);
+    if cat.tables.contains_key(&key) {
+        return Err(format!("relation \"{}\" already exists", table.name));
+    }
+    cat.next_oid += 1;
+    cat.tables.insert(key, table);
+    Ok(())
+}
+
+pub fn drop_table(schema: &str, name: &str) -> Result<(), String> {
+    let mut cat = CATALOG.write();
+    let key = fqn(schema, name);
+    if cat.tables.remove(&key).is_none() {
+        return Err(format!("table \"{}\" does not exist", name));
+    }
+    Ok(())
+}
+
+pub fn get_table(schema: &str, name: &str) -> Option<Table> {
+    let cat = CATALOG.read();
+    cat.tables.get(&fqn(schema, name)).cloned()
+}
+
+pub fn table_exists(schema: &str, name: &str) -> bool {
+    let cat = CATALOG.read();
+    cat.tables.contains_key(&fqn(schema, name))
+}
+
+pub fn list_tables(schema: &str) -> Vec<Table> {
+    let cat = CATALOG.read();
+    let prefix = format!("{}.", schema);
+    cat.tables
+        .iter()
+        .filter(|(k, _)| k.starts_with(&prefix))
+        .map(|(_, t)| t.clone())
+        .collect()
+}
+
+pub fn reset() {
+    let mut cat = CATALOG.write();
+    cat.tables.clear();
+    cat.next_oid = 16384;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_table() -> Table {
+        Table {
+            name: "users".to_string(),
+            schema: "public".to_string(),
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    type_oid: TypeOid::Int4,
+                    nullable: false,
+                    primary_key: true,
+                },
+                Column {
+                    name: "name".to_string(),
+                    type_oid: TypeOid::Text,
+                    nullable: false,
+                    primary_key: false,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn create_and_get() {
+        reset();
+        create_table(test_table()).unwrap();
+        let t = get_table("public", "users").unwrap();
+        assert_eq!(t.columns.len(), 2);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn duplicate_create_fails() {
+        reset();
+        create_table(test_table()).unwrap();
+        assert!(create_table(test_table()).is_err());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn drop_works() {
+        reset();
+        create_table(test_table()).unwrap();
+        drop_table("public", "users").unwrap();
+        assert!(!table_exists("public", "users"));
+    }
+}

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -1,0 +1,537 @@
+use pg_query::NodeEnum;
+use serde::Serialize;
+
+use crate::catalog::{self, Column, Table};
+use crate::storage;
+use crate::types::{TypeOid, Value};
+
+#[derive(Debug, Serialize)]
+pub struct QueryResult {
+    pub tag: String,
+    pub columns: Vec<(String, i32)>,
+    pub rows: Vec<Vec<Option<String>>>,
+}
+
+pub fn execute(sql: &str) -> Result<QueryResult, String> {
+    let parsed = pg_query::parse(sql).map_err(|e| e.to_string())?;
+
+    let raw_stmt = parsed
+        .protobuf
+        .stmts
+        .first()
+        .ok_or("empty query")?;
+
+    let stmt = raw_stmt
+        .stmt
+        .as_ref()
+        .ok_or("missing statement")?;
+
+    let node = stmt.node.as_ref().ok_or("missing node")?;
+
+    match node {
+        NodeEnum::CreateStmt(create) => exec_create_table(create),
+        NodeEnum::DropStmt(drop) => exec_drop(drop),
+        NodeEnum::InsertStmt(insert) => exec_insert(insert),
+        NodeEnum::SelectStmt(select) => exec_select(select, sql),
+        NodeEnum::DeleteStmt(delete) => exec_delete(delete),
+        NodeEnum::TruncateStmt(trunc) => exec_truncate(trunc),
+        NodeEnum::VariableSetStmt(_) => Ok(QueryResult {
+            tag: "SET".into(),
+            columns: vec![],
+            rows: vec![],
+        }),
+        NodeEnum::VariableShowStmt(_) => Ok(QueryResult {
+            tag: "SHOW".into(),
+            columns: vec![],
+            rows: vec![],
+        }),
+        NodeEnum::TransactionStmt(_) => Ok(QueryResult {
+            tag: "OK".into(),
+            columns: vec![],
+            rows: vec![],
+        }),
+        _ => Err(format!("unsupported statement type")),
+    }
+}
+
+fn exec_create_table(
+    create: &pg_query::protobuf::CreateStmt,
+) -> Result<QueryResult, String> {
+    let rel = create
+        .relation
+        .as_ref()
+        .ok_or("CREATE TABLE missing relation")?;
+    let table_name = &rel.relname;
+    let schema = if rel.schemaname.is_empty() {
+        "public"
+    } else {
+        &rel.schemaname
+    };
+
+    let mut columns = Vec::new();
+    for elt in &create.table_elts {
+        let node = elt.node.as_ref().ok_or("missing table element")?;
+        if let NodeEnum::ColumnDef(col) = node {
+            let type_name = extract_type_name(col);
+            let nullable = !col.is_not_null;
+            columns.push(Column {
+                name: col.colname.clone(),
+                type_oid: TypeOid::from_name(&type_name),
+                nullable,
+                primary_key: false,
+            });
+        }
+    }
+
+    let table = Table {
+        name: table_name.clone(),
+        schema: schema.to_string(),
+        columns,
+    };
+
+    catalog::create_table(table)?;
+    storage::create_table(schema, table_name);
+
+    Ok(QueryResult {
+        tag: "CREATE TABLE".into(),
+        columns: vec![],
+        rows: vec![],
+    })
+}
+
+fn extract_type_name(col: &pg_query::protobuf::ColumnDef) -> String {
+    col.type_name
+        .as_ref()
+        .map(|tn| {
+            tn.names
+                .iter()
+                .filter_map(|n| n.node.as_ref())
+                .filter_map(|node| {
+                    if let NodeEnum::String(s) = node {
+                        Some(s.sval.clone())
+                    } else {
+                        None
+                    }
+                })
+                .last()
+                .unwrap_or_else(|| "text".into())
+        })
+        .unwrap_or_else(|| "text".into())
+}
+
+fn exec_drop(drop: &pg_query::protobuf::DropStmt) -> Result<QueryResult, String> {
+    for obj in &drop.objects {
+        if let Some(NodeEnum::List(list)) = obj.node.as_ref() {
+            let parts: Vec<String> = list
+                .items
+                .iter()
+                .filter_map(|i| i.node.as_ref())
+                .filter_map(|n| {
+                    if let NodeEnum::String(s) = n {
+                        Some(s.sval.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            let (schema, name) = if parts.len() >= 2 {
+                (parts[0].as_str(), parts[1].as_str())
+            } else if parts.len() == 1 {
+                ("public", parts[0].as_str())
+            } else {
+                continue;
+            };
+
+            catalog::drop_table(schema, name)?;
+            storage::drop_table(schema, name);
+        }
+    }
+
+    Ok(QueryResult {
+        tag: "DROP TABLE".into(),
+        columns: vec![],
+        rows: vec![],
+    })
+}
+
+fn exec_insert(
+    insert: &pg_query::protobuf::InsertStmt,
+) -> Result<QueryResult, String> {
+    let rel = insert
+        .relation
+        .as_ref()
+        .ok_or("INSERT missing relation")?;
+    let table_name = &rel.relname;
+    let schema = if rel.schemaname.is_empty() {
+        "public"
+    } else {
+        &rel.schemaname
+    };
+
+    let table_def = catalog::get_table(schema, table_name)
+        .ok_or_else(|| format!("relation \"{}\" does not exist", table_name))?;
+
+    // Get target column names (or all columns if not specified)
+    let target_cols: Vec<String> = if insert.cols.is_empty() {
+        table_def.columns.iter().map(|c| c.name.clone()).collect()
+    } else {
+        insert
+            .cols
+            .iter()
+            .filter_map(|n| n.node.as_ref())
+            .filter_map(|node| {
+                if let NodeEnum::ResTarget(rt) = node {
+                    Some(rt.name.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    };
+
+    // Extract VALUES rows from the select_stmt
+    let select = insert
+        .select_stmt
+        .as_ref()
+        .and_then(|s| s.node.as_ref())
+        .ok_or("INSERT missing VALUES")?;
+
+    let mut row_count = 0u64;
+
+    if let NodeEnum::SelectStmt(sel) = select {
+        let values_lists = &sel.values_lists;
+        for values_list in values_lists {
+            if let Some(NodeEnum::List(list)) = values_list.node.as_ref() {
+                let mut row = vec![Value::Null; table_def.columns.len()];
+
+                for (i, val_node) in list.items.iter().enumerate() {
+                    if i >= target_cols.len() {
+                        break;
+                    }
+                    let col_name = &target_cols[i];
+                    let col_idx = table_def
+                        .columns
+                        .iter()
+                        .position(|c| &c.name == col_name)
+                        .ok_or_else(|| {
+                            format!("column \"{}\" does not exist", col_name)
+                        })?;
+
+                    row[col_idx] = eval_const(val_node.node.as_ref());
+                }
+                storage::insert(schema, table_name, row)?;
+                row_count += 1;
+            }
+        }
+    }
+
+    Ok(QueryResult {
+        tag: format!("INSERT 0 {}", row_count),
+        columns: vec![],
+        rows: vec![],
+    })
+}
+
+fn eval_const(node: Option<&NodeEnum>) -> Value {
+    match node {
+        Some(NodeEnum::Integer(i)) => Value::Int(i.ival as i64),
+        Some(NodeEnum::Float(f)) => {
+            f.fval.parse::<f64>().map(Value::Float).unwrap_or(Value::Null)
+        }
+        Some(NodeEnum::String(s)) => Value::Text(s.sval.clone()),
+        Some(NodeEnum::AConst(ac)) => {
+            if let Some(val) = &ac.val {
+                match val {
+                    pg_query::protobuf::a_const::Val::Ival(i) => Value::Int(i.ival as i64),
+                    pg_query::protobuf::a_const::Val::Fval(f) => f
+                        .fval
+                        .parse::<f64>()
+                        .map(Value::Float)
+                        .unwrap_or(Value::Null),
+                    pg_query::protobuf::a_const::Val::Sval(s) => {
+                        Value::Text(s.sval.clone())
+                    }
+                    pg_query::protobuf::a_const::Val::Bsval(s) => {
+                        Value::Text(s.bsval.clone())
+                    }
+                    pg_query::protobuf::a_const::Val::Boolval(b) => {
+                        Value::Bool(b.boolval)
+                    }
+                }
+            } else if ac.isnull {
+                Value::Null
+            } else {
+                Value::Null
+            }
+        }
+        Some(NodeEnum::TypeCast(tc)) => {
+            eval_const(tc.arg.as_ref().and_then(|a| a.node.as_ref()))
+        }
+        _ => Value::Null,
+    }
+}
+
+fn exec_select(
+    select: &pg_query::protobuf::SelectStmt,
+    _raw_sql: &str,
+) -> Result<QueryResult, String> {
+    // Check for VALUES-less SELECT (e.g., SELECT 1, SELECT version())
+    if select.from_clause.is_empty() {
+        return exec_select_no_from(select);
+    }
+
+    // Get table from FROM clause
+    let from = select.from_clause.first().ok_or("missing FROM")?;
+    let (schema, table_name) = extract_from_table(from.node.as_ref())?;
+
+    let table_def = catalog::get_table(&schema, &table_name)
+        .ok_or_else(|| format!("relation \"{}\" does not exist", table_name))?;
+
+    let rows = storage::scan(&schema, &table_name)?;
+
+    // Resolve target columns
+    let (col_names, col_indices) = resolve_select_targets(select, &table_def)?;
+    let columns: Vec<(String, i32)> = col_names
+        .iter()
+        .zip(col_indices.iter())
+        .map(|(name, &idx)| (name.clone(), table_def.columns[idx].type_oid.oid()))
+        .collect();
+
+    // Project rows
+    let result_rows: Vec<Vec<Option<String>>> = rows
+        .iter()
+        .map(|row| {
+            col_indices
+                .iter()
+                .map(|&idx| row.get(idx).and_then(|v| v.to_text()))
+                .collect()
+        })
+        .collect();
+
+    let count = result_rows.len();
+    Ok(QueryResult {
+        tag: format!("SELECT {}", count),
+        columns,
+        rows: result_rows,
+    })
+}
+
+fn exec_select_no_from(
+    select: &pg_query::protobuf::SelectStmt,
+) -> Result<QueryResult, String> {
+    let mut columns = Vec::new();
+    let mut row = Vec::new();
+
+    for target in &select.target_list {
+        if let Some(NodeEnum::ResTarget(rt)) = target.node.as_ref() {
+            let alias = if rt.name.is_empty() {
+                "?column?".to_string()
+            } else {
+                rt.name.clone()
+            };
+            let val = eval_const(rt.val.as_ref().and_then(|v| v.node.as_ref()));
+            columns.push((alias, TypeOid::Text.oid()));
+            row.push(val.to_text());
+        }
+    }
+
+    Ok(QueryResult {
+        tag: "SELECT 1".into(),
+        columns,
+        rows: vec![row],
+    })
+}
+
+fn extract_from_table(node: Option<&NodeEnum>) -> Result<(String, String), String> {
+    match node {
+        Some(NodeEnum::RangeVar(rv)) => {
+            let schema = if rv.schemaname.is_empty() {
+                "public".to_string()
+            } else {
+                rv.schemaname.clone()
+            };
+            Ok((schema, rv.relname.clone()))
+        }
+        _ => Err("unsupported FROM clause".into()),
+    }
+}
+
+fn resolve_select_targets(
+    select: &pg_query::protobuf::SelectStmt,
+    table: &Table,
+) -> Result<(Vec<String>, Vec<usize>), String> {
+    let mut names = Vec::new();
+    let mut indices = Vec::new();
+
+    for target in &select.target_list {
+        if let Some(NodeEnum::ResTarget(rt)) = target.node.as_ref() {
+            match rt.val.as_ref().and_then(|v| v.node.as_ref()) {
+                Some(NodeEnum::ColumnRef(cref)) => {
+                    let col_name = cref
+                        .fields
+                        .iter()
+                        .filter_map(|f| f.node.as_ref())
+                        .filter_map(|n| match n {
+                            NodeEnum::String(s) => Some(s.sval.clone()),
+                            NodeEnum::AStar(_) => Some("*".to_string()),
+                            _ => None,
+                        })
+                        .last()
+                        .unwrap_or_default();
+
+                    if col_name == "*" {
+                        for (i, col) in table.columns.iter().enumerate() {
+                            names.push(col.name.clone());
+                            indices.push(i);
+                        }
+                    } else {
+                        let idx = table
+                            .columns
+                            .iter()
+                            .position(|c| c.name == col_name)
+                            .ok_or_else(|| {
+                                format!("column \"{}\" does not exist", col_name)
+                            })?;
+                        let alias = if rt.name.is_empty() {
+                            col_name
+                        } else {
+                            rt.name.clone()
+                        };
+                        names.push(alias);
+                        indices.push(idx);
+                    }
+                }
+                _ => {
+                    names.push("?column?".to_string());
+                    indices.push(0);
+                }
+            }
+        }
+    }
+
+    Ok((names, indices))
+}
+
+fn exec_delete(
+    delete: &pg_query::protobuf::DeleteStmt,
+) -> Result<QueryResult, String> {
+    let rel = delete
+        .relation
+        .as_ref()
+        .ok_or("DELETE missing relation")?;
+    let table_name = &rel.relname;
+    let schema = if rel.schemaname.is_empty() {
+        "public"
+    } else {
+        &rel.schemaname
+    };
+
+    // For now: DELETE without WHERE deletes all rows
+    if delete.where_clause.is_some() {
+        return Err("DELETE with WHERE not yet implemented".into());
+    }
+
+    let count = storage::delete_all(schema, table_name)?;
+    Ok(QueryResult {
+        tag: format!("DELETE {}", count),
+        columns: vec![],
+        rows: vec![],
+    })
+}
+
+fn exec_truncate(
+    trunc: &pg_query::protobuf::TruncateStmt,
+) -> Result<QueryResult, String> {
+    for rel_node in &trunc.relations {
+        if let Some(NodeEnum::RangeVar(rv)) = rel_node.node.as_ref() {
+            let schema = if rv.schemaname.is_empty() {
+                "public"
+            } else {
+                &rv.schemaname
+            };
+            storage::delete_all(schema, &rv.relname)?;
+        }
+    }
+    Ok(QueryResult {
+        tag: "TRUNCATE TABLE".into(),
+        columns: vec![],
+        rows: vec![],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup() {
+        catalog::reset();
+        storage::reset();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn create_and_insert_and_select() {
+        setup();
+        execute("CREATE TABLE users (id integer, name text)").unwrap();
+        execute("INSERT INTO users VALUES (1, 'alice')").unwrap();
+        execute("INSERT INTO users VALUES (2, 'bob')").unwrap();
+
+        let result = execute("SELECT * FROM users").unwrap();
+        assert_eq!(result.rows.len(), 2);
+        assert_eq!(result.columns.len(), 2);
+        assert_eq!(result.rows[0][0], Some("1".into()));
+        assert_eq!(result.rows[0][1], Some("alice".into()));
+        assert_eq!(result.rows[1][1], Some("bob".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn select_specific_columns() {
+        setup();
+        execute("CREATE TABLE t (a int, b text, c int)").unwrap();
+        execute("INSERT INTO t VALUES (1, 'x', 10)").unwrap();
+
+        let result = execute("SELECT b, c FROM t").unwrap();
+        assert_eq!(result.columns.len(), 2);
+        assert_eq!(result.columns[0].0, "b");
+        assert_eq!(result.rows[0][0], Some("x".into()));
+        assert_eq!(result.rows[0][1], Some("10".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn select_no_from() {
+        setup();
+        let result = execute("SELECT 42").unwrap();
+        assert_eq!(result.rows[0][0], Some("42".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn drop_table() {
+        setup();
+        execute("CREATE TABLE t (id int)").unwrap();
+        execute("DROP TABLE t").unwrap();
+        assert!(execute("SELECT * FROM t").is_err());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn insert_into_nonexistent() {
+        setup();
+        assert!(execute("INSERT INTO ghost VALUES (1)").is_err());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn truncate() {
+        setup();
+        execute("CREATE TABLE t (id int)").unwrap();
+        execute("INSERT INTO t VALUES (1)").unwrap();
+        execute("INSERT INTO t VALUES (2)").unwrap();
+        execute("TRUNCATE t").unwrap();
+        let result = execute("SELECT * FROM t").unwrap();
+        assert_eq!(result.rows.len(), 0);
+    }
+}

--- a/native/engine/src/lib.rs
+++ b/native/engine/src/lib.rs
@@ -1,4 +1,8 @@
+mod catalog;
+mod executor;
 mod parser;
+mod storage;
+mod types;
 
 #[rustler::nif]
 fn ping() -> &'static str {
@@ -13,6 +17,12 @@ fn parse_sql(sql: &str) -> Result<String, String> {
 #[rustler::nif]
 fn parse_sql_ast(sql: &str) -> Result<String, String> {
     parser::parse_ast(sql)
+}
+
+#[rustler::nif]
+fn execute_sql(sql: &str) -> Result<String, String> {
+    let result = executor::execute(sql)?;
+    serde_json::to_string(&result).map_err(|e| e.to_string())
 }
 
 rustler::init!("Elixir.Engine.Native");

--- a/native/engine/src/storage.rs
+++ b/native/engine/src/storage.rs
@@ -1,0 +1,126 @@
+use crate::types::Value;
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+/// In-memory row storage. Each table maps to a Vec of rows.
+/// This is the Phase 1 storage — will be replaced with a persistent
+/// B-tree engine with undo-log MVCC and direct I/O in Phase 2.
+static STORE: LazyLock<RwLock<Storage>> = LazyLock::new(|| RwLock::new(Storage::new()));
+
+type Row = Vec<Value>;
+
+struct TableStore {
+    rows: Vec<Row>,
+}
+
+struct Storage {
+    tables: HashMap<String, TableStore>,
+}
+
+impl Storage {
+    fn new() -> Self {
+        Self {
+            tables: HashMap::new(),
+        }
+    }
+}
+
+fn key(schema: &str, name: &str) -> String {
+    format!("{}.{}", schema, name)
+}
+
+pub fn create_table(schema: &str, name: &str) {
+    let mut store = STORE.write();
+    store
+        .tables
+        .insert(key(schema, name), TableStore { rows: Vec::new() });
+}
+
+pub fn drop_table(schema: &str, name: &str) {
+    let mut store = STORE.write();
+    store.tables.remove(&key(schema, name));
+}
+
+pub fn insert(schema: &str, name: &str, row: Row) -> Result<(), String> {
+    let mut store = STORE.write();
+    let table = store
+        .tables
+        .get_mut(&key(schema, name))
+        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+    table.rows.push(row);
+    Ok(())
+}
+
+pub fn scan(schema: &str, name: &str) -> Result<Vec<Row>, String> {
+    let store = STORE.read();
+    let table = store
+        .tables
+        .get(&key(schema, name))
+        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+    Ok(table.rows.clone())
+}
+
+pub fn delete_all(schema: &str, name: &str) -> Result<u64, String> {
+    let mut store = STORE.write();
+    let table = store
+        .tables
+        .get_mut(&key(schema, name))
+        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+    let count = table.rows.len() as u64;
+    table.rows.clear();
+    Ok(count)
+}
+
+pub fn row_count(schema: &str, name: &str) -> Result<u64, String> {
+    let store = STORE.read();
+    let table = store
+        .tables
+        .get(&key(schema, name))
+        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+    Ok(table.rows.len() as u64)
+}
+
+pub fn reset() {
+    let mut store = STORE.write();
+    store.tables.clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[serial_test::serial]
+    fn insert_and_scan() {
+        reset();
+        create_table("public", "t");
+        insert(
+            "public",
+            "t",
+            vec![Value::Int(1), Value::Text("hello".into())],
+        )
+        .unwrap();
+        insert(
+            "public",
+            "t",
+            vec![Value::Int(2), Value::Text("world".into())],
+        )
+        .unwrap();
+        let rows = scan("public", "t").unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0][0], Value::Int(1));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn delete_all_works() {
+        reset();
+        create_table("public", "t");
+        insert("public", "t", vec![Value::Int(1)]).unwrap();
+        insert("public", "t", vec![Value::Int(2)]).unwrap();
+        let count = delete_all("public", "t").unwrap();
+        assert_eq!(count, 2);
+        assert_eq!(scan("public", "t").unwrap().len(), 0);
+    }
+}

--- a/native/engine/src/types.rs
+++ b/native/engine/src/types.rs
@@ -1,0 +1,66 @@
+use serde::{Deserialize, Serialize};
+
+/// Runtime values for SQL expressions.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum Value {
+    Null,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    Text(String),
+    Bytea(Vec<u8>),
+}
+
+impl Value {
+    pub fn to_text(&self) -> Option<String> {
+        match self {
+            Value::Null => None,
+            Value::Bool(b) => Some(if *b { "t" } else { "f" }.to_string()),
+            Value::Int(i) => Some(i.to_string()),
+            Value::Float(f) => Some(f.to_string()),
+            Value::Text(s) => Some(s.clone()),
+            Value::Bytea(b) => Some(format!("\\x{}", hex_encode(b))),
+        }
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+/// Column type OIDs matching PostgreSQL.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub enum TypeOid {
+    Bool = 16,
+    Bytea = 17,
+    Int8 = 20,
+    Int2 = 21,
+    Int4 = 23,
+    Text = 25,
+    Float4 = 700,
+    Float8 = 701,
+    Varchar = 1043,
+    Numeric = 1700,
+}
+
+impl TypeOid {
+    pub fn from_name(name: &str) -> Self {
+        match name.to_lowercase().as_str() {
+            "bool" | "boolean" => TypeOid::Bool,
+            "int2" | "smallint" => TypeOid::Int2,
+            "int4" | "integer" | "int" | "serial" => TypeOid::Int4,
+            "int8" | "bigint" | "bigserial" => TypeOid::Int8,
+            "float4" | "real" => TypeOid::Float4,
+            "float8" | "double precision" => TypeOid::Float8,
+            "numeric" | "decimal" => TypeOid::Numeric,
+            "text" => TypeOid::Text,
+            "varchar" | "character varying" => TypeOid::Varchar,
+            "bytea" => TypeOid::Bytea,
+            _ => TypeOid::Text,
+        }
+    }
+
+    pub fn oid(&self) -> i32 {
+        *self as i32
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 complete. pgrx now executes real SQL against real storage via the Rust engine.

- **Catalog**: lightweight in-memory metadata store (no MVCC, no heap bloat — unlike PostgreSQL's 65 catalog tables)
- **Storage**: in-memory row storage (Phase 1 placeholder — will become persistent B-tree with undo-log MVCC)
- **Executor**: walks the pg_query AST and dispatches to catalog/storage
- **Types**: Value enum + TypeOid with correct PostgreSQL OIDs (int4=23, text=25, etc.)
- **Wire protocol**: updated to route through Rust executor instead of hardcoded responses

### What works end-to-end via real psql:
```sql
CREATE TABLE users (id integer, name text, email text);
INSERT INTO users VALUES (1, 'alice', 'alice@example.com');
SELECT * FROM users;
SELECT name, email FROM users;
DROP TABLE users;
TRUNCATE users;
```

18 Rust tests, all passing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/pgrx/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
