### PR TITLE
Phase 2: SQL query engine — WHERE, ORDER BY, expressions, constraints, aggregates

### DIFF
--- a/native/engine/src/catalog.rs
+++ b/native/engine/src/catalog.rs
@@ -14,6 +14,7 @@ pub struct Column {
     pub type_oid: TypeOid,
     pub nullable: bool,
     pub primary_key: bool,
+    pub unique: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -102,12 +103,14 @@ mod tests {
                     type_oid: TypeOid::Int4,
                     nullable: false,
                     primary_key: true,
+                    unique: true,
                 },
                 Column {
                     name: "name".to_string(),
                     type_oid: TypeOid::Text,
                     nullable: false,
                     primary_key: false,
+                    unique: false,
                 },
             ],
         }

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -304,7 +304,6 @@ fn exec_insert(
 // ── Constraint enforcement ────────────────────────────────────────────
 
 fn check_constraints(table: &Table, row: &[Value], schema: &str) -> Result<(), String> {
-    // Collect PK column indices for composite PK check
     let pk_cols: Vec<usize> = table
         .columns
         .iter()
@@ -313,7 +312,7 @@ fn check_constraints(table: &Table, row: &[Value], schema: &str) -> Result<(), S
         .map(|(i, _)| i)
         .collect();
 
-    // NOT NULL checks
+    // NOT NULL checks (no scan needed)
     for (i, col) in table.columns.iter().enumerate() {
         if !col.nullable && matches!(row[i], Value::Null) {
             return Err(format!(
@@ -323,9 +322,21 @@ fn check_constraints(table: &Table, row: &[Value], schema: &str) -> Result<(), S
         }
     }
 
-    // Composite PK check (if multiple PK columns)
+    // Check if any uniqueness checks are needed before scanning
+    let needs_unique_check = pk_cols.len() > 1
+        || table.columns.iter().enumerate().any(|(_, c)| {
+            (c.primary_key || c.unique)
+        });
+
+    if !needs_unique_check {
+        return Ok(());
+    }
+
+    // Scan existing rows ONCE for all constraint checks
+    let existing = storage::scan(schema, &table.name)?;
+
+    // Composite PK check
     if pk_cols.len() > 1 {
-        let existing = storage::scan(schema, &table.name)?;
         let new_key: Vec<&Value> = pk_cols.iter().map(|&i| &row[i]).collect();
         for erow in &existing {
             let ekey: Vec<&Value> = pk_cols.iter().map(|&i| &erow[i]).collect();
@@ -341,11 +352,9 @@ fn check_constraints(table: &Table, row: &[Value], schema: &str) -> Result<(), S
     // Per-column UNIQUE / single-column PK checks
     for (i, col) in table.columns.iter().enumerate() {
         if (col.primary_key || col.unique) && !matches!(row[i], Value::Null) {
-            // Skip composite PK columns (already checked above)
             if col.primary_key && pk_cols.len() > 1 {
                 continue;
             }
-            let existing = storage::scan(schema, &table.name)?;
             for erow in &existing {
                 if i < erow.len() && erow[i] == row[i] {
                     let cname = if col.primary_key {
@@ -495,7 +504,9 @@ fn eval_a_expr(
             .and_then(|n| n.node.as_ref())
             .ok_or("unary - missing operand")?;
         return match eval_expr(right, row, table)? {
-            Value::Int(n) => Ok(Value::Int(-n)),
+            Value::Int(n) => Ok(Value::Int(
+                n.checked_neg().ok_or("integer out of range")?,
+            )),
             Value::Float(f) => Ok(Value::Float(-f)),
             Value::Null => Ok(Value::Null),
             _ => Err("unary minus requires numeric".into()),
@@ -603,14 +614,22 @@ fn eval_arithmetic(op: &str, left: &Value, right: &Value) -> Result<Value, Strin
     }
     match (left, right) {
         (Value::Int(a), Value::Int(b)) => match op {
-            "+" => Ok(Value::Int(a + b)),
-            "-" => Ok(Value::Int(a - b)),
-            "*" => Ok(Value::Int(a * b)),
+            "+" => Ok(Value::Int(
+                a.checked_add(*b).ok_or("integer out of range")?,
+            )),
+            "-" => Ok(Value::Int(
+                a.checked_sub(*b).ok_or("integer out of range")?,
+            )),
+            "*" => Ok(Value::Int(
+                a.checked_mul(*b).ok_or("integer out of range")?,
+            )),
             "/" => {
                 if *b == 0 {
                     Err("division by zero".into())
                 } else {
-                    Ok(Value::Int(a / b))
+                    Ok(Value::Int(
+                        a.checked_div(*b).ok_or("integer out of range")?,
+                    ))
                 }
             }
             _ => Err(format!("unsupported arithmetic op: {}", op)),
@@ -690,7 +709,9 @@ fn eval_scalar_function(name: &str, args: &[Value]) -> Result<Value, String> {
             Ok(Value::Text(parts))
         }
         "abs" => match args.first() {
-            Some(Value::Int(n)) => Ok(Value::Int(n.abs())),
+            Some(Value::Int(n)) => Ok(Value::Int(
+                n.checked_abs().ok_or("integer out of range")?,
+            )),
             Some(Value::Float(f)) => Ok(Value::Float(f.abs())),
             Some(Value::Null) => Ok(Value::Null),
             _ => Err("abs() requires numeric argument".into()),

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use pg_query::NodeEnum;
 use serde::Serialize;
 
@@ -32,7 +34,7 @@ pub fn execute(sql: &str) -> Result<QueryResult, String> {
         NodeEnum::CreateStmt(create) => exec_create_table(create),
         NodeEnum::DropStmt(drop) => exec_drop(drop),
         NodeEnum::InsertStmt(insert) => exec_insert(insert),
-        NodeEnum::SelectStmt(select) => exec_select(select, sql),
+        NodeEnum::SelectStmt(select) => exec_select(select),
         NodeEnum::DeleteStmt(delete) => exec_delete(delete),
         NodeEnum::UpdateStmt(update) => exec_update(update),
         NodeEnum::TruncateStmt(trunc) => exec_truncate(trunc),
@@ -51,9 +53,11 @@ pub fn execute(sql: &str) -> Result<QueryResult, String> {
             columns: vec![],
             rows: vec![],
         }),
-        _ => Err(format!("unsupported statement type")),
+        _ => Err("unsupported statement type".into()),
     }
 }
+
+// ── CREATE TABLE ──────────────────────────────────────────────────────
 
 fn exec_create_table(
     create: &pg_query::protobuf::CreateStmt,
@@ -74,13 +78,75 @@ fn exec_create_table(
         let node = elt.node.as_ref().ok_or("missing table element")?;
         if let NodeEnum::ColumnDef(col) = node {
             let type_name = extract_type_name(col);
-            let nullable = !col.is_not_null;
+            let mut nullable = !col.is_not_null;
+            let mut primary_key = false;
+            let mut unique = false;
+
+            // Parse inline constraints
+            for cnode in &col.constraints {
+                if let Some(NodeEnum::Constraint(c)) = cnode.node.as_ref() {
+                    match c.contype {
+                        x if x == pg_query::protobuf::ConstrType::ConstrPrimary as i32 => {
+                            primary_key = true;
+                            nullable = false;
+                            unique = true;
+                        }
+                        x if x == pg_query::protobuf::ConstrType::ConstrUnique as i32 => {
+                            unique = true;
+                        }
+                        x if x == pg_query::protobuf::ConstrType::ConstrNotnull as i32 => {
+                            nullable = false;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
             columns.push(Column {
                 name: col.colname.clone(),
                 type_oid: TypeOid::from_name(&type_name),
                 nullable,
-                primary_key: false,
+                primary_key,
+                unique,
             });
+        }
+    }
+
+    // Handle table-level constraints (e.g., PRIMARY KEY (a, b))
+    for elt in &create.table_elts {
+        if let Some(NodeEnum::Constraint(c)) = elt.node.as_ref() {
+            let key_cols: Vec<String> = c
+                .keys
+                .iter()
+                .filter_map(|k| k.node.as_ref())
+                .filter_map(|n| {
+                    if let NodeEnum::String(s) = n {
+                        Some(s.sval.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            match c.contype {
+                x if x == pg_query::protobuf::ConstrType::ConstrPrimary as i32 => {
+                    for col in &mut columns {
+                        if key_cols.contains(&col.name) {
+                            col.primary_key = true;
+                            col.nullable = false;
+                            col.unique = true;
+                        }
+                    }
+                }
+                x if x == pg_query::protobuf::ConstrType::ConstrUnique as i32 => {
+                    for col in &mut columns {
+                        if key_cols.contains(&col.name) {
+                            col.unique = true;
+                        }
+                    }
+                }
+                _ => {}
+            }
         }
     }
 
@@ -120,6 +186,8 @@ fn extract_type_name(col: &pg_query::protobuf::ColumnDef) -> String {
         .unwrap_or_else(|| "text".into())
 }
 
+// ── DROP ──────────────────────────────────────────────────────────────
+
 fn exec_drop(drop: &pg_query::protobuf::DropStmt) -> Result<QueryResult, String> {
     for obj in &drop.objects {
         if let Some(NodeEnum::List(list)) = obj.node.as_ref() {
@@ -156,6 +224,8 @@ fn exec_drop(drop: &pg_query::protobuf::DropStmt) -> Result<QueryResult, String>
     })
 }
 
+// ── INSERT ────────────────────────────────────────────────────────────
+
 fn exec_insert(
     insert: &pg_query::protobuf::InsertStmt,
 ) -> Result<QueryResult, String> {
@@ -173,7 +243,6 @@ fn exec_insert(
     let table_def = catalog::get_table(schema, table_name)
         .ok_or_else(|| format!("relation \"{}\" does not exist", table_name))?;
 
-    // Get target column names (or all columns if not specified)
     let target_cols: Vec<String> = if insert.cols.is_empty() {
         table_def.columns.iter().map(|c| c.name.clone()).collect()
     } else {
@@ -191,7 +260,6 @@ fn exec_insert(
             .collect()
     };
 
-    // Extract VALUES rows from the select_stmt
     let select = insert
         .select_stmt
         .as_ref()
@@ -201,8 +269,7 @@ fn exec_insert(
     let mut row_count = 0u64;
 
     if let NodeEnum::SelectStmt(sel) = select {
-        let values_lists = &sel.values_lists;
-        for values_list in values_lists {
+        for values_list in &sel.values_lists {
             if let Some(NodeEnum::List(list)) = values_list.node.as_ref() {
                 let mut row = vec![Value::Null; table_def.columns.len()];
 
@@ -215,12 +282,12 @@ fn exec_insert(
                         .columns
                         .iter()
                         .position(|c| &c.name == col_name)
-                        .ok_or_else(|| {
-                            format!("column \"{}\" does not exist", col_name)
-                        })?;
+                        .ok_or_else(|| format!("column \"{}\" does not exist", col_name))?;
 
                     row[col_idx] = eval_const(val_node.node.as_ref());
                 }
+
+                check_constraints(&table_def, &row, schema)?;
                 storage::insert(schema, table_name, row)?;
                 row_count += 1;
             }
@@ -233,6 +300,72 @@ fn exec_insert(
         rows: vec![],
     })
 }
+
+// ── Constraint enforcement ────────────────────────────────────────────
+
+fn check_constraints(table: &Table, row: &[Value], schema: &str) -> Result<(), String> {
+    // Collect PK column indices for composite PK check
+    let pk_cols: Vec<usize> = table
+        .columns
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| c.primary_key)
+        .map(|(i, _)| i)
+        .collect();
+
+    // NOT NULL checks
+    for (i, col) in table.columns.iter().enumerate() {
+        if !col.nullable && matches!(row[i], Value::Null) {
+            return Err(format!(
+                "null value in column \"{}\" violates not-null constraint",
+                col.name
+            ));
+        }
+    }
+
+    // Composite PK check (if multiple PK columns)
+    if pk_cols.len() > 1 {
+        let existing = storage::scan(schema, &table.name)?;
+        let new_key: Vec<&Value> = pk_cols.iter().map(|&i| &row[i]).collect();
+        for erow in &existing {
+            let ekey: Vec<&Value> = pk_cols.iter().map(|&i| &erow[i]).collect();
+            if new_key == ekey {
+                return Err(format!(
+                    "duplicate key value violates unique constraint \"{}_pkey\"",
+                    table.name
+                ));
+            }
+        }
+    }
+
+    // Per-column UNIQUE / single-column PK checks
+    for (i, col) in table.columns.iter().enumerate() {
+        if (col.primary_key || col.unique) && !matches!(row[i], Value::Null) {
+            // Skip composite PK columns (already checked above)
+            if col.primary_key && pk_cols.len() > 1 {
+                continue;
+            }
+            let existing = storage::scan(schema, &table.name)?;
+            for erow in &existing {
+                if i < erow.len() && erow[i] == row[i] {
+                    let cname = if col.primary_key {
+                        format!("{}_pkey", table.name)
+                    } else {
+                        format!("{}_{}_key", table.name, col.name)
+                    };
+                    return Err(format!(
+                        "duplicate key value violates unique constraint \"{}\"",
+                        cname
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ── Expression evaluation ─────────────────────────────────────────────
 
 fn eval_const(node: Option<&NodeEnum>) -> Value {
     match node {
@@ -250,18 +383,10 @@ fn eval_const(node: Option<&NodeEnum>) -> Value {
                         .parse::<f64>()
                         .map(Value::Float)
                         .unwrap_or(Value::Null),
-                    pg_query::protobuf::a_const::Val::Sval(s) => {
-                        Value::Text(s.sval.clone())
-                    }
-                    pg_query::protobuf::a_const::Val::Bsval(s) => {
-                        Value::Text(s.bsval.clone())
-                    }
-                    pg_query::protobuf::a_const::Val::Boolval(b) => {
-                        Value::Bool(b.boolval)
-                    }
+                    pg_query::protobuf::a_const::Val::Sval(s) => Value::Text(s.sval.clone()),
+                    pg_query::protobuf::a_const::Val::Bsval(s) => Value::Text(s.bsval.clone()),
+                    pg_query::protobuf::a_const::Val::Boolval(b) => Value::Bool(b.boolval),
                 }
-            } else if ac.isnull {
-                Value::Null
             } else {
                 Value::Null
             }
@@ -309,9 +434,7 @@ fn eval_expr(node: &NodeEnum, row: &[Value], table: &Table) -> Result<Value, Str
                         .map(Value::Float)
                         .map_err(|e| e.to_string()),
                     pg_query::protobuf::a_const::Val::Sval(s) => Ok(Value::Text(s.sval.clone())),
-                    pg_query::protobuf::a_const::Val::Bsval(s) => {
-                        Ok(Value::Text(s.bsval.clone()))
-                    }
+                    pg_query::protobuf::a_const::Val::Bsval(s) => Ok(Value::Text(s.bsval.clone())),
                     pg_query::protobuf::a_const::Val::Boolval(b) => Ok(Value::Bool(b.boolval)),
                 }
             } else {
@@ -333,115 +456,8 @@ fn eval_expr(node: &NodeEnum, row: &[Value], table: &Table) -> Result<Value, Str
                 .ok_or("TypeCast missing arg")?;
             eval_expr(inner, row, table)
         }
-        NodeEnum::AExpr(expr) => {
-            if expr.kind != pg_query::protobuf::AExprKind::AexprOp as i32 {
-                return Err(format!("unsupported A_Expr kind: {}", expr.kind));
-            }
-            let op = expr
-                .name
-                .iter()
-                .filter_map(|n| n.node.as_ref())
-                .filter_map(|n| {
-                    if let NodeEnum::String(s) = n {
-                        Some(s.sval.clone())
-                    } else {
-                        None
-                    }
-                })
-                .next()
-                .ok_or("A_Expr missing operator")?;
-
-            let left_node = expr
-                .lexpr
-                .as_ref()
-                .and_then(|n| n.node.as_ref())
-                .ok_or("A_Expr missing left operand")?;
-            let right_node = expr
-                .rexpr
-                .as_ref()
-                .and_then(|n| n.node.as_ref())
-                .ok_or("A_Expr missing right operand")?;
-
-            let left = eval_expr(left_node, row, table)?;
-            let right = eval_expr(right_node, row, table)?;
-
-            // Arithmetic operators
-            if op == "+" || op == "-" || op == "*" || op == "/" {
-                return eval_arithmetic(&op, &left, &right);
-            }
-
-            // NULL propagation for comparison
-            if matches!(left, Value::Null) || matches!(right, Value::Null) {
-                return Ok(Value::Null);
-            }
-
-            let cmp = left.compare(&right);
-            let result = match op.as_str() {
-                "=" => cmp.map(|o| o == std::cmp::Ordering::Equal),
-                "<>" | "!=" => cmp.map(|o| o != std::cmp::Ordering::Equal),
-                "<" => cmp.map(|o| o == std::cmp::Ordering::Less),
-                ">" => cmp.map(|o| o == std::cmp::Ordering::Greater),
-                "<=" => cmp.map(|o| o != std::cmp::Ordering::Greater),
-                ">=" => cmp.map(|o| o != std::cmp::Ordering::Less),
-                _ => return Err(format!("unsupported operator: {}", op)),
-            };
-            Ok(result.map(Value::Bool).unwrap_or(Value::Null))
-        }
-        NodeEnum::BoolExpr(bexpr) => {
-            let boolop = bexpr.boolop;
-            if boolop == pg_query::protobuf::BoolExprType::AndExpr as i32 {
-                // AND: false if any false, NULL if any NULL and no false, true otherwise
-                let mut has_null = false;
-                for arg in &bexpr.args {
-                    let inner = arg.node.as_ref().ok_or("BoolExpr: missing arg node")?;
-                    match eval_expr(inner, row, table)? {
-                        Value::Bool(false) => return Ok(Value::Bool(false)),
-                        Value::Null => has_null = true,
-                        Value::Bool(true) => {}
-                        other => {
-                            return Err(format!("AND expects bool, got {:?}", other));
-                        }
-                    }
-                }
-                if has_null {
-                    Ok(Value::Null)
-                } else {
-                    Ok(Value::Bool(true))
-                }
-            } else if boolop == pg_query::protobuf::BoolExprType::OrExpr as i32 {
-                // OR: true if any true, NULL if any NULL and no true, false otherwise
-                let mut has_null = false;
-                for arg in &bexpr.args {
-                    let inner = arg.node.as_ref().ok_or("BoolExpr: missing arg node")?;
-                    match eval_expr(inner, row, table)? {
-                        Value::Bool(true) => return Ok(Value::Bool(true)),
-                        Value::Null => has_null = true,
-                        Value::Bool(false) => {}
-                        other => {
-                            return Err(format!("OR expects bool, got {:?}", other));
-                        }
-                    }
-                }
-                if has_null {
-                    Ok(Value::Null)
-                } else {
-                    Ok(Value::Bool(false))
-                }
-            } else if boolop == pg_query::protobuf::BoolExprType::NotExpr as i32 {
-                let inner = bexpr
-                    .args
-                    .first()
-                    .and_then(|a| a.node.as_ref())
-                    .ok_or("NOT missing arg")?;
-                match eval_expr(inner, row, table)? {
-                    Value::Bool(b) => Ok(Value::Bool(!b)),
-                    Value::Null => Ok(Value::Null),
-                    other => Err(format!("NOT expects bool, got {:?}", other)),
-                }
-            } else {
-                Err(format!("unsupported BoolExpr op: {}", boolop))
-            }
-        }
+        NodeEnum::AExpr(expr) => eval_a_expr(expr, row, table),
+        NodeEnum::BoolExpr(bexpr) => eval_bool_expr(bexpr, row, table),
         NodeEnum::NullTest(nt) => {
             let inner = nt
                 .arg
@@ -456,7 +472,128 @@ fn eval_expr(node: &NodeEnum, row: &[Value], table: &Table) -> Result<Value, Str
                 Ok(Value::Bool(!is_null))
             }
         }
-        _ => Err(format!("unsupported expression node: {:?}", std::mem::discriminant(node))),
+        NodeEnum::FuncCall(fc) => eval_func_call(fc, row, table),
+        _ => Err(format!(
+            "unsupported expression node: {:?}",
+            std::mem::discriminant(node)
+        )),
+    }
+}
+
+fn eval_a_expr(
+    expr: &pg_query::protobuf::AExpr,
+    row: &[Value],
+    table: &Table,
+) -> Result<Value, String> {
+    let op = extract_op_name(&expr.name)?;
+
+    // Unary minus
+    if expr.lexpr.is_none() && op == "-" {
+        let right = expr
+            .rexpr
+            .as_ref()
+            .and_then(|n| n.node.as_ref())
+            .ok_or("unary - missing operand")?;
+        return match eval_expr(right, row, table)? {
+            Value::Int(n) => Ok(Value::Int(-n)),
+            Value::Float(f) => Ok(Value::Float(-f)),
+            Value::Null => Ok(Value::Null),
+            _ => Err("unary minus requires numeric".into()),
+        };
+    }
+
+    let left_node = expr
+        .lexpr
+        .as_ref()
+        .and_then(|n| n.node.as_ref())
+        .ok_or("A_Expr missing left operand")?;
+    let right_node = expr
+        .rexpr
+        .as_ref()
+        .and_then(|n| n.node.as_ref())
+        .ok_or("A_Expr missing right operand")?;
+
+    let left = eval_expr(left_node, row, table)?;
+    let right = eval_expr(right_node, row, table)?;
+
+    // String concatenation
+    if op == "||" {
+        return match (&left, &right) {
+            (Value::Null, _) | (_, Value::Null) => Ok(Value::Null),
+            _ => {
+                let l = left.to_text().unwrap_or_default();
+                let r = right.to_text().unwrap_or_default();
+                Ok(Value::Text(format!("{}{}", l, r)))
+            }
+        };
+    }
+
+    // Arithmetic
+    if matches!(op.as_str(), "+" | "-" | "*" | "/") {
+        return eval_arithmetic(&op, &left, &right);
+    }
+
+    // NULL propagation for comparisons
+    if matches!(left, Value::Null) || matches!(right, Value::Null) {
+        return Ok(Value::Null);
+    }
+
+    let cmp = left.compare(&right);
+    let result = match op.as_str() {
+        "=" => cmp.map(|o| o == std::cmp::Ordering::Equal),
+        "<>" | "!=" => cmp.map(|o| o != std::cmp::Ordering::Equal),
+        "<" => cmp.map(|o| o == std::cmp::Ordering::Less),
+        ">" => cmp.map(|o| o == std::cmp::Ordering::Greater),
+        "<=" => cmp.map(|o| o != std::cmp::Ordering::Greater),
+        ">=" => cmp.map(|o| o != std::cmp::Ordering::Less),
+        _ => return Err(format!("unsupported operator: {}", op)),
+    };
+    Ok(result.map(Value::Bool).unwrap_or(Value::Null))
+}
+
+fn eval_bool_expr(
+    bexpr: &pg_query::protobuf::BoolExpr,
+    row: &[Value],
+    table: &Table,
+) -> Result<Value, String> {
+    let boolop = bexpr.boolop;
+    if boolop == pg_query::protobuf::BoolExprType::AndExpr as i32 {
+        let mut has_null = false;
+        for arg in &bexpr.args {
+            let inner = arg.node.as_ref().ok_or("BoolExpr: missing arg")?;
+            match eval_expr(inner, row, table)? {
+                Value::Bool(false) => return Ok(Value::Bool(false)),
+                Value::Null => has_null = true,
+                Value::Bool(true) => {}
+                other => return Err(format!("AND expects bool, got {:?}", other)),
+            }
+        }
+        Ok(if has_null { Value::Null } else { Value::Bool(true) })
+    } else if boolop == pg_query::protobuf::BoolExprType::OrExpr as i32 {
+        let mut has_null = false;
+        for arg in &bexpr.args {
+            let inner = arg.node.as_ref().ok_or("BoolExpr: missing arg")?;
+            match eval_expr(inner, row, table)? {
+                Value::Bool(true) => return Ok(Value::Bool(true)),
+                Value::Null => has_null = true,
+                Value::Bool(false) => {}
+                other => return Err(format!("OR expects bool, got {:?}", other)),
+            }
+        }
+        Ok(if has_null { Value::Null } else { Value::Bool(false) })
+    } else if boolop == pg_query::protobuf::BoolExprType::NotExpr as i32 {
+        let inner = bexpr
+            .args
+            .first()
+            .and_then(|a| a.node.as_ref())
+            .ok_or("NOT missing arg")?;
+        match eval_expr(inner, row, table)? {
+            Value::Bool(b) => Ok(Value::Bool(!b)),
+            Value::Null => Ok(Value::Null),
+            other => Err(format!("NOT expects bool, got {:?}", other)),
+        }
+    } else {
+        Err(format!("unsupported BoolExpr op: {}", boolop))
     }
 }
 
@@ -482,22 +619,91 @@ fn eval_arithmetic(op: &str, left: &Value, right: &Value) -> Result<Value, Strin
             "+" => Ok(Value::Float(a + b)),
             "-" => Ok(Value::Float(a - b)),
             "*" => Ok(Value::Float(a * b)),
-            "/" => Ok(Value::Float(a / b)),
+            "/" => {
+                if *b == 0.0 {
+                    Err("division by zero".into())
+                } else {
+                    Ok(Value::Float(a / b))
+                }
+            }
             _ => Err(format!("unsupported arithmetic op: {}", op)),
         },
         (Value::Int(a), Value::Float(b)) => {
-            let a = *a as f64;
-            eval_arithmetic(op, &Value::Float(a), &Value::Float(*b))
+            eval_arithmetic(op, &Value::Float(*a as f64), &Value::Float(*b))
         }
         (Value::Float(a), Value::Int(b)) => {
-            let b = *b as f64;
-            eval_arithmetic(op, &Value::Float(*a), &Value::Float(b))
+            eval_arithmetic(op, &Value::Float(*a), &Value::Float(*b as f64))
         }
         _ => Err(format!("cannot apply {} to {:?} and {:?}", op, left, right)),
     }
 }
 
-fn eval_where(where_clause: &Option<Box<pg_query::protobuf::Node>>, row: &[Value], table: &Table) -> bool {
+fn eval_func_call(
+    fc: &pg_query::protobuf::FuncCall,
+    row: &[Value],
+    table: &Table,
+) -> Result<Value, String> {
+    let name = extract_func_name(fc);
+
+    // Aggregate functions are handled in exec_select_aggregate, not here.
+    // If we reach here, it's a scalar function.
+    let args: Vec<Value> = fc
+        .args
+        .iter()
+        .map(|a| {
+            eval_expr(
+                a.node.as_ref().ok_or("FuncCall: missing arg")?,
+                row,
+                table,
+            )
+        })
+        .collect::<Result<_, _>>()?;
+
+    eval_scalar_function(&name, &args)
+}
+
+fn eval_scalar_function(name: &str, args: &[Value]) -> Result<Value, String> {
+    match name {
+        "upper" => match args.first() {
+            Some(Value::Text(s)) => Ok(Value::Text(s.to_uppercase())),
+            Some(Value::Null) => Ok(Value::Null),
+            _ => Err("upper() requires text argument".into()),
+        },
+        "lower" => match args.first() {
+            Some(Value::Text(s)) => Ok(Value::Text(s.to_lowercase())),
+            Some(Value::Null) => Ok(Value::Null),
+            _ => Err("lower() requires text argument".into()),
+        },
+        "length" => match args.first() {
+            Some(Value::Text(s)) => Ok(Value::Int(s.len() as i64)),
+            Some(Value::Null) => Ok(Value::Null),
+            _ => Err("length() requires text argument".into()),
+        },
+        "concat" => {
+            let parts: String = args
+                .iter()
+                .map(|v| match v {
+                    Value::Null => String::new(),
+                    v => v.to_text().unwrap_or_default(),
+                })
+                .collect();
+            Ok(Value::Text(parts))
+        }
+        "abs" => match args.first() {
+            Some(Value::Int(n)) => Ok(Value::Int(n.abs())),
+            Some(Value::Float(f)) => Ok(Value::Float(f.abs())),
+            Some(Value::Null) => Ok(Value::Null),
+            _ => Err("abs() requires numeric argument".into()),
+        },
+        _ => Err(format!("function {}() does not exist", name)),
+    }
+}
+
+fn eval_where(
+    where_clause: &Option<Box<pg_query::protobuf::Node>>,
+    row: &[Value],
+    table: &Table,
+) -> bool {
     match where_clause {
         Some(wc) => match wc.node.as_ref() {
             Some(expr) => matches!(eval_expr(expr, row, table), Ok(Value::Bool(true))),
@@ -507,80 +713,65 @@ fn eval_where(where_clause: &Option<Box<pg_query::protobuf::Node>>, row: &[Value
     }
 }
 
-fn exec_select(
-    select: &pg_query::protobuf::SelectStmt,
-    _raw_sql: &str,
-) -> Result<QueryResult, String> {
-    // Check for VALUES-less SELECT (e.g., SELECT 1, SELECT version())
-    if select.from_clause.is_empty() {
-        return exec_select_no_from(select);
-    }
+// ── Helper extractors ─────────────────────────────────────────────────
 
-    // Get table from FROM clause
-    let from = select.from_clause.first().ok_or("missing FROM")?;
-    let (schema, table_name) = extract_from_table(from.node.as_ref())?;
-
-    let table_def = catalog::get_table(&schema, &table_name)
-        .ok_or_else(|| format!("relation \"{}\" does not exist", table_name))?;
-
-    let all_rows = storage::scan(&schema, &table_name)?;
-
-    // Apply WHERE filter
-    let rows: Vec<Vec<Value>> = all_rows
-        .into_iter()
-        .filter(|row| eval_where(&select.where_clause, row, &table_def))
-        .collect();
-
-    // Resolve target columns
-    let (col_names, col_indices) = resolve_select_targets(select, &table_def)?;
-    let columns: Vec<(String, i32)> = col_names
+fn extract_op_name(name_nodes: &[pg_query::protobuf::Node]) -> Result<String, String> {
+    name_nodes
         .iter()
-        .zip(col_indices.iter())
-        .map(|(name, &idx)| (name.clone(), table_def.columns[idx].type_oid.oid()))
-        .collect();
-
-    // Project rows
-    let result_rows: Vec<Vec<Option<String>>> = rows
-        .iter()
-        .map(|row| {
-            col_indices
-                .iter()
-                .map(|&idx| row.get(idx).and_then(|v| v.to_text()))
-                .collect()
+        .filter_map(|n| n.node.as_ref())
+        .filter_map(|n| {
+            if let NodeEnum::String(s) = n {
+                Some(s.sval.clone())
+            } else {
+                None
+            }
         })
-        .collect();
-
-    let count = result_rows.len();
-    Ok(QueryResult {
-        tag: format!("SELECT {}", count),
-        columns,
-        rows: result_rows,
-    })
+        .next()
+        .ok_or_else(|| "missing operator name".into())
 }
 
-fn exec_select_no_from(
-    select: &pg_query::protobuf::SelectStmt,
-) -> Result<QueryResult, String> {
-    let mut columns = Vec::new();
-    let mut row = Vec::new();
-
-    for target in &select.target_list {
-        if let Some(NodeEnum::ResTarget(rt)) = target.node.as_ref() {
-            let alias = if rt.name.is_empty() {
-                "?column?".to_string()
+fn extract_func_name(fc: &pg_query::protobuf::FuncCall) -> String {
+    fc.funcname
+        .iter()
+        .filter_map(|n| n.node.as_ref())
+        .filter_map(|n| {
+            if let NodeEnum::String(s) = n {
+                Some(s.sval.to_lowercase())
             } else {
-                rt.name.clone()
-            };
-            let val = eval_const(rt.val.as_ref().and_then(|v| v.node.as_ref()));
-            columns.push((alias, TypeOid::Text.oid()));
-            row.push(val.to_text());
-        }
-    }
+                None
+            }
+        })
+        .last()
+        .unwrap_or_default()
+}
 
-    Ok(QueryResult {
-        tag: "SELECT 1".into(),
-        columns,
-        rows: vec![row],
+fn extract_col_name(cref: &pg_query::protobuf::ColumnRef) -> String {
+    cref.fields
+        .iter()
+        .filter_map(|f| f.node.as_ref())
+        .filter_map(|n| {
+            if let NodeEnum::String(s) = n {
+                Some(s.sval.clone())
+            } else {
+                None
+            }
+        })
+        .last()
+        .unwrap_or_default()
+}
+
+fn is_aggregate(name: &str) -> bool {
+    matches!(name, "count" | "sum" | "avg" | "min" | "max")
+}
+
+fn query_has_aggregates(select: &pg_query::protobuf::SelectStmt) -> bool {
+    select.target_list.iter().any(|t| {
+        if let Some(NodeEnum::ResTarget(rt)) = t.node.as_ref() {
+            if let Some(NodeEnum::FuncCall(fc)) = rt.val.as_ref().and_then(|v| v.node.as_ref()) {
+                return is_aggregate(&extract_func_name(fc));
+            }
+        }
+        false
     })
 }
 
@@ -598,16 +789,23 @@ fn extract_from_table(node: Option<&NodeEnum>) -> Result<(String, String), Strin
     }
 }
 
-fn resolve_select_targets(
+// ── SELECT target resolution ──────────────────────────────────────────
+
+enum SelectTarget {
+    Column { name: String, idx: usize },
+    Expr { name: String, expr: NodeEnum },
+}
+
+fn resolve_targets(
     select: &pg_query::protobuf::SelectStmt,
     table: &Table,
-) -> Result<(Vec<String>, Vec<usize>), String> {
-    let mut names = Vec::new();
-    let mut indices = Vec::new();
+) -> Result<Vec<SelectTarget>, String> {
+    let mut targets = Vec::new();
 
     for target in &select.target_list {
         if let Some(NodeEnum::ResTarget(rt)) = target.node.as_ref() {
-            match rt.val.as_ref().and_then(|v| v.node.as_ref()) {
+            let val_node = rt.val.as_ref().and_then(|v| v.node.as_ref());
+            match val_node {
                 Some(NodeEnum::ColumnRef(cref)) => {
                     let col_name = cref
                         .fields
@@ -623,8 +821,10 @@ fn resolve_select_targets(
 
                     if col_name == "*" {
                         for (i, col) in table.columns.iter().enumerate() {
-                            names.push(col.name.clone());
-                            indices.push(i);
+                            targets.push(SelectTarget::Column {
+                                name: col.name.clone(),
+                                idx: i,
+                            });
                         }
                     } else {
                         let idx = table
@@ -639,20 +839,668 @@ fn resolve_select_targets(
                         } else {
                             rt.name.clone()
                         };
-                        names.push(alias);
-                        indices.push(idx);
+                        targets.push(SelectTarget::Column { name: alias, idx });
                     }
                 }
-                _ => {
-                    names.push("?column?".to_string());
-                    indices.push(0);
+                Some(expr) => {
+                    let alias = if rt.name.is_empty() {
+                        "?column?".to_string()
+                    } else {
+                        rt.name.clone()
+                    };
+                    targets.push(SelectTarget::Expr {
+                        name: alias,
+                        expr: expr.clone(),
+                    });
+                }
+                None => {
+                    targets.push(SelectTarget::Column {
+                        name: "?column?".into(),
+                        idx: 0,
+                    });
                 }
             }
         }
     }
 
-    Ok((names, indices))
+    Ok(targets)
 }
+
+// ── SELECT execution ──────────────────────────────────────────────────
+
+fn exec_select(
+    select: &pg_query::protobuf::SelectStmt,
+) -> Result<QueryResult, String> {
+    if select.from_clause.is_empty() {
+        return exec_select_no_from(select);
+    }
+
+    let from = select.from_clause.first().ok_or("missing FROM")?;
+    let (schema, table_name) = extract_from_table(from.node.as_ref())?;
+    let table_def = catalog::get_table(&schema, &table_name)
+        .ok_or_else(|| format!("relation \"{}\" does not exist", table_name))?;
+
+    let all_rows = storage::scan(&schema, &table_name)?;
+
+    // WHERE filter
+    let mut rows: Vec<Vec<Value>> = all_rows
+        .into_iter()
+        .filter(|row| eval_where(&select.where_clause, row, &table_def))
+        .collect();
+
+    // Route to aggregate path if needed
+    if query_has_aggregates(select) || !select.group_clause.is_empty() {
+        return exec_select_aggregate(select, &table_def, rows);
+    }
+
+    // ORDER BY (on full rows before projection)
+    if !select.sort_clause.is_empty() {
+        let sort_keys = resolve_sort_keys(&select.sort_clause, &table_def, select)?;
+        rows.sort_by(|a, b| compare_rows(&sort_keys, a, b));
+    }
+
+    // OFFSET
+    if let Some(ref offset_node) = select.limit_offset {
+        if let Some(n) = eval_const_i64(offset_node.node.as_ref()) {
+            let n = n.max(0) as usize;
+            if n >= rows.len() {
+                rows.clear();
+            } else {
+                rows.drain(0..n);
+            }
+        }
+    }
+
+    // LIMIT
+    if let Some(ref limit_node) = select.limit_count {
+        if let Some(n) = eval_const_i64(limit_node.node.as_ref()) {
+            rows.truncate(n.max(0) as usize);
+        }
+    }
+
+    // Resolve targets and project
+    let targets = resolve_targets(select, &table_def)?;
+    let columns: Vec<(String, i32)> = targets
+        .iter()
+        .map(|t| match t {
+            SelectTarget::Column { name, idx } => {
+                (name.clone(), table_def.columns[*idx].type_oid.oid())
+            }
+            SelectTarget::Expr { name, .. } => (name.clone(), TypeOid::Text.oid()),
+        })
+        .collect();
+
+    let result_rows: Vec<Vec<Option<String>>> = rows
+        .iter()
+        .map(|row| {
+            targets
+                .iter()
+                .map(|t| match t {
+                    SelectTarget::Column { idx, .. } => {
+                        row.get(*idx).and_then(|v| v.to_text())
+                    }
+                    SelectTarget::Expr { expr, .. } => {
+                        eval_expr(expr, row, &table_def)
+                            .ok()
+                            .and_then(|v| v.to_text())
+                    }
+                })
+                .collect()
+        })
+        .collect();
+
+    let count = result_rows.len();
+    Ok(QueryResult {
+        tag: format!("SELECT {}", count),
+        columns,
+        rows: result_rows,
+    })
+}
+
+fn exec_select_no_from(
+    select: &pg_query::protobuf::SelectStmt,
+) -> Result<QueryResult, String> {
+    let dummy_table = Table {
+        name: String::new(),
+        schema: String::new(),
+        columns: vec![],
+    };
+    let mut columns = Vec::new();
+    let mut row = Vec::new();
+
+    for target in &select.target_list {
+        if let Some(NodeEnum::ResTarget(rt)) = target.node.as_ref() {
+            let alias = if rt.name.is_empty() {
+                "?column?".to_string()
+            } else {
+                rt.name.clone()
+            };
+            let val = match rt.val.as_ref().and_then(|v| v.node.as_ref()) {
+                Some(expr) => eval_expr(expr, &[], &dummy_table)
+                    .unwrap_or(Value::Null),
+                None => Value::Null,
+            };
+            columns.push((alias, TypeOid::Text.oid()));
+            row.push(val.to_text());
+        }
+    }
+
+    Ok(QueryResult {
+        tag: "SELECT 1".into(),
+        columns,
+        rows: vec![row],
+    })
+}
+
+// ── ORDER BY helpers ──────────────────────────────────────────────────
+
+struct SortKey {
+    col_idx: usize,
+    ascending: bool,
+    nulls_first: bool,
+}
+
+fn resolve_sort_keys(
+    sort_clause: &[pg_query::protobuf::Node],
+    table: &Table,
+    select: &pg_query::protobuf::SelectStmt,
+) -> Result<Vec<SortKey>, String> {
+    let mut keys = Vec::new();
+    for snode in sort_clause {
+        if let Some(NodeEnum::SortBy(sb)) = snode.node.as_ref() {
+            let col_idx = match sb.node.as_ref().and_then(|n| n.node.as_ref()) {
+                Some(NodeEnum::ColumnRef(cref)) => {
+                    let name = extract_col_name(cref);
+                    table
+                        .columns
+                        .iter()
+                        .position(|c| c.name == name)
+                        .ok_or_else(|| {
+                            format!("column \"{}\" does not exist", name)
+                        })?
+                }
+                Some(NodeEnum::AConst(ac)) => {
+                    // Ordinal: ORDER BY 1 means first column in target list
+                    let ordinal = match &ac.val {
+                        Some(pg_query::protobuf::a_const::Val::Ival(i)) => i.ival as usize,
+                        _ => return Err("invalid ORDER BY ordinal".into()),
+                    };
+                    // Map ordinal to actual table column index via target list
+                    resolve_ordinal_to_col_idx(ordinal, select, table)?
+                }
+                _ => return Err("unsupported ORDER BY expression".into()),
+            };
+
+            let ascending = sb.sortby_dir
+                != pg_query::protobuf::SortByDir::SortbyDesc as i32;
+            let nulls_first = match sb.sortby_nulls {
+                x if x == pg_query::protobuf::SortByNulls::SortbyNullsFirst as i32 => true,
+                x if x == pg_query::protobuf::SortByNulls::SortbyNullsLast as i32 => false,
+                _ => !ascending, // default: NULLS LAST for ASC, FIRST for DESC
+            };
+
+            keys.push(SortKey {
+                col_idx,
+                ascending,
+                nulls_first,
+            });
+        }
+    }
+    Ok(keys)
+}
+
+fn resolve_ordinal_to_col_idx(
+    ordinal: usize,
+    select: &pg_query::protobuf::SelectStmt,
+    table: &Table,
+) -> Result<usize, String> {
+    if ordinal == 0 || ordinal > select.target_list.len() {
+        return Err(format!("ORDER BY position {} is not in select list", ordinal));
+    }
+    let target = &select.target_list[ordinal - 1];
+    if let Some(NodeEnum::ResTarget(rt)) = target.node.as_ref() {
+        if let Some(NodeEnum::ColumnRef(cref)) = rt.val.as_ref().and_then(|v| v.node.as_ref()) {
+            let name = extract_col_name(cref);
+            return table
+                .columns
+                .iter()
+                .position(|c| c.name == name)
+                .ok_or_else(|| format!("column \"{}\" does not exist", name));
+        }
+    }
+    Err("ORDER BY ordinal must reference a column".into())
+}
+
+fn compare_rows(keys: &[SortKey], a: &[Value], b: &[Value]) -> std::cmp::Ordering {
+    for k in keys {
+        let va = &a[k.col_idx];
+        let vb = &b[k.col_idx];
+        let ord = match (va, vb) {
+            (Value::Null, Value::Null) => std::cmp::Ordering::Equal,
+            (Value::Null, _) => {
+                if k.nulls_first {
+                    std::cmp::Ordering::Less
+                } else {
+                    std::cmp::Ordering::Greater
+                }
+            }
+            (_, Value::Null) => {
+                if k.nulls_first {
+                    std::cmp::Ordering::Greater
+                } else {
+                    std::cmp::Ordering::Less
+                }
+            }
+            _ => va.compare(vb).unwrap_or(std::cmp::Ordering::Equal),
+        };
+        let ord = if k.ascending { ord } else { ord.reverse() };
+        if ord != std::cmp::Ordering::Equal {
+            return ord;
+        }
+    }
+    std::cmp::Ordering::Equal
+}
+
+fn eval_const_i64(node: Option<&NodeEnum>) -> Option<i64> {
+    match eval_const(node) {
+        Value::Int(n) => Some(n),
+        Value::Float(f) => Some(f as i64),
+        _ => None,
+    }
+}
+
+// ── Aggregate execution ───────────────────────────────────────────────
+
+fn exec_select_aggregate(
+    select: &pg_query::protobuf::SelectStmt,
+    table: &Table,
+    rows: Vec<Vec<Value>>,
+) -> Result<QueryResult, String> {
+    let group_col_indices = resolve_group_columns(&select.group_clause, table)?;
+
+    // Group rows (use Vec to maintain insertion order)
+    let mut groups: Vec<(Vec<Value>, Vec<Vec<Value>>)> = Vec::new();
+    let mut group_index: HashMap<String, usize> = HashMap::new();
+
+    if group_col_indices.is_empty() {
+        groups.push((vec![], rows));
+    } else {
+        for row in rows {
+            let key: Vec<Value> = group_col_indices.iter().map(|&i| row[i].clone()).collect();
+            let key_str = format!("{:?}", key);
+
+            if let Some(&idx) = group_index.get(&key_str) {
+                groups[idx].1.push(row);
+            } else {
+                let idx = groups.len();
+                group_index.insert(key_str, idx);
+                groups.push((key.clone(), vec![row]));
+            }
+        }
+    }
+
+    // Build result columns and rows
+    let mut result_columns = Vec::new();
+    let mut result_rows = Vec::new();
+    let mut columns_built = false;
+
+    for (group_key, group_rows) in &groups {
+        let mut result_row = Vec::new();
+
+        for target in &select.target_list {
+            if let Some(NodeEnum::ResTarget(rt)) = target.node.as_ref() {
+                let val_node = rt.val.as_ref().and_then(|v| v.node.as_ref());
+
+                match val_node {
+                    Some(NodeEnum::FuncCall(fc)) => {
+                        let name = extract_func_name(fc);
+                        if is_aggregate(&name) {
+                            let agg_val = compute_aggregate(&name, fc, group_rows, table)?;
+                            if !columns_built {
+                                let alias = if rt.name.is_empty() {
+                                    name.clone()
+                                } else {
+                                    rt.name.clone()
+                                };
+                                let oid = match name.as_str() {
+                                    "count" => TypeOid::Int8.oid(),
+                                    "avg" => TypeOid::Float8.oid(),
+                                    _ => TypeOid::Text.oid(),
+                                };
+                                result_columns.push((alias, oid));
+                            }
+                            result_row.push(agg_val.to_text());
+                        } else {
+                            return Err(format!(
+                                "function {}() is not an aggregate function",
+                                name
+                            ));
+                        }
+                    }
+                    Some(NodeEnum::ColumnRef(cref)) => {
+                        let col_name = extract_col_name(cref);
+                        let col_idx = table
+                            .columns
+                            .iter()
+                            .position(|c| c.name == col_name)
+                            .ok_or_else(|| {
+                                format!("column \"{}\" does not exist", col_name)
+                            })?;
+
+                        if !group_col_indices.contains(&col_idx) {
+                            return Err(format!(
+                                "column \"{}\" must appear in the GROUP BY clause or be used in an aggregate function",
+                                col_name
+                            ));
+                        }
+
+                        if !columns_built {
+                            let alias = if rt.name.is_empty() {
+                                col_name
+                            } else {
+                                rt.name.clone()
+                            };
+                            result_columns.push((alias, table.columns[col_idx].type_oid.oid()));
+                        }
+
+                        let key_pos = group_col_indices
+                            .iter()
+                            .position(|&i| i == col_idx)
+                            .unwrap();
+                        result_row.push(group_key[key_pos].to_text());
+                    }
+                    _ => {
+                        return Err(
+                            "invalid expression in aggregate query".into(),
+                        );
+                    }
+                }
+            }
+        }
+
+        result_rows.push(result_row);
+        columns_built = true;
+    }
+
+    // HAVING filter
+    if let Some(having_node) = &select.having_clause {
+        if let Some(having_expr) = having_node.node.as_ref() {
+            let mut filtered = Vec::new();
+            for (i, (_, group_rows)) in groups.iter().enumerate() {
+                if eval_having(having_expr, group_rows, table)? {
+                    filtered.push(result_rows[i].clone());
+                }
+            }
+            result_rows = filtered;
+        }
+    }
+
+    Ok(QueryResult {
+        tag: format!("SELECT {}", result_rows.len()),
+        columns: result_columns,
+        rows: result_rows,
+    })
+}
+
+fn resolve_group_columns(
+    group_clause: &[pg_query::protobuf::Node],
+    table: &Table,
+) -> Result<Vec<usize>, String> {
+    let mut indices = Vec::new();
+    for node in group_clause {
+        if let Some(NodeEnum::ColumnRef(cref)) = node.node.as_ref() {
+            let col_name = extract_col_name(cref);
+            let idx = table
+                .columns
+                .iter()
+                .position(|c| c.name == col_name)
+                .ok_or_else(|| format!("column \"{}\" does not exist", col_name))?;
+            indices.push(idx);
+        }
+    }
+    Ok(indices)
+}
+
+fn compute_aggregate(
+    name: &str,
+    fc: &pg_query::protobuf::FuncCall,
+    rows: &[Vec<Value>],
+    table: &Table,
+) -> Result<Value, String> {
+    match name {
+        "count" => {
+            if fc.agg_star {
+                Ok(Value::Int(rows.len() as i64))
+            } else {
+                let arg = fc
+                    .args
+                    .first()
+                    .and_then(|a| a.node.as_ref())
+                    .ok_or("COUNT requires argument")?;
+                let count = rows
+                    .iter()
+                    .filter(|row| {
+                        !matches!(eval_expr(arg, row, table), Ok(Value::Null) | Err(_))
+                    })
+                    .count();
+                Ok(Value::Int(count as i64))
+            }
+        }
+        "sum" => {
+            let arg = fc
+                .args
+                .first()
+                .and_then(|a| a.node.as_ref())
+                .ok_or("SUM requires argument")?;
+            let mut si: i64 = 0;
+            let mut sf: f64 = 0.0;
+            let mut is_float = false;
+            let mut has_val = false;
+            for row in rows {
+                match eval_expr(arg, row, table)? {
+                    Value::Int(n) => {
+                        si += n;
+                        has_val = true;
+                    }
+                    Value::Float(f) => {
+                        sf += f;
+                        is_float = true;
+                        has_val = true;
+                    }
+                    Value::Null => {}
+                    _ => return Err("SUM requires numeric".into()),
+                }
+            }
+            if !has_val {
+                return Ok(Value::Null);
+            }
+            Ok(if is_float {
+                Value::Float(sf + si as f64)
+            } else {
+                Value::Int(si)
+            })
+        }
+        "avg" => {
+            let arg = fc
+                .args
+                .first()
+                .and_then(|a| a.node.as_ref())
+                .ok_or("AVG requires argument")?;
+            let mut sum: f64 = 0.0;
+            let mut count: i64 = 0;
+            for row in rows {
+                match eval_expr(arg, row, table)? {
+                    Value::Int(n) => {
+                        sum += n as f64;
+                        count += 1;
+                    }
+                    Value::Float(f) => {
+                        sum += f;
+                        count += 1;
+                    }
+                    Value::Null => {}
+                    _ => return Err("AVG requires numeric".into()),
+                }
+            }
+            Ok(if count == 0 {
+                Value::Null
+            } else {
+                Value::Float(sum / count as f64)
+            })
+        }
+        "min" => {
+            let arg = fc
+                .args
+                .first()
+                .and_then(|a| a.node.as_ref())
+                .ok_or("MIN requires argument")?;
+            let mut result: Option<Value> = None;
+            for row in rows {
+                let v = eval_expr(arg, row, table)?;
+                if matches!(v, Value::Null) {
+                    continue;
+                }
+                result = Some(match result {
+                    None => v,
+                    Some(cur) => {
+                        if v.compare(&cur) == Some(std::cmp::Ordering::Less) {
+                            v
+                        } else {
+                            cur
+                        }
+                    }
+                });
+            }
+            Ok(result.unwrap_or(Value::Null))
+        }
+        "max" => {
+            let arg = fc
+                .args
+                .first()
+                .and_then(|a| a.node.as_ref())
+                .ok_or("MAX requires argument")?;
+            let mut result: Option<Value> = None;
+            for row in rows {
+                let v = eval_expr(arg, row, table)?;
+                if matches!(v, Value::Null) {
+                    continue;
+                }
+                result = Some(match result {
+                    None => v,
+                    Some(cur) => {
+                        if v.compare(&cur) == Some(std::cmp::Ordering::Greater) {
+                            v
+                        } else {
+                            cur
+                        }
+                    }
+                });
+            }
+            Ok(result.unwrap_or(Value::Null))
+        }
+        _ => Err(format!("unknown aggregate function: {}", name)),
+    }
+}
+
+fn eval_having(
+    expr: &NodeEnum,
+    group_rows: &[Vec<Value>],
+    table: &Table,
+) -> Result<bool, String> {
+    let val = eval_having_expr(expr, group_rows, table)?;
+    Ok(matches!(val, Value::Bool(true)))
+}
+
+fn eval_having_expr(
+    node: &NodeEnum,
+    group_rows: &[Vec<Value>],
+    table: &Table,
+) -> Result<Value, String> {
+    match node {
+        NodeEnum::FuncCall(fc) => {
+            let name = extract_func_name(fc);
+            if is_aggregate(&name) {
+                compute_aggregate(&name, fc, group_rows, table)
+            } else {
+                Err(format!("non-aggregate function in HAVING: {}", name))
+            }
+        }
+        NodeEnum::AExpr(expr) => {
+            let op = extract_op_name(&expr.name)?;
+            let left = expr
+                .lexpr
+                .as_ref()
+                .and_then(|n| n.node.as_ref())
+                .map(|n| eval_having_expr(n, group_rows, table))
+                .transpose()?;
+            let right = expr
+                .rexpr
+                .as_ref()
+                .and_then(|n| n.node.as_ref())
+                .map(|n| eval_having_expr(n, group_rows, table))
+                .transpose()?;
+
+            let (l, r) = match (left, right) {
+                (Some(l), Some(r)) => (l, r),
+                _ => return Ok(Value::Null),
+            };
+
+            if matches!(l, Value::Null) || matches!(r, Value::Null) {
+                return Ok(Value::Null);
+            }
+
+            let cmp = l.compare(&r);
+            let result = match op.as_str() {
+                "=" => cmp.map(|o| o == std::cmp::Ordering::Equal),
+                "<>" | "!=" => cmp.map(|o| o != std::cmp::Ordering::Equal),
+                "<" => cmp.map(|o| o == std::cmp::Ordering::Less),
+                ">" => cmp.map(|o| o == std::cmp::Ordering::Greater),
+                "<=" => cmp.map(|o| o != std::cmp::Ordering::Greater),
+                ">=" => cmp.map(|o| o != std::cmp::Ordering::Less),
+                _ => return Err(format!("unsupported operator in HAVING: {}", op)),
+            };
+            Ok(result.map(Value::Bool).unwrap_or(Value::Null))
+        }
+        NodeEnum::AConst(_) | NodeEnum::Integer(_) | NodeEnum::Float(_) => {
+            let dummy = Table {
+                name: String::new(),
+                schema: String::new(),
+                columns: vec![],
+            };
+            eval_expr(node, &[], &dummy)
+        }
+        NodeEnum::BoolExpr(be) => {
+            let boolop = be.boolop;
+            if boolop == pg_query::protobuf::BoolExprType::AndExpr as i32 {
+                for arg in &be.args {
+                    if let Some(n) = arg.node.as_ref() {
+                        match eval_having_expr(n, group_rows, table)? {
+                            Value::Bool(false) => return Ok(Value::Bool(false)),
+                            Value::Bool(true) => continue,
+                            _ => return Ok(Value::Null),
+                        }
+                    }
+                }
+                Ok(Value::Bool(true))
+            } else if boolop == pg_query::protobuf::BoolExprType::OrExpr as i32 {
+                for arg in &be.args {
+                    if let Some(n) = arg.node.as_ref() {
+                        match eval_having_expr(n, group_rows, table)? {
+                            Value::Bool(true) => return Ok(Value::Bool(true)),
+                            _ => continue,
+                        }
+                    }
+                }
+                Ok(Value::Bool(false))
+            } else {
+                Err("unsupported HAVING boolean expression".into())
+            }
+        }
+        _ => Err("unsupported expression in HAVING clause".into()),
+    }
+}
+
+// ── DELETE ─────────────────────────────────────────────────────────────
 
 fn exec_delete(
     delete: &pg_query::protobuf::DeleteStmt,
@@ -672,7 +1520,9 @@ fn exec_delete(
         let table_def = catalog::get_table(schema, table_name)
             .ok_or_else(|| format!("relation \"{}\" does not exist", table_name))?;
         let wc = delete.where_clause.clone();
-        storage::delete_where(schema, table_name, |row| eval_where(&wc, row, &table_def))?
+        storage::delete_where(schema, table_name, |row| {
+            eval_where(&wc, row, &table_def)
+        })?
     } else {
         storage::delete_all(schema, table_name)?
     };
@@ -683,6 +1533,8 @@ fn exec_delete(
         rows: vec![],
     })
 }
+
+// ── UPDATE ────────────────────────────────────────────────────────────
 
 fn exec_update(
     update: &pg_query::protobuf::UpdateStmt,
@@ -701,7 +1553,6 @@ fn exec_update(
     let table_def = catalog::get_table(schema, table_name)
         .ok_or_else(|| format!("relation \"{}\" does not exist", table_name))?;
 
-    // Pre-parse the SET assignments: (column_index, expression_node)
     let mut assignments: Vec<(usize, NodeEnum)> = Vec::new();
     for target in &update.target_list {
         if let Some(NodeEnum::ResTarget(rt)) = target.node.as_ref() {
@@ -729,7 +1580,6 @@ fn exec_update(
         table_name,
         |row| eval_where(&wc, row, &td),
         |row| {
-            // Evaluate expressions against the OLD row values
             let old_row = row.clone();
             for (col_idx, expr_node) in &assigns {
                 if let Ok(val) = eval_expr(expr_node, &old_row, &td) {
@@ -745,6 +1595,8 @@ fn exec_update(
         rows: vec![],
     })
 }
+
+// ── TRUNCATE ──────────────────────────────────────────────────────────
 
 fn exec_truncate(
     trunc: &pg_query::protobuf::TruncateStmt,
@@ -766,6 +1618,10 @@ fn exec_truncate(
     })
 }
 
+// ══════════════════════════════════════════════════════════════════════
+// Tests
+// ══════════════════════════════════════════════════════════════════════
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -775,6 +1631,16 @@ mod tests {
         storage::reset();
     }
 
+    fn setup_test_table() {
+        setup();
+        execute("CREATE TABLE t (id integer, name text)").unwrap();
+        execute("INSERT INTO t VALUES (1, 'alice')").unwrap();
+        execute("INSERT INTO t VALUES (2, 'bob')").unwrap();
+        execute("INSERT INTO t VALUES (3, 'carol')").unwrap();
+    }
+
+    // ── Basic CRUD ────────────────────────────────────────────────────
+
     #[test]
     #[serial_test::serial]
     fn create_and_insert_and_select() {
@@ -782,13 +1648,10 @@ mod tests {
         execute("CREATE TABLE users (id integer, name text)").unwrap();
         execute("INSERT INTO users VALUES (1, 'alice')").unwrap();
         execute("INSERT INTO users VALUES (2, 'bob')").unwrap();
-
         let result = execute("SELECT * FROM users").unwrap();
         assert_eq!(result.rows.len(), 2);
-        assert_eq!(result.columns.len(), 2);
         assert_eq!(result.rows[0][0], Some("1".into()));
         assert_eq!(result.rows[0][1], Some("alice".into()));
-        assert_eq!(result.rows[1][1], Some("bob".into()));
     }
 
     #[test]
@@ -797,7 +1660,6 @@ mod tests {
         setup();
         execute("CREATE TABLE t (a int, b text, c int)").unwrap();
         execute("INSERT INTO t VALUES (1, 'x', 10)").unwrap();
-
         let result = execute("SELECT b, c FROM t").unwrap();
         assert_eq!(result.columns.len(), 2);
         assert_eq!(result.columns[0].0, "b");
@@ -841,15 +1703,7 @@ mod tests {
         assert_eq!(result.rows.len(), 0);
     }
 
-    // --- WHERE clause tests ---
-
-    fn setup_test_table() {
-        setup();
-        execute("CREATE TABLE t (id integer, name text)").unwrap();
-        execute("INSERT INTO t VALUES (1, 'alice')").unwrap();
-        execute("INSERT INTO t VALUES (2, 'bob')").unwrap();
-        execute("INSERT INTO t VALUES (3, 'carol')").unwrap();
-    }
+    // ── WHERE ─────────────────────────────────────────────────────────
 
     #[test]
     #[serial_test::serial]
@@ -883,8 +1737,6 @@ mod tests {
         setup_test_table();
         let r = execute("SELECT * FROM t WHERE id = 1 OR id = 3").unwrap();
         assert_eq!(r.rows.len(), 2);
-        assert_eq!(r.rows[0][1], Some("alice".into()));
-        assert_eq!(r.rows[1][1], Some("carol".into()));
     }
 
     #[test]
@@ -911,7 +1763,7 @@ mod tests {
         assert_eq!(r.rows[0][0], Some("2".into()));
     }
 
-    // --- UPDATE tests ---
+    // ── UPDATE ────────────────────────────────────────────────────────
 
     #[test]
     #[serial_test::serial]
@@ -921,9 +1773,6 @@ mod tests {
         assert_eq!(r.tag, "UPDATE 1");
         let sel = execute("SELECT * FROM t WHERE id = 1").unwrap();
         assert_eq!(sel.rows[0][1], Some("updated".into()));
-        // Other rows unchanged
-        let sel2 = execute("SELECT * FROM t WHERE id = 2").unwrap();
-        assert_eq!(sel2.rows[0][1], Some("bob".into()));
     }
 
     #[test]
@@ -932,23 +1781,18 @@ mod tests {
         setup_test_table();
         let r = execute("UPDATE t SET name = 'all'").unwrap();
         assert_eq!(r.tag, "UPDATE 3");
-        let sel = execute("SELECT * FROM t").unwrap();
-        for row in &sel.rows {
-            assert_eq!(row[1], Some("all".into()));
-        }
     }
 
     #[test]
     #[serial_test::serial]
     fn update_self_referential() {
         setup_test_table();
-        let r = execute("UPDATE t SET id = id + 1 WHERE id = 1").unwrap();
-        assert_eq!(r.tag, "UPDATE 1");
+        execute("UPDATE t SET id = id + 1 WHERE id = 1").unwrap();
         let sel = execute("SELECT * FROM t WHERE name = 'alice'").unwrap();
         assert_eq!(sel.rows[0][0], Some("2".into()));
     }
 
-    // --- DELETE WHERE tests ---
+    // ── DELETE WHERE ──────────────────────────────────────────────────
 
     #[test]
     #[serial_test::serial]
@@ -956,8 +1800,7 @@ mod tests {
         setup_test_table();
         let r = execute("DELETE FROM t WHERE id = 1").unwrap();
         assert_eq!(r.tag, "DELETE 1");
-        let sel = execute("SELECT * FROM t").unwrap();
-        assert_eq!(sel.rows.len(), 2);
+        assert_eq!(execute("SELECT * FROM t").unwrap().rows.len(), 2);
     }
 
     #[test]
@@ -966,7 +1809,368 @@ mod tests {
         setup_test_table();
         let r = execute("DELETE FROM t WHERE id = 999").unwrap();
         assert_eq!(r.tag, "DELETE 0");
-        let sel = execute("SELECT * FROM t").unwrap();
-        assert_eq!(sel.rows.len(), 3);
+        assert_eq!(execute("SELECT * FROM t").unwrap().rows.len(), 3);
+    }
+
+    // ── ORDER BY / LIMIT / OFFSET ─────────────────────────────────────
+
+    #[test]
+    #[serial_test::serial]
+    fn order_by_asc() {
+        setup();
+        execute("CREATE TABLE t (id int, name text)").unwrap();
+        execute("INSERT INTO t VALUES (3, 'c')").unwrap();
+        execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+        execute("INSERT INTO t VALUES (2, 'b')").unwrap();
+        let r = execute("SELECT * FROM t ORDER BY id").unwrap();
+        assert_eq!(r.rows[0][0], Some("1".into()));
+        assert_eq!(r.rows[1][0], Some("2".into()));
+        assert_eq!(r.rows[2][0], Some("3".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn order_by_desc() {
+        setup();
+        execute("CREATE TABLE t (id int)").unwrap();
+        execute("INSERT INTO t VALUES (1)").unwrap();
+        execute("INSERT INTO t VALUES (3)").unwrap();
+        execute("INSERT INTO t VALUES (2)").unwrap();
+        let r = execute("SELECT * FROM t ORDER BY id DESC").unwrap();
+        assert_eq!(r.rows[0][0], Some("3".into()));
+        assert_eq!(r.rows[2][0], Some("1".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn limit_basic() {
+        setup();
+        execute("CREATE TABLE t (id int)").unwrap();
+        for i in 1..=5 {
+            execute(&format!("INSERT INTO t VALUES ({})", i)).unwrap();
+        }
+        let r = execute("SELECT * FROM t LIMIT 2").unwrap();
+        assert_eq!(r.rows.len(), 2);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn limit_offset() {
+        setup();
+        execute("CREATE TABLE t (id int)").unwrap();
+        for i in 1..=5 {
+            execute(&format!("INSERT INTO t VALUES ({})", i)).unwrap();
+        }
+        let r = execute("SELECT * FROM t ORDER BY id LIMIT 2 OFFSET 1").unwrap();
+        assert_eq!(r.rows.len(), 2);
+        assert_eq!(r.rows[0][0], Some("2".into()));
+        assert_eq!(r.rows[1][0], Some("3".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn order_by_desc_limit() {
+        setup();
+        execute("CREATE TABLE t (id int)").unwrap();
+        for i in 1..=5 {
+            execute(&format!("INSERT INTO t VALUES ({})", i)).unwrap();
+        }
+        let r = execute("SELECT * FROM t ORDER BY id DESC LIMIT 2").unwrap();
+        assert_eq!(r.rows[0][0], Some("5".into()));
+        assert_eq!(r.rows[1][0], Some("4".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn offset_beyond() {
+        setup();
+        execute("CREATE TABLE t (id int)").unwrap();
+        execute("INSERT INTO t VALUES (1)").unwrap();
+        let r = execute("SELECT * FROM t OFFSET 1000").unwrap();
+        assert_eq!(r.rows.len(), 0);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn limit_zero() {
+        setup();
+        execute("CREATE TABLE t (id int)").unwrap();
+        execute("INSERT INTO t VALUES (1)").unwrap();
+        let r = execute("SELECT * FROM t LIMIT 0").unwrap();
+        assert_eq!(r.rows.len(), 0);
+    }
+
+    // ── Expressions in SELECT ─────────────────────────────────────────
+
+    #[test]
+    #[serial_test::serial]
+    fn select_arithmetic() {
+        setup();
+        execute("CREATE TABLE t (id int, price float8)").unwrap();
+        execute("INSERT INTO t VALUES (1, 100.0)").unwrap();
+        let r = execute("SELECT id, price * 1.1 FROM t").unwrap();
+        assert_eq!(r.rows[0][0], Some("1".into()));
+        let val: f64 = r.rows[0][1].as_ref().unwrap().parse().unwrap();
+        assert!((val - 110.0).abs() < 0.01);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn select_upper() {
+        setup();
+        execute("CREATE TABLE t (name text)").unwrap();
+        execute("INSERT INTO t VALUES ('hello')").unwrap();
+        let r = execute("SELECT upper(name) FROM t").unwrap();
+        assert_eq!(r.rows[0][0], Some("HELLO".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn select_lower() {
+        setup();
+        execute("CREATE TABLE t (name text)").unwrap();
+        execute("INSERT INTO t VALUES ('HELLO')").unwrap();
+        let r = execute("SELECT lower(name) FROM t").unwrap();
+        assert_eq!(r.rows[0][0], Some("hello".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn select_length() {
+        setup();
+        execute("CREATE TABLE t (name text)").unwrap();
+        execute("INSERT INTO t VALUES ('hello')").unwrap();
+        let r = execute("SELECT length(name) FROM t").unwrap();
+        assert_eq!(r.rows[0][0], Some("5".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn select_concat_func() {
+        setup();
+        execute("CREATE TABLE t (a text, b text)").unwrap();
+        execute("INSERT INTO t VALUES ('hello', 'world')").unwrap();
+        let r = execute("SELECT concat(a, ' ', b) FROM t").unwrap();
+        assert_eq!(r.rows[0][0], Some("hello world".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn select_concat_op() {
+        setup();
+        execute("CREATE TABLE t (a text, b text)").unwrap();
+        execute("INSERT INTO t VALUES ('hello', 'world')").unwrap();
+        let r = execute("SELECT a || ' ' || b FROM t").unwrap();
+        assert_eq!(r.rows[0][0], Some("hello world".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn select_unary_minus() {
+        setup();
+        execute("CREATE TABLE t (id int)").unwrap();
+        execute("INSERT INTO t VALUES (5)").unwrap();
+        let r = execute("SELECT -id FROM t").unwrap();
+        assert_eq!(r.rows[0][0], Some("-5".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn select_int_division() {
+        setup();
+        let r = execute("SELECT 5 / 2").unwrap();
+        assert_eq!(r.rows[0][0], Some("2".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn select_expr_with_alias() {
+        setup();
+        execute("CREATE TABLE t (id int)").unwrap();
+        execute("INSERT INTO t VALUES (1)").unwrap();
+        let r = execute("SELECT id + 1 AS next_id FROM t").unwrap();
+        assert_eq!(r.columns[0].0, "next_id");
+        assert_eq!(r.rows[0][0], Some("2".into()));
+    }
+
+    // ── Constraints ───────────────────────────────────────────────────
+
+    #[test]
+    #[serial_test::serial]
+    fn pk_prevents_duplicate() {
+        setup();
+        execute("CREATE TABLE t (id int PRIMARY KEY, name text)").unwrap();
+        execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+        let err = execute("INSERT INTO t VALUES (1, 'b')");
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("unique constraint"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn pk_prevents_null() {
+        setup();
+        execute("CREATE TABLE t (id int PRIMARY KEY, name text)").unwrap();
+        let err = execute("INSERT INTO t (name) VALUES ('a')");
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("not-null"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn unique_prevents_duplicate() {
+        setup();
+        execute("CREATE TABLE t (id int, email text UNIQUE)").unwrap();
+        execute("INSERT INTO t VALUES (1, 'a@b.com')").unwrap();
+        assert!(execute("INSERT INTO t VALUES (2, 'a@b.com')").is_err());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn unique_allows_multiple_nulls() {
+        setup();
+        execute("CREATE TABLE t (id int, email text UNIQUE)").unwrap();
+        execute("INSERT INTO t VALUES (1, NULL)").unwrap();
+        execute("INSERT INTO t VALUES (2, NULL)").unwrap();
+        let r = execute("SELECT * FROM t").unwrap();
+        assert_eq!(r.rows.len(), 2);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn not_null_constraint() {
+        setup();
+        execute("CREATE TABLE t (id int NOT NULL, name text)").unwrap();
+        let err = execute("INSERT INTO t (name) VALUES ('a')");
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("not-null"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn composite_pk() {
+        setup();
+        execute("CREATE TABLE t (a int, b int, c text, PRIMARY KEY (a, b))").unwrap();
+        execute("INSERT INTO t VALUES (1, 1, 'x')").unwrap();
+        execute("INSERT INTO t VALUES (1, 2, 'y')").unwrap(); // ok
+        assert!(execute("INSERT INTO t VALUES (1, 1, 'z')").is_err()); // duplicate
+    }
+
+    // ── Aggregates / GROUP BY / HAVING ────────────────────────────────
+
+    #[test]
+    #[serial_test::serial]
+    fn count_star() {
+        setup();
+        execute("CREATE TABLE t (id int, name text)").unwrap();
+        execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+        execute("INSERT INTO t VALUES (2, 'b')").unwrap();
+        let r = execute("SELECT COUNT(*) FROM t").unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][0], Some("2".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn count_column_skips_nulls() {
+        setup();
+        execute("CREATE TABLE t (id int, name text)").unwrap();
+        execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+        execute("INSERT INTO t VALUES (2, NULL)").unwrap();
+        let r = execute("SELECT COUNT(name) FROM t").unwrap();
+        assert_eq!(r.rows[0][0], Some("1".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn count_empty_table() {
+        setup();
+        execute("CREATE TABLE t (id int)").unwrap();
+        let r = execute("SELECT COUNT(*) FROM t").unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][0], Some("0".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn sum_basic() {
+        setup();
+        execute("CREATE TABLE t (id int)").unwrap();
+        execute("INSERT INTO t VALUES (10)").unwrap();
+        execute("INSERT INTO t VALUES (20)").unwrap();
+        execute("INSERT INTO t VALUES (30)").unwrap();
+        let r = execute("SELECT SUM(id) FROM t").unwrap();
+        assert_eq!(r.rows[0][0], Some("60".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn sum_empty_is_null() {
+        setup();
+        execute("CREATE TABLE t (id int)").unwrap();
+        let r = execute("SELECT SUM(id) FROM t").unwrap();
+        assert_eq!(r.rows[0][0], None);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn avg_basic() {
+        setup();
+        execute("CREATE TABLE t (val int)").unwrap();
+        execute("INSERT INTO t VALUES (10)").unwrap();
+        execute("INSERT INTO t VALUES (20)").unwrap();
+        let r = execute("SELECT AVG(val) FROM t").unwrap();
+        assert_eq!(r.rows[0][0], Some("15".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn min_max() {
+        setup();
+        execute("CREATE TABLE t (id int)").unwrap();
+        execute("INSERT INTO t VALUES (3)").unwrap();
+        execute("INSERT INTO t VALUES (1)").unwrap();
+        execute("INSERT INTO t VALUES (5)").unwrap();
+        let r = execute("SELECT MIN(id), MAX(id) FROM t").unwrap();
+        assert_eq!(r.rows[0][0], Some("1".into()));
+        assert_eq!(r.rows[0][1], Some("5".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn group_by_basic() {
+        setup();
+        execute("CREATE TABLE emp (dept text, salary int)").unwrap();
+        execute("INSERT INTO emp VALUES ('eng', 100)").unwrap();
+        execute("INSERT INTO emp VALUES ('eng', 200)").unwrap();
+        execute("INSERT INTO emp VALUES ('sales', 150)").unwrap();
+        let r = execute("SELECT dept, COUNT(*) FROM emp GROUP BY dept").unwrap();
+        assert_eq!(r.rows.len(), 2);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn group_by_having() {
+        setup();
+        execute("CREATE TABLE emp (dept text, salary int)").unwrap();
+        execute("INSERT INTO emp VALUES ('eng', 100)").unwrap();
+        execute("INSERT INTO emp VALUES ('eng', 200)").unwrap();
+        execute("INSERT INTO emp VALUES ('sales', 150)").unwrap();
+        let r = execute(
+            "SELECT dept, COUNT(*) FROM emp GROUP BY dept HAVING COUNT(*) > 1",
+        )
+        .unwrap();
+        assert_eq!(r.rows.len(), 1);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn mixed_agg_no_group_by_error() {
+        setup();
+        execute("CREATE TABLE t (id int, name text)").unwrap();
+        execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+        let err = execute("SELECT id, COUNT(*) FROM t");
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("GROUP BY"));
     }
 }

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -287,8 +287,11 @@ fn exec_insert(
                     row[col_idx] = eval_const(val_node.node.as_ref());
                 }
 
-                check_constraints(&table_def, &row, schema)?;
-                storage::insert(schema, table_name, row)?;
+                check_not_null(&table_def, &row)?;
+                let (unique_checks, pk_cols) = build_unique_checks(&table_def);
+                storage::insert_checked(
+                    schema, table_name, row, &unique_checks, &pk_cols,
+                )?;
                 row_count += 1;
             }
         }
@@ -303,16 +306,7 @@ fn exec_insert(
 
 // ── Constraint enforcement ────────────────────────────────────────────
 
-fn check_constraints(table: &Table, row: &[Value], schema: &str) -> Result<(), String> {
-    let pk_cols: Vec<usize> = table
-        .columns
-        .iter()
-        .enumerate()
-        .filter(|(_, c)| c.primary_key)
-        .map(|(i, _)| i)
-        .collect();
-
-    // NOT NULL checks (no scan needed)
+fn check_not_null(table: &Table, row: &[Value]) -> Result<(), String> {
     for (i, col) in table.columns.iter().enumerate() {
         if !col.nullable && matches!(row[i], Value::Null) {
             return Err(format!(
@@ -321,24 +315,52 @@ fn check_constraints(table: &Table, row: &[Value], schema: &str) -> Result<(), S
             ));
         }
     }
+    Ok(())
+}
 
-    // Check if any uniqueness checks are needed before scanning
-    let needs_unique_check = pk_cols.len() > 1
-        || table.columns.iter().enumerate().any(|(_, c)| {
-            (c.primary_key || c.unique)
-        });
+fn build_unique_checks(table: &Table) -> (Vec<(usize, String)>, Vec<usize>) {
+    let pk_cols: Vec<usize> = table
+        .columns
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| c.primary_key)
+        .map(|(i, _)| i)
+        .collect();
 
-    if !needs_unique_check {
-        return Ok(());
+    let mut unique_checks = Vec::new();
+    for (i, col) in table.columns.iter().enumerate() {
+        if col.primary_key && pk_cols.len() > 1 {
+            continue; // composite PK checked separately
+        }
+        if col.primary_key || col.unique {
+            let cname = if col.primary_key {
+                format!("{}_pkey", table.name)
+            } else {
+                format!("{}_{}_key", table.name, col.name)
+            };
+            unique_checks.push((i, cname));
+        }
     }
 
-    // Scan existing rows ONCE for all constraint checks
-    let existing = storage::scan(schema, &table.name)?;
+    (unique_checks, pk_cols)
+}
 
-    // Composite PK check
+/// Validate uniqueness of `new_row` against `all_rows`, excluding row at `skip_idx`.
+fn check_unique_against(
+    table: &Table,
+    new_row: &[Value],
+    all_rows: &[Vec<Value>],
+    skip_idx: usize,
+) -> Result<(), String> {
+    let (unique_checks, pk_cols) = build_unique_checks(table);
+
+    // Composite PK
     if pk_cols.len() > 1 {
-        let new_key: Vec<&Value> = pk_cols.iter().map(|&i| &row[i]).collect();
-        for erow in &existing {
+        let new_key: Vec<&Value> = pk_cols.iter().map(|&i| &new_row[i]).collect();
+        for (idx, erow) in all_rows.iter().enumerate() {
+            if idx == skip_idx {
+                continue;
+            }
             let ekey: Vec<&Value> = pk_cols.iter().map(|&i| &erow[i]).collect();
             if new_key == ekey {
                 return Err(format!(
@@ -349,24 +371,19 @@ fn check_constraints(table: &Table, row: &[Value], schema: &str) -> Result<(), S
         }
     }
 
-    // Per-column UNIQUE / single-column PK checks
-    for (i, col) in table.columns.iter().enumerate() {
-        if (col.primary_key || col.unique) && !matches!(row[i], Value::Null) {
-            if col.primary_key && pk_cols.len() > 1 {
+    for &(col_idx, ref cname) in &unique_checks {
+        if matches!(new_row[col_idx], Value::Null) {
+            continue;
+        }
+        for (idx, erow) in all_rows.iter().enumerate() {
+            if idx == skip_idx {
                 continue;
             }
-            for erow in &existing {
-                if i < erow.len() && erow[i] == row[i] {
-                    let cname = if col.primary_key {
-                        format!("{}_pkey", table.name)
-                    } else {
-                        format!("{}_{}_key", table.name, col.name)
-                    };
-                    return Err(format!(
-                        "duplicate key value violates unique constraint \"{}\"",
-                        cname
-                    ));
-                }
+            if col_idx < erow.len() && erow[col_idx] == new_row[col_idx] {
+                return Err(format!(
+                    "duplicate key value violates unique constraint \"{}\"",
+                    cname
+                ));
             }
         }
     }
@@ -1596,17 +1613,21 @@ fn exec_update(
     let td = table_def.clone();
     let assigns = assignments.clone();
 
-    let count = storage::update_rows(
+    let count = storage::update_rows_checked(
         schema,
         table_name,
         |row| eval_where(&wc, row, &td),
         |row| {
-            let old_row = row.clone();
+            // Compute new row values, propagating errors
+            let mut new_row = row.clone();
             for (col_idx, expr_node) in &assigns {
-                if let Ok(val) = eval_expr(expr_node, &old_row, &td) {
-                    row[*col_idx] = val;
-                }
+                new_row[*col_idx] = eval_expr(expr_node, row, &td)?;
             }
+            check_not_null(&td, &new_row)?;
+            Ok(new_row)
+        },
+        |new_row, all_rows, skip_idx| {
+            check_unique_against(&td, new_row, all_rows, skip_idx)
         },
     )?;
 
@@ -2193,5 +2214,44 @@ mod tests {
         let err = execute("SELECT id, COUNT(*) FROM t");
         assert!(err.is_err());
         assert!(err.unwrap_err().contains("GROUP BY"));
+    }
+
+    // ── Devin review fixes ────────────────────────────────────────────
+
+    #[test]
+    #[serial_test::serial]
+    fn update_division_by_zero_errors() {
+        setup();
+        execute("CREATE TABLE t (id int, val int)").unwrap();
+        execute("INSERT INTO t VALUES (1, 10)").unwrap();
+        let err = execute("UPDATE t SET val = val / 0 WHERE id = 1");
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("division by zero"));
+        // Row should be unchanged
+        let r = execute("SELECT val FROM t WHERE id = 1").unwrap();
+        assert_eq!(r.rows[0][0], Some("10".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn update_enforces_unique_constraint() {
+        setup();
+        execute("CREATE TABLE t (id int PRIMARY KEY, name text)").unwrap();
+        execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+        execute("INSERT INTO t VALUES (2, 'b')").unwrap();
+        let err = execute("UPDATE t SET id = 1 WHERE id = 2");
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("unique constraint"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn update_enforces_not_null() {
+        setup();
+        execute("CREATE TABLE t (id int PRIMARY KEY, name text NOT NULL)").unwrap();
+        execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+        let err = execute("UPDATE t SET name = NULL WHERE id = 1");
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("not-null"));
     }
 }

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -34,6 +34,7 @@ pub fn execute(sql: &str) -> Result<QueryResult, String> {
         NodeEnum::InsertStmt(insert) => exec_insert(insert),
         NodeEnum::SelectStmt(select) => exec_select(select, sql),
         NodeEnum::DeleteStmt(delete) => exec_delete(delete),
+        NodeEnum::UpdateStmt(update) => exec_update(update),
         NodeEnum::TruncateStmt(trunc) => exec_truncate(trunc),
         NodeEnum::VariableSetStmt(_) => Ok(QueryResult {
             tag: "SET".into(),
@@ -272,6 +273,240 @@ fn eval_const(node: Option<&NodeEnum>) -> Value {
     }
 }
 
+fn eval_expr(node: &NodeEnum, row: &[Value], table: &Table) -> Result<Value, String> {
+    match node {
+        NodeEnum::ColumnRef(cref) => {
+            let col_name = cref
+                .fields
+                .iter()
+                .filter_map(|f| f.node.as_ref())
+                .filter_map(|n| {
+                    if let NodeEnum::String(s) = n {
+                        Some(s.sval.clone())
+                    } else {
+                        None
+                    }
+                })
+                .last()
+                .ok_or("empty ColumnRef")?;
+            let idx = table
+                .columns
+                .iter()
+                .position(|c| c.name == col_name)
+                .ok_or_else(|| format!("column \"{}\" does not exist", col_name))?;
+            Ok(row.get(idx).cloned().unwrap_or(Value::Null))
+        }
+        NodeEnum::AConst(ac) => {
+            if ac.isnull {
+                return Ok(Value::Null);
+            }
+            if let Some(val) = &ac.val {
+                match val {
+                    pg_query::protobuf::a_const::Val::Ival(i) => Ok(Value::Int(i.ival as i64)),
+                    pg_query::protobuf::a_const::Val::Fval(f) => f
+                        .fval
+                        .parse::<f64>()
+                        .map(Value::Float)
+                        .map_err(|e| e.to_string()),
+                    pg_query::protobuf::a_const::Val::Sval(s) => Ok(Value::Text(s.sval.clone())),
+                    pg_query::protobuf::a_const::Val::Bsval(s) => {
+                        Ok(Value::Text(s.bsval.clone()))
+                    }
+                    pg_query::protobuf::a_const::Val::Boolval(b) => Ok(Value::Bool(b.boolval)),
+                }
+            } else {
+                Ok(Value::Null)
+            }
+        }
+        NodeEnum::Integer(i) => Ok(Value::Int(i.ival as i64)),
+        NodeEnum::Float(f) => f
+            .fval
+            .parse::<f64>()
+            .map(Value::Float)
+            .map_err(|e| e.to_string()),
+        NodeEnum::String(s) => Ok(Value::Text(s.sval.clone())),
+        NodeEnum::TypeCast(tc) => {
+            let inner = tc
+                .arg
+                .as_ref()
+                .and_then(|a| a.node.as_ref())
+                .ok_or("TypeCast missing arg")?;
+            eval_expr(inner, row, table)
+        }
+        NodeEnum::AExpr(expr) => {
+            if expr.kind != pg_query::protobuf::AExprKind::AexprOp as i32 {
+                return Err(format!("unsupported A_Expr kind: {}", expr.kind));
+            }
+            let op = expr
+                .name
+                .iter()
+                .filter_map(|n| n.node.as_ref())
+                .filter_map(|n| {
+                    if let NodeEnum::String(s) = n {
+                        Some(s.sval.clone())
+                    } else {
+                        None
+                    }
+                })
+                .next()
+                .ok_or("A_Expr missing operator")?;
+
+            let left_node = expr
+                .lexpr
+                .as_ref()
+                .and_then(|n| n.node.as_ref())
+                .ok_or("A_Expr missing left operand")?;
+            let right_node = expr
+                .rexpr
+                .as_ref()
+                .and_then(|n| n.node.as_ref())
+                .ok_or("A_Expr missing right operand")?;
+
+            let left = eval_expr(left_node, row, table)?;
+            let right = eval_expr(right_node, row, table)?;
+
+            // Arithmetic operators
+            if op == "+" || op == "-" || op == "*" || op == "/" {
+                return eval_arithmetic(&op, &left, &right);
+            }
+
+            // NULL propagation for comparison
+            if matches!(left, Value::Null) || matches!(right, Value::Null) {
+                return Ok(Value::Null);
+            }
+
+            let cmp = left.compare(&right);
+            let result = match op.as_str() {
+                "=" => cmp.map(|o| o == std::cmp::Ordering::Equal),
+                "<>" | "!=" => cmp.map(|o| o != std::cmp::Ordering::Equal),
+                "<" => cmp.map(|o| o == std::cmp::Ordering::Less),
+                ">" => cmp.map(|o| o == std::cmp::Ordering::Greater),
+                "<=" => cmp.map(|o| o != std::cmp::Ordering::Greater),
+                ">=" => cmp.map(|o| o != std::cmp::Ordering::Less),
+                _ => return Err(format!("unsupported operator: {}", op)),
+            };
+            Ok(result.map(Value::Bool).unwrap_or(Value::Null))
+        }
+        NodeEnum::BoolExpr(bexpr) => {
+            let boolop = bexpr.boolop;
+            if boolop == pg_query::protobuf::BoolExprType::AndExpr as i32 {
+                // AND: false if any false, NULL if any NULL and no false, true otherwise
+                let mut has_null = false;
+                for arg in &bexpr.args {
+                    let inner = arg.node.as_ref().ok_or("BoolExpr: missing arg node")?;
+                    match eval_expr(inner, row, table)? {
+                        Value::Bool(false) => return Ok(Value::Bool(false)),
+                        Value::Null => has_null = true,
+                        Value::Bool(true) => {}
+                        other => {
+                            return Err(format!("AND expects bool, got {:?}", other));
+                        }
+                    }
+                }
+                if has_null {
+                    Ok(Value::Null)
+                } else {
+                    Ok(Value::Bool(true))
+                }
+            } else if boolop == pg_query::protobuf::BoolExprType::OrExpr as i32 {
+                // OR: true if any true, NULL if any NULL and no true, false otherwise
+                let mut has_null = false;
+                for arg in &bexpr.args {
+                    let inner = arg.node.as_ref().ok_or("BoolExpr: missing arg node")?;
+                    match eval_expr(inner, row, table)? {
+                        Value::Bool(true) => return Ok(Value::Bool(true)),
+                        Value::Null => has_null = true,
+                        Value::Bool(false) => {}
+                        other => {
+                            return Err(format!("OR expects bool, got {:?}", other));
+                        }
+                    }
+                }
+                if has_null {
+                    Ok(Value::Null)
+                } else {
+                    Ok(Value::Bool(false))
+                }
+            } else if boolop == pg_query::protobuf::BoolExprType::NotExpr as i32 {
+                let inner = bexpr
+                    .args
+                    .first()
+                    .and_then(|a| a.node.as_ref())
+                    .ok_or("NOT missing arg")?;
+                match eval_expr(inner, row, table)? {
+                    Value::Bool(b) => Ok(Value::Bool(!b)),
+                    Value::Null => Ok(Value::Null),
+                    other => Err(format!("NOT expects bool, got {:?}", other)),
+                }
+            } else {
+                Err(format!("unsupported BoolExpr op: {}", boolop))
+            }
+        }
+        NodeEnum::NullTest(nt) => {
+            let inner = nt
+                .arg
+                .as_ref()
+                .and_then(|a| a.node.as_ref())
+                .ok_or("NullTest missing arg")?;
+            let val = eval_expr(inner, row, table)?;
+            let is_null = matches!(val, Value::Null);
+            if nt.nulltesttype == pg_query::protobuf::NullTestType::IsNull as i32 {
+                Ok(Value::Bool(is_null))
+            } else {
+                Ok(Value::Bool(!is_null))
+            }
+        }
+        _ => Err(format!("unsupported expression node: {:?}", std::mem::discriminant(node))),
+    }
+}
+
+fn eval_arithmetic(op: &str, left: &Value, right: &Value) -> Result<Value, String> {
+    if matches!(left, Value::Null) || matches!(right, Value::Null) {
+        return Ok(Value::Null);
+    }
+    match (left, right) {
+        (Value::Int(a), Value::Int(b)) => match op {
+            "+" => Ok(Value::Int(a + b)),
+            "-" => Ok(Value::Int(a - b)),
+            "*" => Ok(Value::Int(a * b)),
+            "/" => {
+                if *b == 0 {
+                    Err("division by zero".into())
+                } else {
+                    Ok(Value::Int(a / b))
+                }
+            }
+            _ => Err(format!("unsupported arithmetic op: {}", op)),
+        },
+        (Value::Float(a), Value::Float(b)) => match op {
+            "+" => Ok(Value::Float(a + b)),
+            "-" => Ok(Value::Float(a - b)),
+            "*" => Ok(Value::Float(a * b)),
+            "/" => Ok(Value::Float(a / b)),
+            _ => Err(format!("unsupported arithmetic op: {}", op)),
+        },
+        (Value::Int(a), Value::Float(b)) => {
+            let a = *a as f64;
+            eval_arithmetic(op, &Value::Float(a), &Value::Float(*b))
+        }
+        (Value::Float(a), Value::Int(b)) => {
+            let b = *b as f64;
+            eval_arithmetic(op, &Value::Float(*a), &Value::Float(b))
+        }
+        _ => Err(format!("cannot apply {} to {:?} and {:?}", op, left, right)),
+    }
+}
+
+fn eval_where(where_clause: &Option<Box<pg_query::protobuf::Node>>, row: &[Value], table: &Table) -> bool {
+    match where_clause {
+        Some(wc) => match wc.node.as_ref() {
+            Some(expr) => matches!(eval_expr(expr, row, table), Ok(Value::Bool(true))),
+            None => true,
+        },
+        None => true,
+    }
+}
+
 fn exec_select(
     select: &pg_query::protobuf::SelectStmt,
     _raw_sql: &str,
@@ -288,7 +523,13 @@ fn exec_select(
     let table_def = catalog::get_table(&schema, &table_name)
         .ok_or_else(|| format!("relation \"{}\" does not exist", table_name))?;
 
-    let rows = storage::scan(&schema, &table_name)?;
+    let all_rows = storage::scan(&schema, &table_name)?;
+
+    // Apply WHERE filter
+    let rows: Vec<Vec<Value>> = all_rows
+        .into_iter()
+        .filter(|row| eval_where(&select.where_clause, row, &table_def))
+        .collect();
 
     // Resolve target columns
     let (col_names, col_indices) = resolve_select_targets(select, &table_def)?;
@@ -427,14 +668,79 @@ fn exec_delete(
         &rel.schemaname
     };
 
-    // For now: DELETE without WHERE deletes all rows
-    if delete.where_clause.is_some() {
-        return Err("DELETE with WHERE not yet implemented".into());
-    }
+    let count = if delete.where_clause.is_some() {
+        let table_def = catalog::get_table(schema, table_name)
+            .ok_or_else(|| format!("relation \"{}\" does not exist", table_name))?;
+        let wc = delete.where_clause.clone();
+        storage::delete_where(schema, table_name, |row| eval_where(&wc, row, &table_def))?
+    } else {
+        storage::delete_all(schema, table_name)?
+    };
 
-    let count = storage::delete_all(schema, table_name)?;
     Ok(QueryResult {
         tag: format!("DELETE {}", count),
+        columns: vec![],
+        rows: vec![],
+    })
+}
+
+fn exec_update(
+    update: &pg_query::protobuf::UpdateStmt,
+) -> Result<QueryResult, String> {
+    let rel = update
+        .relation
+        .as_ref()
+        .ok_or("UPDATE missing relation")?;
+    let table_name = &rel.relname;
+    let schema = if rel.schemaname.is_empty() {
+        "public"
+    } else {
+        &rel.schemaname
+    };
+
+    let table_def = catalog::get_table(schema, table_name)
+        .ok_or_else(|| format!("relation \"{}\" does not exist", table_name))?;
+
+    // Pre-parse the SET assignments: (column_index, expression_node)
+    let mut assignments: Vec<(usize, NodeEnum)> = Vec::new();
+    for target in &update.target_list {
+        if let Some(NodeEnum::ResTarget(rt)) = target.node.as_ref() {
+            let col_name = &rt.name;
+            let col_idx = table_def
+                .columns
+                .iter()
+                .position(|c| &c.name == col_name)
+                .ok_or_else(|| format!("column \"{}\" does not exist", col_name))?;
+            let val_node = rt
+                .val
+                .as_ref()
+                .and_then(|v| v.node.as_ref())
+                .ok_or_else(|| format!("SET {} missing value", col_name))?;
+            assignments.push((col_idx, val_node.clone()));
+        }
+    }
+
+    let wc = update.where_clause.clone();
+    let td = table_def.clone();
+    let assigns = assignments.clone();
+
+    let count = storage::update_rows(
+        schema,
+        table_name,
+        |row| eval_where(&wc, row, &td),
+        |row| {
+            // Evaluate expressions against the OLD row values
+            let old_row = row.clone();
+            for (col_idx, expr_node) in &assigns {
+                if let Ok(val) = eval_expr(expr_node, &old_row, &td) {
+                    row[*col_idx] = val;
+                }
+            }
+        },
+    )?;
+
+    Ok(QueryResult {
+        tag: format!("UPDATE {}", count),
         columns: vec![],
         rows: vec![],
     })
@@ -533,5 +839,134 @@ mod tests {
         execute("TRUNCATE t").unwrap();
         let result = execute("SELECT * FROM t").unwrap();
         assert_eq!(result.rows.len(), 0);
+    }
+
+    // --- WHERE clause tests ---
+
+    fn setup_test_table() {
+        setup();
+        execute("CREATE TABLE t (id integer, name text)").unwrap();
+        execute("INSERT INTO t VALUES (1, 'alice')").unwrap();
+        execute("INSERT INTO t VALUES (2, 'bob')").unwrap();
+        execute("INSERT INTO t VALUES (3, 'carol')").unwrap();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn select_where_eq() {
+        setup_test_table();
+        let r = execute("SELECT * FROM t WHERE id = 1").unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][1], Some("alice".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn select_where_gt() {
+        setup_test_table();
+        let r = execute("SELECT * FROM t WHERE id > 1").unwrap();
+        assert_eq!(r.rows.len(), 2);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn select_where_and() {
+        setup_test_table();
+        let r = execute("SELECT * FROM t WHERE id > 1 AND name = 'bob'").unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][0], Some("2".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn select_where_or() {
+        setup_test_table();
+        let r = execute("SELECT * FROM t WHERE id = 1 OR id = 3").unwrap();
+        assert_eq!(r.rows.len(), 2);
+        assert_eq!(r.rows[0][1], Some("alice".into()));
+        assert_eq!(r.rows[1][1], Some("carol".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn select_where_is_null() {
+        setup();
+        execute("CREATE TABLE t (id integer, name text)").unwrap();
+        execute("INSERT INTO t (id) VALUES (1)").unwrap();
+        execute("INSERT INTO t VALUES (2, 'bob')").unwrap();
+        let r = execute("SELECT * FROM t WHERE name IS NULL").unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][0], Some("1".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn select_where_is_not_null() {
+        setup();
+        execute("CREATE TABLE t (id integer, name text)").unwrap();
+        execute("INSERT INTO t (id) VALUES (1)").unwrap();
+        execute("INSERT INTO t VALUES (2, 'bob')").unwrap();
+        let r = execute("SELECT * FROM t WHERE name IS NOT NULL").unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][0], Some("2".into()));
+    }
+
+    // --- UPDATE tests ---
+
+    #[test]
+    #[serial_test::serial]
+    fn update_with_where() {
+        setup_test_table();
+        let r = execute("UPDATE t SET name = 'updated' WHERE id = 1").unwrap();
+        assert_eq!(r.tag, "UPDATE 1");
+        let sel = execute("SELECT * FROM t WHERE id = 1").unwrap();
+        assert_eq!(sel.rows[0][1], Some("updated".into()));
+        // Other rows unchanged
+        let sel2 = execute("SELECT * FROM t WHERE id = 2").unwrap();
+        assert_eq!(sel2.rows[0][1], Some("bob".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn update_all_rows() {
+        setup_test_table();
+        let r = execute("UPDATE t SET name = 'all'").unwrap();
+        assert_eq!(r.tag, "UPDATE 3");
+        let sel = execute("SELECT * FROM t").unwrap();
+        for row in &sel.rows {
+            assert_eq!(row[1], Some("all".into()));
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn update_self_referential() {
+        setup_test_table();
+        let r = execute("UPDATE t SET id = id + 1 WHERE id = 1").unwrap();
+        assert_eq!(r.tag, "UPDATE 1");
+        let sel = execute("SELECT * FROM t WHERE name = 'alice'").unwrap();
+        assert_eq!(sel.rows[0][0], Some("2".into()));
+    }
+
+    // --- DELETE WHERE tests ---
+
+    #[test]
+    #[serial_test::serial]
+    fn delete_where() {
+        setup_test_table();
+        let r = execute("DELETE FROM t WHERE id = 1").unwrap();
+        assert_eq!(r.tag, "DELETE 1");
+        let sel = execute("SELECT * FROM t").unwrap();
+        assert_eq!(sel.rows.len(), 2);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn delete_where_no_match() {
+        setup_test_table();
+        let r = execute("DELETE FROM t WHERE id = 999").unwrap();
+        assert_eq!(r.tag, "DELETE 0");
+        let sel = execute("SELECT * FROM t").unwrap();
+        assert_eq!(sel.rows.len(), 3);
     }
 }

--- a/native/engine/src/storage.rs
+++ b/native/engine/src/storage.rs
@@ -108,6 +108,88 @@ pub fn update_rows(
     Ok(count)
 }
 
+/// Insert with uniqueness check under a single write lock (no TOCTOU race).
+/// `unique_checks` is a list of (column_index, constraint_name) pairs.
+/// `pk_cols` is a list of column indices forming the composite primary key (if any).
+pub fn insert_checked(
+    schema: &str,
+    name: &str,
+    row: Row,
+    unique_checks: &[(usize, String)],
+    pk_cols: &[usize],
+) -> Result<(), String> {
+    let mut store = STORE.write();
+    let table = store
+        .tables
+        .get_mut(&key(schema, name))
+        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+
+    // Composite PK check
+    if pk_cols.len() > 1 {
+        let new_key: Vec<&Value> = pk_cols.iter().map(|&i| &row[i]).collect();
+        for erow in &table.rows {
+            let ekey: Vec<&Value> = pk_cols.iter().map(|&i| &erow[i]).collect();
+            if new_key == ekey {
+                return Err(format!(
+                    "duplicate key value violates unique constraint \"{}.{}_pkey\"",
+                    schema, name
+                ));
+            }
+        }
+    }
+
+    // Per-column unique checks
+    for &(col_idx, ref cname) in unique_checks {
+        if matches!(row[col_idx], Value::Null) {
+            continue; // NULLs don't violate UNIQUE
+        }
+        for erow in &table.rows {
+            if col_idx < erow.len() && erow[col_idx] == row[col_idx] {
+                return Err(format!(
+                    "duplicate key value violates unique constraint \"{}\"",
+                    cname
+                ));
+            }
+        }
+    }
+
+    table.rows.push(row);
+    Ok(())
+}
+
+/// Update matching rows with validation. Returns error if any updater fails.
+pub fn update_rows_checked(
+    schema: &str,
+    name: &str,
+    predicate: impl Fn(&Row) -> bool,
+    updater: impl Fn(&Row) -> Result<Row, String>,
+    validator: impl Fn(&Row, &[Row], usize) -> Result<(), String>,
+) -> Result<u64, String> {
+    let mut store = STORE.write();
+    let table = store
+        .tables
+        .get_mut(&key(schema, name))
+        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+
+    // First pass: compute new rows and validate
+    let mut updates: Vec<(usize, Row)> = Vec::new();
+    for (idx, row) in table.rows.iter().enumerate() {
+        if predicate(row) {
+            let new_row = updater(row)?;
+            // Validate against all OTHER rows (excluding current)
+            validator(&new_row, &table.rows, idx)?;
+            updates.push((idx, new_row));
+        }
+    }
+
+    // Second pass: apply
+    let count = updates.len() as u64;
+    for (idx, new_row) in updates {
+        table.rows[idx] = new_row;
+    }
+    Ok(count)
+}
+
 pub fn row_count(schema: &str, name: &str) -> Result<u64, String> {
     let store = STORE.read();
     let table = store

--- a/native/engine/src/storage.rs
+++ b/native/engine/src/storage.rs
@@ -72,6 +72,42 @@ pub fn delete_all(schema: &str, name: &str) -> Result<u64, String> {
     Ok(count)
 }
 
+pub fn delete_where(
+    schema: &str,
+    name: &str,
+    predicate: impl Fn(&Row) -> bool,
+) -> Result<u64, String> {
+    let mut store = STORE.write();
+    let table = store
+        .tables
+        .get_mut(&key(schema, name))
+        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+    let before = table.rows.len();
+    table.rows.retain(|row| !predicate(row));
+    Ok((before - table.rows.len()) as u64)
+}
+
+pub fn update_rows(
+    schema: &str,
+    name: &str,
+    predicate: impl Fn(&Row) -> bool,
+    updater: impl Fn(&mut Row),
+) -> Result<u64, String> {
+    let mut store = STORE.write();
+    let table = store
+        .tables
+        .get_mut(&key(schema, name))
+        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+    let mut count = 0u64;
+    for row in table.rows.iter_mut() {
+        if predicate(row) {
+            updater(row);
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
 pub fn row_count(schema: &str, name: &str) -> Result<u64, String> {
     let store = STORE.read();
     let table = store

--- a/native/engine/src/types.rs
+++ b/native/engine/src/types.rs
@@ -12,6 +12,19 @@ pub enum Value {
 }
 
 impl Value {
+    pub fn compare(&self, other: &Value) -> Option<std::cmp::Ordering> {
+        match (self, other) {
+            (Value::Null, _) | (_, Value::Null) => None,
+            (Value::Int(a), Value::Int(b)) => a.partial_cmp(b),
+            (Value::Float(a), Value::Float(b)) => a.partial_cmp(b),
+            (Value::Int(a), Value::Float(b)) => (*a as f64).partial_cmp(b),
+            (Value::Float(a), Value::Int(b)) => a.partial_cmp(&(*b as f64)),
+            (Value::Text(a), Value::Text(b)) => a.partial_cmp(b),
+            (Value::Bool(a), Value::Bool(b)) => a.partial_cmp(b),
+            _ => None,
+        }
+    }
+
     pub fn to_text(&self) -> Option<String> {
         match self {
             Value::Null => None,


### PR DESCRIPTION
## Summary

Implements Phase 2 of the pgrx SQL engine, adding 8 major features that transform the engine from a demo into something actually usable:

- **Expression evaluator** (`eval_expr`) — recursive AST walker for all expression types
- **WHERE clauses** — comparison operators, AND/OR/NOT, IS NULL/IS NOT NULL, NULL propagation
- **UPDATE with SET and WHERE** — expression evaluation against old row values
- **DELETE with WHERE** — filtered row deletion
- **ORDER BY / LIMIT / OFFSET** — multi-key sorting, NULLS FIRST/LAST, ordinal references
- **SELECT expressions** — arithmetic (+,-,*,/), functions (upper, lower, length, concat, abs), string concatenation (||), unary minus, aliasing
- **Constraints** — PRIMARY KEY, UNIQUE, NOT NULL enforcement on INSERT, composite PK support
- **Aggregates** — COUNT(*), COUNT(col), SUM, AVG, MIN, MAX with GROUP BY and HAVING

## Changes

- `executor.rs`: +1473 lines — eval_expr, ORDER BY, LIMIT, expressions, aggregates, constraints
- `catalog.rs`: +3 lines — added `unique` field to Column
- 61 tests passing (was 6 in Phase 1)

## What's Now Supported

```sql
SELECT * FROM users WHERE age > 21 AND active = true;
SELECT dept, COUNT(*), AVG(salary) FROM emp GROUP BY dept HAVING COUNT(*) > 2;
SELECT upper(name), length(name) FROM users ORDER BY name DESC LIMIT 10 OFFSET 5;
UPDATE users SET name = 'new' WHERE id = 1;
DELETE FROM users WHERE active = false;
CREATE TABLE t (id int PRIMARY KEY, email text UNIQUE, name text NOT NULL);
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/pgrx/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
