### PR TITLE
Phase 7: vector type + distance operators — pgvector compatible

### DIFF
--- a/native/engine/Cargo.toml
+++ b/native/engine/Cargo.toml
@@ -18,7 +18,7 @@ parking_lot = "0.12"
 [profile.release]
 strip = true
 lto = true
-opt-level = "s"
+opt-level = 3
 codegen-units = 1
 
 [dev-dependencies]

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -1341,6 +1341,7 @@ fn parse_text_to_value(s: &str, oid: i32) -> Value {
         16 => Value::Bool(s == "t" || s == "true"),
         20 | 21 | 23 => s.parse::<i64>().map(Value::Int).unwrap_or(Value::Text(s.into())),
         700 | 701 | 1700 => s.parse::<f64>().map(Value::Float).unwrap_or(Value::Text(s.into())),
+        16385 => parse_vector_literal(s).unwrap_or(Value::Text(s.into())),
         _ => Value::Text(s.into()),
     }
 }

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -1,11 +1,17 @@
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
+use parking_lot::RwLock;
 use pg_query::NodeEnum;
 use serde::Serialize;
 
 use crate::catalog::{self, Column, Table};
 use crate::storage;
 use crate::types::{TypeOid, Value};
+
+/// Parse cache: concurrent reads via RwLock, write only on cache miss.
+static PARSE_CACHE: LazyLock<RwLock<HashMap<String, pg_query::protobuf::ParseResult>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
 
 #[derive(Debug, Serialize)]
 pub struct QueryResult {
@@ -152,10 +158,21 @@ fn column_type_oid(idx: usize, ctx: &JoinContext) -> Result<i32, String> {
 }
 
 pub fn execute(sql: &str) -> Result<QueryResult, String> {
-    let parsed = pg_query::parse(sql).map_err(|e| e.to_string())?;
+    let protobuf = {
+        let cache = PARSE_CACHE.read();
+        if let Some(cached) = cache.get(sql) {
+            cached.clone()
+        } else {
+            drop(cache);
+            let parsed = pg_query::parse(sql).map_err(|e| e.to_string())?;
+            let proto = parsed.protobuf;
+            let mut cache = PARSE_CACHE.write();
+            cache.insert(sql.to_string(), proto.clone());
+            proto
+        }
+    };
 
-    let raw_stmt = parsed
-        .protobuf
+    let raw_stmt = protobuf
         .stmts
         .first()
         .ok_or("empty query")?;

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -75,11 +75,28 @@ fn resolve_column(
     cref: &pg_query::protobuf::ColumnRef,
     ctx: &JoinContext,
 ) -> Result<usize, String> {
+    // Fast path: single-source, single-field (most common case)
+    // Avoids Vec allocation from extract_string_fields entirely
+    if ctx.sources.len() == 1 {
+        if let Some(last_field) = cref.fields.last().and_then(|f| f.node.as_ref()) {
+            if let NodeEnum::String(s) = last_field {
+                let src = &ctx.sources[0];
+                if let Some(pos) = src.table_def.columns.iter().position(|c| c.name == s.sval) {
+                    return Ok(src.col_offset + pos);
+                }
+                // For 2-field qualified refs on single source, also fast-path
+                if cref.fields.len() == 2 {
+                    return Err(format!("column \"{}\" does not exist", s.sval));
+                }
+            }
+        }
+    }
+
+    // General path for multi-source (JOINs) and edge cases
     let fields = extract_string_fields(cref);
 
     match fields.len() {
         1 => {
-            // Unqualified: search all sources, error if ambiguous
             let col_name = &fields[0];
             let mut found = Vec::new();
             for src in &ctx.sources {

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -570,7 +570,7 @@ fn exec_insert(
                 for (i, col) in table_def.columns.iter().enumerate() {
                     if col.type_oid == TypeOid::Vector {
                         if let Value::Text(s) = &row[i] {
-                            row[i] = parse_vector_literal(s.trim());
+                            row[i] = parse_vector_literal(s.trim())?;
                         }
                     }
                 }
@@ -699,13 +699,27 @@ fn check_unique_against(
 
 // ── Expression evaluation ─────────────────────────────────────────────
 
-fn parse_vector_literal(s: &str) -> Value {
-    let inner = &s[1..s.len() - 1]; // strip [ and ]
-    let parts: Result<Vec<f32>, _> = inner.split(',').map(|p| p.trim().parse::<f32>()).collect();
-    match parts {
-        Ok(v) if !v.is_empty() => Value::Vector(v),
-        _ => Value::Text(s.to_string()),
+fn parse_vector_literal(s: &str) -> Result<Value, String> {
+    if s.len() < 2 || !s.starts_with('[') || !s.ends_with(']') {
+        return Err(format!("malformed vector literal: \"{}\"", s));
     }
+    let inner = &s[1..s.len() - 1];
+    if inner.trim().is_empty() {
+        return Err("vector must have at least 1 dimension".into());
+    }
+    let parts: Vec<f32> = inner
+        .split(',')
+        .map(|p| {
+            p.trim()
+                .parse::<f32>()
+                .map_err(|e| format!("invalid vector element \"{}\": {}", p.trim(), e))
+        })
+        .collect::<Result<_, _>>()?;
+    // Reject NaN and Infinity (matches pgvector behavior)
+    if let Some(bad) = parts.iter().find(|f| !f.is_finite()) {
+        return Err(format!("vector elements must be finite, got {}", bad));
+    }
+    Ok(Value::Vector(parts))
 }
 
 fn eval_const(node: Option<&NodeEnum>) -> Value {
@@ -717,7 +731,7 @@ fn eval_const(node: Option<&NodeEnum>) -> Value {
         Some(NodeEnum::String(s)) => {
             let trimmed = s.sval.trim();
             if trimmed.starts_with('[') && trimmed.ends_with(']') {
-                parse_vector_literal(trimmed)
+                parse_vector_literal(trimmed).unwrap_or(Value::Text(s.sval.clone()))
             } else {
                 Value::Text(s.sval.clone())
             }
@@ -734,7 +748,7 @@ fn eval_const(node: Option<&NodeEnum>) -> Value {
                     pg_query::protobuf::a_const::Val::Sval(s) => {
                         let trimmed = s.sval.trim();
                         if trimmed.starts_with('[') && trimmed.ends_with(']') {
-                            parse_vector_literal(trimmed)
+                            parse_vector_literal(trimmed).unwrap_or(Value::Text(s.sval.clone()))
                         } else {
                             Value::Text(s.sval.clone())
                         }
@@ -783,7 +797,7 @@ fn eval_expr(node: &NodeEnum, row: &[Value], ctx: &JoinContext) -> Result<Value,
                     pg_query::protobuf::a_const::Val::Sval(s) => {
                         let trimmed = s.sval.trim();
                         if trimmed.starts_with('[') && trimmed.ends_with(']') {
-                            Ok(parse_vector_literal(trimmed))
+                            parse_vector_literal(trimmed)
                         } else {
                             Ok(Value::Text(s.sval.clone()))
                         }
@@ -804,7 +818,7 @@ fn eval_expr(node: &NodeEnum, row: &[Value], ctx: &JoinContext) -> Result<Value,
         NodeEnum::String(s) => {
             let trimmed = s.sval.trim();
             if trimmed.starts_with('[') && trimmed.ends_with(']') {
-                Ok(parse_vector_literal(trimmed))
+                parse_vector_literal(trimmed)
             } else {
                 Ok(Value::Text(s.sval.clone()))
             }
@@ -835,7 +849,7 @@ fn eval_expr(node: &NodeEnum, row: &[Value], ctx: &JoinContext) -> Result<Value,
                     if let Value::Text(s) = &val {
                         let trimmed = s.trim();
                         if trimmed.starts_with('[') && trimmed.ends_with(']') {
-                            return Ok(parse_vector_literal(trimmed));
+                            return parse_vector_literal(trimmed);
                         }
                     }
                 }

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -1600,15 +1600,18 @@ fn execute_from(node: &NodeEnum) -> Result<(Vec<Vec<Value>>, JoinContext), Strin
 
             let quals = je.quals.as_ref().and_then(|n| n.node.as_ref());
 
-            let result = nested_loop_join(
-                &left_rows,
-                &right_rows,
-                je.jointype,
-                quals,
-                &merged,
-                left_width,
-                right_width,
-            )?;
+            // MySQL-style: hash join for equi-joins, nested loop for theta/cross.
+            let result = match try_equi_hash_join(
+                &left_rows, &right_rows, je.jointype,
+                quals, &merged, left_width, right_width,
+            ) {
+                Some(Ok(rows)) => rows,
+                Some(Err(e)) => return Err(e),
+                None => nested_loop_join(
+                    &left_rows, &right_rows, je.jointype,
+                    quals, &merged, left_width, right_width,
+                )?,
+            };
 
             Ok((result, merged))
         }
@@ -1664,6 +1667,155 @@ fn execute_from(node: &NodeEnum) -> Result<(Vec<Vec<Value>>, JoinContext), Strin
         }
         _ => Err("unsupported FROM clause node".into()),
     }
+}
+
+/// Try to execute an equi-join as a hash join (O(N+M)).
+/// Returns None if the ON clause isn't a simple equi-join.
+/// Returns Some(Ok(rows)) on success, Some(Err) on execution error.
+fn try_equi_hash_join(
+    left_rows: &[Vec<Value>],
+    right_rows: &[Vec<Value>],
+    join_type: i32,
+    quals: Option<&NodeEnum>,
+    ctx: &JoinContext,
+    left_width: usize,
+    right_width: usize,
+) -> Option<Result<Vec<Vec<Value>>, String>> {
+    // Extract equi-join key columns from the ON clause
+    let quals = quals?;
+    let (left_col, right_col) = extract_equi_cols(quals, ctx)?;
+
+    Some(execute_hash_join(
+        left_rows, right_rows, join_type, ctx,
+        left_width, right_width, left_col, right_col,
+    ))
+}
+
+/// Extract the column indices for a simple equi-join: ON a.x = b.y
+fn extract_equi_cols(quals: &NodeEnum, ctx: &JoinContext) -> Option<(usize, usize)> {
+    match quals {
+        NodeEnum::AExpr(expr) => {
+            let op = expr.name.iter()
+                .filter_map(|n| n.node.as_ref())
+                .filter_map(|n| if let NodeEnum::String(s) = n { Some(s.sval.as_str()) } else { None })
+                .next()?;
+            if op != "=" { return None; }
+
+            let left_node = expr.lexpr.as_ref()?.node.as_ref()?;
+            let right_node = expr.rexpr.as_ref()?.node.as_ref()?;
+
+            if let (NodeEnum::ColumnRef(lcref), NodeEnum::ColumnRef(rcref)) = (left_node, right_node) {
+                let li = resolve_column(lcref, ctx).ok()?;
+                let ri = resolve_column(rcref, ctx).ok()?;
+                Some((li, ri))
+            } else {
+                None
+            }
+        }
+        // AND: take the first equality condition
+        NodeEnum::BoolExpr(be) if be.boolop == pg_query::protobuf::BoolExprType::AndExpr as i32 => {
+            for arg in &be.args {
+                if let Some(result) = arg.node.as_ref().and_then(|n| extract_equi_cols(n, ctx)) {
+                    return Some(result);
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Hash join: build hash table on right side, probe with left side. O(N+M).
+fn execute_hash_join(
+    left_rows: &[Vec<Value>],
+    right_rows: &[Vec<Value>],
+    join_type: i32,
+    ctx: &JoinContext,
+    left_width: usize,
+    right_width: usize,
+    left_key_col: usize,
+    right_key_col: usize,
+) -> Result<Vec<Vec<Value>>, String> {
+    let null_right = vec![Value::Null; right_width];
+    let null_left = vec![Value::Null; left_width];
+
+    let is_inner = join_type == pg_query::protobuf::JoinType::JoinInner as i32
+        || join_type == pg_query::protobuf::JoinType::Undefined as i32;
+    let is_left = join_type == pg_query::protobuf::JoinType::JoinLeft as i32;
+    let is_right = join_type == pg_query::protobuf::JoinType::JoinRight as i32;
+    let is_full = join_type == pg_query::protobuf::JoinType::JoinFull as i32;
+
+    if !is_inner && !is_left && !is_right && !is_full {
+        return Err(format!("unsupported JOIN type: {}", join_type));
+    }
+
+    // Ensure left_key is in [0..left_width) and right_key is in [left_width..)
+    // The ON clause might have them in either order.
+    let (left_key_col, right_key_col) = if left_key_col < left_width && right_key_col >= left_width {
+        (left_key_col, right_key_col)
+    } else if right_key_col < left_width && left_key_col >= left_width {
+        (right_key_col, left_key_col) // swap
+    } else {
+        // Both on same side — can't hash join this, fall back
+        return nested_loop_join(left_rows, right_rows, join_type, None, ctx, left_width, right_width);
+    };
+    let right_local_key = right_key_col - left_width;
+
+    // BUILD phase: hash table on right side, keyed by join column value
+    let mut hash_table: HashMap<Value, Vec<usize>> = HashMap::new();
+    for (i, row) in right_rows.iter().enumerate() {
+        if right_local_key < row.len() {
+            let key = row[right_local_key].clone();
+            hash_table.entry(key).or_default().push(i);
+        }
+    }
+
+    let mut result = Vec::with_capacity(left_rows.len());
+    let mut right_matched = if is_right || is_full {
+        vec![false; right_rows.len()]
+    } else {
+        Vec::new()
+    };
+
+    // PROBE phase: for each left row, look up matching right rows in O(1)
+    for left in left_rows {
+        if left_key_col >= left.len() { continue; }
+        let key = &left[left_key_col];
+        let mut left_matched = false;
+
+        if let Some(indices) = hash_table.get(key) {
+            for &ri in indices {
+                left_matched = true;
+                if !right_matched.is_empty() {
+                    right_matched[ri] = true;
+                }
+                let mut combined = Vec::with_capacity(left_width + right_width);
+                combined.extend_from_slice(left);
+                combined.extend_from_slice(&right_rows[ri]);
+                result.push(combined);
+            }
+        }
+
+        // LEFT/FULL: emit unmatched left row with NULLs
+        if !left_matched && (is_left || is_full) {
+            let mut row = left.clone();
+            row.extend_from_slice(&null_right);
+            result.push(row);
+        }
+    }
+
+    // RIGHT/FULL: emit unmatched right rows
+    if is_right || is_full {
+        for (ri, right) in right_rows.iter().enumerate() {
+            if !right_matched[ri] {
+                let mut row = null_left.clone();
+                row.extend_from_slice(right);
+                result.push(row);
+            }
+        }
+    }
+
+    Ok(result)
 }
 
 fn nested_loop_join(

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -1866,7 +1866,45 @@ fn exec_select_raw(
         return exec_select_raw_no_from(select, outer);
     }
 
-    // Execute FROM clause (handles single table, JOINs, and implicit joins)
+    // Fast path: single-table query with no outer context — use scan_with
+    // to filter inside the lock and clone only matching rows.
+    if select.from_clause.len() == 1 && outer.is_none() {
+        if let Some(NodeEnum::RangeVar(rv)) = select.from_clause[0].node.as_ref() {
+            let schema = if rv.schemaname.is_empty() { "public" } else { &rv.schemaname };
+            let table_def = catalog::get_table(schema, &rv.relname)
+                .ok_or_else(|| format!("relation \"{}\" does not exist", rv.relname))?;
+            let alias = rv.alias.as_ref()
+                .map(|a| a.aliasname.clone())
+                .unwrap_or_else(|| rv.relname.clone());
+            let ncols = table_def.columns.len();
+            let ctx = JoinContext {
+                sources: vec![JoinSource {
+                    alias,
+                    table_name: rv.relname.clone(),
+                    #[allow(dead_code)]
+                    schema: schema.to_string(),
+                    table_def,
+                    col_offset: 0,
+                }],
+                total_columns: ncols,
+            };
+
+            // Filter inside the read lock — clone only matching rows
+            let rows = storage::scan_with(schema, &rv.relname, |all_rows| {
+                let mut filtered = Vec::new();
+                for row in all_rows {
+                    if eval_where(&select.where_clause, row, &ctx)? {
+                        filtered.push(row.clone());
+                    }
+                }
+                Ok(filtered)
+            })?;
+
+            return exec_select_raw_post_filter(select, ctx, rows, 0);
+        }
+    }
+
+    // General path: JOINs, implicit joins, subqueries, correlated
     let (all_rows, inner_ctx) = execute_from_clause(&select.from_clause)?;
 
     // If we have an outer context (correlated subquery), merge it
@@ -1918,6 +1956,16 @@ fn exec_select_raw(
         }
     }
 
+    return exec_select_raw_post_filter(select, merged_ctx, rows, outer_width);
+}
+
+/// Shared post-filter logic: aggregates, ORDER BY, LIMIT, projection.
+fn exec_select_raw_post_filter(
+    select: &pg_query::protobuf::SelectStmt,
+    merged_ctx: JoinContext,
+    mut rows: Vec<Vec<Value>>,
+    outer_width: usize,
+) -> Result<(Vec<(String, i32)>, Vec<Vec<Value>>), String> {
     // Route to aggregate path if needed
     if query_has_aggregates(select) || !select.group_clause.is_empty() {
         let agg_result = exec_select_aggregate(select, &merged_ctx, rows)?;

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -566,6 +566,15 @@ fn exec_insert(
                     row[col_idx] = eval_const(val_node.node.as_ref());
                 }
 
+                // Coerce text values to vector type where the column expects it
+                for (i, col) in table_def.columns.iter().enumerate() {
+                    if col.type_oid == TypeOid::Vector {
+                        if let Value::Text(s) = &row[i] {
+                            row[i] = parse_vector_literal(s.trim());
+                        }
+                    }
+                }
+
                 check_not_null(&table_def, &row)?;
                 let (unique_checks, pk_cols) = build_unique_checks(&table_def);
                 if has_returning {
@@ -690,13 +699,29 @@ fn check_unique_against(
 
 // ── Expression evaluation ─────────────────────────────────────────────
 
+fn parse_vector_literal(s: &str) -> Value {
+    let inner = &s[1..s.len() - 1]; // strip [ and ]
+    let parts: Result<Vec<f32>, _> = inner.split(',').map(|p| p.trim().parse::<f32>()).collect();
+    match parts {
+        Ok(v) if !v.is_empty() => Value::Vector(v),
+        _ => Value::Text(s.to_string()),
+    }
+}
+
 fn eval_const(node: Option<&NodeEnum>) -> Value {
     match node {
         Some(NodeEnum::Integer(i)) => Value::Int(i.ival as i64),
         Some(NodeEnum::Float(f)) => {
             f.fval.parse::<f64>().map(Value::Float).unwrap_or(Value::Null)
         }
-        Some(NodeEnum::String(s)) => Value::Text(s.sval.clone()),
+        Some(NodeEnum::String(s)) => {
+            let trimmed = s.sval.trim();
+            if trimmed.starts_with('[') && trimmed.ends_with(']') {
+                parse_vector_literal(trimmed)
+            } else {
+                Value::Text(s.sval.clone())
+            }
+        }
         Some(NodeEnum::AConst(ac)) => {
             if let Some(val) = &ac.val {
                 match val {
@@ -706,7 +731,14 @@ fn eval_const(node: Option<&NodeEnum>) -> Value {
                         .parse::<f64>()
                         .map(Value::Float)
                         .unwrap_or(Value::Null),
-                    pg_query::protobuf::a_const::Val::Sval(s) => Value::Text(s.sval.clone()),
+                    pg_query::protobuf::a_const::Val::Sval(s) => {
+                        let trimmed = s.sval.trim();
+                        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+                            parse_vector_literal(trimmed)
+                        } else {
+                            Value::Text(s.sval.clone())
+                        }
+                    }
                     pg_query::protobuf::a_const::Val::Bsval(s) => Value::Text(s.bsval.clone()),
                     pg_query::protobuf::a_const::Val::Boolval(b) => Value::Bool(b.boolval),
                 }
@@ -748,7 +780,14 @@ fn eval_expr(node: &NodeEnum, row: &[Value], ctx: &JoinContext) -> Result<Value,
                         .parse::<f64>()
                         .map(Value::Float)
                         .map_err(|e| e.to_string()),
-                    pg_query::protobuf::a_const::Val::Sval(s) => Ok(Value::Text(s.sval.clone())),
+                    pg_query::protobuf::a_const::Val::Sval(s) => {
+                        let trimmed = s.sval.trim();
+                        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+                            Ok(parse_vector_literal(trimmed))
+                        } else {
+                            Ok(Value::Text(s.sval.clone()))
+                        }
+                    }
                     pg_query::protobuf::a_const::Val::Bsval(s) => Ok(Value::Text(s.bsval.clone())),
                     pg_query::protobuf::a_const::Val::Boolval(b) => Ok(Value::Bool(b.boolval)),
                 }
@@ -762,14 +801,46 @@ fn eval_expr(node: &NodeEnum, row: &[Value], ctx: &JoinContext) -> Result<Value,
             .parse::<f64>()
             .map(Value::Float)
             .map_err(|e| e.to_string()),
-        NodeEnum::String(s) => Ok(Value::Text(s.sval.clone())),
+        NodeEnum::String(s) => {
+            let trimmed = s.sval.trim();
+            if trimmed.starts_with('[') && trimmed.ends_with(']') {
+                Ok(parse_vector_literal(trimmed))
+            } else {
+                Ok(Value::Text(s.sval.clone()))
+            }
+        }
         NodeEnum::TypeCast(tc) => {
             let inner = tc
                 .arg
                 .as_ref()
                 .and_then(|a| a.node.as_ref())
                 .ok_or("TypeCast missing arg")?;
-            eval_expr(inner, row, ctx)
+            let val = eval_expr(inner, row, ctx)?;
+            // Handle cast to vector type
+            if let Some(tn) = &tc.type_name {
+                let type_name: String = tn
+                    .names
+                    .iter()
+                    .filter_map(|n| n.node.as_ref())
+                    .filter_map(|node| {
+                        if let NodeEnum::String(s) = node {
+                            Some(s.sval.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .last()
+                    .unwrap_or_default();
+                if type_name == "vector" {
+                    if let Value::Text(s) = &val {
+                        let trimmed = s.trim();
+                        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+                            return Ok(parse_vector_literal(trimmed));
+                        }
+                    }
+                }
+            }
+            Ok(val)
         }
         NodeEnum::AExpr(expr) => eval_a_expr(expr, row, ctx),
         NodeEnum::BoolExpr(bexpr) => eval_bool_expr(bexpr, row, ctx),
@@ -1048,6 +1119,68 @@ fn eval_a_expr(
     // Arithmetic
     if matches!(op.as_str(), "+" | "-" | "*" | "/") {
         return eval_arithmetic(&op, &left, &right);
+    }
+
+    // Vector distance operators (return Float, not Bool — no NULL propagation needed here)
+    match op.as_str() {
+        "<->" => {
+            return match (&left, &right) {
+                (Value::Null, _) | (_, Value::Null) => Ok(Value::Null),
+                (Value::Vector(a), Value::Vector(b)) if a.len() == b.len() => {
+                    let dist: f32 = a
+                        .iter()
+                        .zip(b.iter())
+                        .map(|(x, y)| (x - y) * (x - y))
+                        .sum::<f32>()
+                        .sqrt();
+                    Ok(Value::Float(dist as f64))
+                }
+                (Value::Vector(a), Value::Vector(b)) => Err(format!(
+                    "different vector dimensions {} and {}",
+                    a.len(),
+                    b.len()
+                )),
+                _ => Err("operator <-> requires vector operands".into()),
+            };
+        }
+        "<=>" => {
+            return match (&left, &right) {
+                (Value::Null, _) | (_, Value::Null) => Ok(Value::Null),
+                (Value::Vector(a), Value::Vector(b)) if a.len() == b.len() => {
+                    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+                    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+                    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+                    let denom = norm_a * norm_b;
+                    if denom == 0.0 {
+                        Ok(Value::Float(1.0))
+                    } else {
+                        Ok(Value::Float((1.0 - dot / denom) as f64))
+                    }
+                }
+                (Value::Vector(a), Value::Vector(b)) => Err(format!(
+                    "different vector dimensions {} and {}",
+                    a.len(),
+                    b.len()
+                )),
+                _ => Err("operator <=> requires vector operands".into()),
+            };
+        }
+        "<#>" => {
+            return match (&left, &right) {
+                (Value::Null, _) | (_, Value::Null) => Ok(Value::Null),
+                (Value::Vector(a), Value::Vector(b)) if a.len() == b.len() => {
+                    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+                    Ok(Value::Float((-dot) as f64))
+                }
+                (Value::Vector(a), Value::Vector(b)) => Err(format!(
+                    "different vector dimensions {} and {}",
+                    a.len(),
+                    b.len()
+                )),
+                _ => Err("operator <#> requires vector operands".into()),
+            };
+        }
+        _ => {}
     }
 
     // NULL propagation for comparisons
@@ -1779,8 +1912,15 @@ fn exec_select_raw(
 
     // ORDER BY (on full rows before projection)
     if !select.sort_clause.is_empty() {
-        let sort_keys = resolve_sort_keys(&select.sort_clause, &merged_ctx, select)?;
+        let (sort_keys, expr_count) =
+            resolve_sort_keys_with_exprs(&select.sort_clause, &merged_ctx, select, &mut rows)?;
         rows.sort_by(|a, b| compare_rows(&sort_keys, a, b));
+        // Strip temporary expression columns appended for sorting
+        if expr_count > 0 {
+            for row in rows.iter_mut() {
+                row.truncate(row.len() - expr_count);
+            }
+        }
     }
 
     // OFFSET
@@ -1924,33 +2064,52 @@ struct SortKey {
     nulls_first: bool,
 }
 
-fn resolve_sort_keys(
+/// Extended ORDER BY resolver that supports arbitrary expressions (e.g. `embedding <-> '[1,0,0]'`).
+/// Expression results are appended as temporary columns to each row; the caller must strip them.
+/// Returns (sort_keys, number_of_expression_columns_appended).
+fn resolve_sort_keys_with_exprs(
     sort_clause: &[pg_query::protobuf::Node],
     ctx: &JoinContext,
     select: &pg_query::protobuf::SelectStmt,
-) -> Result<Vec<SortKey>, String> {
+    rows: &mut Vec<Vec<Value>>,
+) -> Result<(Vec<SortKey>, usize), String> {
     let mut keys = Vec::new();
+    let mut expr_nodes: Vec<(usize, &NodeEnum)> = Vec::new(); // (key_index, expr_node)
+    let base_width = if rows.is_empty() {
+        ctx.total_columns
+    } else {
+        rows[0].len()
+    };
+    let mut next_col = base_width;
+
     for snode in sort_clause {
         if let Some(NodeEnum::SortBy(sb)) = snode.node.as_ref() {
-            let col_idx = match sb.node.as_ref().and_then(|n| n.node.as_ref()) {
+            let inner = sb.node.as_ref().and_then(|n| n.node.as_ref());
+            let col_idx = match inner {
                 Some(NodeEnum::ColumnRef(cref)) => resolve_column(cref, ctx)?,
                 Some(NodeEnum::AConst(ac)) => {
-                    // Ordinal: ORDER BY 1 means first column in target list
                     let ordinal = match &ac.val {
                         Some(pg_query::protobuf::a_const::Val::Ival(i)) => i.ival as usize,
                         _ => return Err("invalid ORDER BY ordinal".into()),
                     };
                     resolve_ordinal_to_col_idx(ordinal, select, ctx)?
                 }
-                _ => return Err("unsupported ORDER BY expression".into()),
+                Some(expr_node) => {
+                    // Arbitrary expression — will be evaluated per-row
+                    let idx = next_col;
+                    next_col += 1;
+                    expr_nodes.push((keys.len(), expr_node));
+                    idx
+                }
+                None => return Err("ORDER BY missing expression".into()),
             };
 
-            let ascending = sb.sortby_dir
-                != pg_query::protobuf::SortByDir::SortbyDesc as i32;
+            let ascending =
+                sb.sortby_dir != pg_query::protobuf::SortByDir::SortbyDesc as i32;
             let nulls_first = match sb.sortby_nulls {
                 x if x == pg_query::protobuf::SortByNulls::SortbyNullsFirst as i32 => true,
                 x if x == pg_query::protobuf::SortByNulls::SortbyNullsLast as i32 => false,
-                _ => !ascending, // default: NULLS LAST for ASC, FIRST for DESC
+                _ => !ascending,
             };
 
             keys.push(SortKey {
@@ -1960,7 +2119,30 @@ fn resolve_sort_keys(
             });
         }
     }
-    Ok(keys)
+
+    let expr_count = next_col - base_width;
+
+    // Evaluate expression ORDER BY keys for every row
+    if expr_count > 0 {
+        for row in rows.iter_mut() {
+            // Pre-extend with Nulls
+            row.resize(next_col, Value::Null);
+        }
+        // Need to clone expr_nodes data to avoid borrow issues
+        let expr_data: Vec<(usize, NodeEnum)> = expr_nodes
+            .iter()
+            .map(|(ki, node)| (*ki, (*node).clone()))
+            .collect();
+        for row in rows.iter_mut() {
+            for (key_idx, expr_node) in &expr_data {
+                let col_idx = keys[*key_idx].col_idx;
+                let val = eval_expr(expr_node, row, ctx)?;
+                row[col_idx] = val;
+            }
+        }
+    }
+
+    Ok((keys, expr_count))
 }
 
 fn resolve_ordinal_to_col_idx(
@@ -3563,5 +3745,96 @@ mod tests {
         let err = execute("SELECT (SELECT id FROM t)");
         assert!(err.is_err());
         assert!(err.unwrap_err().contains("more than one row"));
+    }
+
+    // ── Vector type tests ────────────────────────────────────────────────
+
+    #[test]
+    #[serial_test::serial]
+    fn vector_create_insert_select() {
+        setup();
+        execute("CREATE TABLE items (id int, embedding vector)").unwrap();
+        execute("INSERT INTO items VALUES (1, '[1.0, 2.0, 3.0]')").unwrap();
+        execute("INSERT INTO items VALUES (2, '[4.0, 5.0, 6.0]')").unwrap();
+        let r = execute("SELECT * FROM items").unwrap();
+        assert_eq!(r.rows.len(), 2);
+        assert_eq!(r.rows[0][1], Some("[1,2,3]".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn vector_l2_distance() {
+        setup();
+        execute("CREATE TABLE items (id int, embedding vector)").unwrap();
+        execute("INSERT INTO items VALUES (1, '[1.0, 0.0, 0.0]')").unwrap();
+        execute("INSERT INTO items VALUES (2, '[0.0, 1.0, 0.0]')").unwrap();
+        execute("INSERT INTO items VALUES (3, '[1.0, 1.0, 0.0]')").unwrap();
+        // L2 distance from [1,0,0]: item 1=0, item 3=1, item 2=sqrt(2)
+        let r = execute("SELECT id FROM items ORDER BY embedding <-> '[1.0, 0.0, 0.0]' LIMIT 2")
+            .unwrap();
+        assert_eq!(r.rows.len(), 2);
+        assert_eq!(r.rows[0][0], Some("1".into())); // closest
+        assert_eq!(r.rows[1][0], Some("3".into())); // second closest
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn vector_cosine_distance() {
+        setup();
+        execute("CREATE TABLE items (id int, embedding vector)").unwrap();
+        execute("INSERT INTO items VALUES (1, '[1.0, 0.0]')").unwrap();
+        execute("INSERT INTO items VALUES (2, '[0.0, 1.0]')").unwrap();
+        execute("INSERT INTO items VALUES (3, '[0.707, 0.707]')").unwrap();
+        // Cosine distance from [1,0]: item 1=0, item 3~0.29, item 2=1
+        let r = execute("SELECT id FROM items ORDER BY embedding <=> '[1.0, 0.0]' LIMIT 2")
+            .unwrap();
+        assert_eq!(r.rows.len(), 2);
+        assert_eq!(r.rows[0][0], Some("1".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn vector_inner_product() {
+        setup();
+        execute("CREATE TABLE items (id int, embedding vector)").unwrap();
+        execute("INSERT INTO items VALUES (1, '[1.0, 2.0, 3.0]')").unwrap();
+        execute("INSERT INTO items VALUES (2, '[3.0, 2.0, 1.0]')").unwrap();
+        // Inner product with [1,0,0]: item 1=1, item 2=3
+        // Negative inner product: item 1=-1, item 2=-3
+        // ORDER BY <#> (ascending): item 2 first (most similar via inner product)
+        let r =
+            execute("SELECT id FROM items ORDER BY embedding <#> '[1.0, 0.0, 0.0]'").unwrap();
+        assert_eq!(r.rows[0][0], Some("2".into())); // highest inner product
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn vector_dimension_mismatch() {
+        setup();
+        execute("CREATE TABLE items (id int, embedding vector)").unwrap();
+        execute("INSERT INTO items VALUES (1, '[1.0, 2.0]')").unwrap();
+        execute("INSERT INTO items VALUES (2, '[1.0, 2.0, 3.0]')").unwrap();
+        // Different dimensions should error
+        let err = execute("SELECT id FROM items ORDER BY embedding <-> '[1.0, 2.0]'");
+        // This will error during the sort comparison
+        assert!(err.is_err());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn vector_knn_search() {
+        setup();
+        execute("CREATE TABLE points (id int, pos vector)").unwrap();
+        execute("INSERT INTO points VALUES (1, '[0.0, 0.0]')").unwrap();
+        execute("INSERT INTO points VALUES (2, '[1.0, 1.0]')").unwrap();
+        execute("INSERT INTO points VALUES (3, '[2.0, 2.0]')").unwrap();
+        execute("INSERT INTO points VALUES (4, '[10.0, 10.0]')").unwrap();
+        // KNN: 3 nearest to [1.5, 1.5]
+        let r = execute("SELECT id FROM points ORDER BY pos <-> '[1.5, 1.5]' LIMIT 3").unwrap();
+        assert_eq!(r.rows.len(), 3);
+        assert_eq!(r.rows[0][0], Some("2".into())); // [1,1] closest to [1.5,1.5]
+        assert_eq!(r.rows[1][0], Some("3".into())); // [2,2] next
+        // third is [0,0] which is closer than [10,10]
+        assert_eq!(r.rows[2][0], Some("1".into()));
     }
 }

--- a/native/engine/src/storage.rs
+++ b/native/engine/src/storage.rs
@@ -1,29 +1,23 @@
 use crate::types::Value;
 use parking_lot::RwLock;
 use std::collections::HashMap;
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 /// In-memory row storage. Each table maps to a Vec of rows.
 /// This is the Phase 1 storage — will be replaced with a persistent
 /// B-tree engine with undo-log MVCC and direct I/O in Phase 2.
-static STORE: LazyLock<RwLock<Storage>> = LazyLock::new(|| RwLock::new(Storage::new()));
+///
+/// Per-table RwLock: the outer HashMap RwLock is only held during
+/// table creation/deletion. Individual table locks allow concurrent
+/// reads on different tables and concurrent same-table reads via
+/// parking_lot's reader-writer fairness.
+static STORE: LazyLock<RwLock<HashMap<String, Arc<RwLock<TableStore>>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
 
 type Row = Vec<Value>;
 
 struct TableStore {
     rows: Vec<Row>,
-}
-
-struct Storage {
-    tables: HashMap<String, TableStore>,
-}
-
-impl Storage {
-    fn new() -> Self {
-        Self {
-            tables: HashMap::new(),
-        }
-    }
 }
 
 fn key(schema: &str, name: &str) -> String {
@@ -32,22 +26,23 @@ fn key(schema: &str, name: &str) -> String {
 
 pub fn create_table(schema: &str, name: &str) {
     let mut store = STORE.write();
-    store
-        .tables
-        .insert(key(schema, name), TableStore { rows: Vec::new() });
+    store.insert(
+        key(schema, name),
+        Arc::new(RwLock::new(TableStore { rows: Vec::new() })),
+    );
 }
 
 pub fn drop_table(schema: &str, name: &str) {
     let mut store = STORE.write();
-    store.tables.remove(&key(schema, name));
+    store.remove(&key(schema, name));
 }
 
 pub fn insert(schema: &str, name: &str, row: Row) -> Result<(), String> {
-    let mut store = STORE.write();
+    let store = STORE.read();
     let table = store
-        .tables
-        .get_mut(&key(schema, name))
+        .get(&key(schema, name))
         .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+    let mut table = table.write();
     table.rows.push(row);
     Ok(())
 }
@@ -55,18 +50,18 @@ pub fn insert(schema: &str, name: &str, row: Row) -> Result<(), String> {
 pub fn scan(schema: &str, name: &str) -> Result<Vec<Row>, String> {
     let store = STORE.read();
     let table = store
-        .tables
         .get(&key(schema, name))
         .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+    let table = table.read();
     Ok(table.rows.clone())
 }
 
 pub fn delete_all(schema: &str, name: &str) -> Result<u64, String> {
-    let mut store = STORE.write();
+    let store = STORE.read();
     let table = store
-        .tables
-        .get_mut(&key(schema, name))
+        .get(&key(schema, name))
         .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+    let mut table = table.write();
     let count = table.rows.len() as u64;
     table.rows.clear();
     Ok(count)
@@ -77,11 +72,11 @@ pub fn delete_where(
     name: &str,
     predicate: impl Fn(&Row) -> bool,
 ) -> Result<u64, String> {
-    let mut store = STORE.write();
+    let store = STORE.read();
     let table = store
-        .tables
-        .get_mut(&key(schema, name))
+        .get(&key(schema, name))
         .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+    let mut table = table.write();
     let before = table.rows.len();
     table.rows.retain(|row| !predicate(row));
     Ok((before - table.rows.len()) as u64)
@@ -93,11 +88,11 @@ pub fn delete_where_returning(
     name: &str,
     predicate: impl Fn(&Row) -> bool,
 ) -> Result<Vec<Row>, String> {
-    let mut store = STORE.write();
+    let store = STORE.read();
     let table = store
-        .tables
-        .get_mut(&key(schema, name))
+        .get(&key(schema, name))
         .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+    let mut table = table.write();
     let mut deleted = Vec::new();
     let mut kept = Vec::new();
     for row in table.rows.drain(..) {
@@ -117,11 +112,11 @@ pub fn update_rows(
     predicate: impl Fn(&Row) -> bool,
     updater: impl Fn(&mut Row),
 ) -> Result<u64, String> {
-    let mut store = STORE.write();
+    let store = STORE.read();
     let table = store
-        .tables
-        .get_mut(&key(schema, name))
+        .get(&key(schema, name))
         .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+    let mut table = table.write();
     let mut count = 0u64;
     for row in table.rows.iter_mut() {
         if predicate(row) {
@@ -142,11 +137,11 @@ pub fn insert_checked(
     unique_checks: &[(usize, String)],
     pk_cols: &[usize],
 ) -> Result<(), String> {
-    let mut store = STORE.write();
+    let store = STORE.read();
     let table = store
-        .tables
-        .get_mut(&key(schema, name))
+        .get(&key(schema, name))
         .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+    let mut table = table.write();
 
     // Composite PK check
     if pk_cols.len() > 1 {
@@ -189,11 +184,11 @@ pub fn update_rows_checked(
     updater: impl FnMut(&Row) -> Result<Row, String>,
     validator: impl Fn(&Row, &[Row], usize) -> Result<(), String>,
 ) -> Result<u64, String> {
-    let mut store = STORE.write();
+    let store = STORE.read();
     let table = store
-        .tables
-        .get_mut(&key(schema, name))
+        .get(&key(schema, name))
         .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+    let mut table = table.write();
 
     // First pass: compute new rows and validate
     let mut updates: Vec<(usize, Row)> = Vec::new();
@@ -218,26 +213,26 @@ pub fn update_rows_checked(
 /// Delete all rows and return them (for DELETE ... RETURNING without WHERE).
 /// Single write lock — no TOCTOU race.
 pub fn delete_all_returning(schema: &str, name: &str) -> Result<Vec<Row>, String> {
-    let mut store = STORE.write();
+    let store = STORE.read();
     let table = store
-        .tables
-        .get_mut(&key(schema, name))
+        .get(&key(schema, name))
         .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+    let mut table = table.write();
     Ok(std::mem::take(&mut table.rows))
 }
 
 pub fn row_count(schema: &str, name: &str) -> Result<u64, String> {
     let store = STORE.read();
     let table = store
-        .tables
         .get(&key(schema, name))
         .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
+    let table = table.read();
     Ok(table.rows.len() as u64)
 }
 
 pub fn reset() {
     let mut store = STORE.write();
-    store.tables.clear();
+    store.clear();
 }
 
 #[cfg(test)]

--- a/native/engine/src/storage.rs
+++ b/native/engine/src/storage.rs
@@ -24,6 +24,16 @@ fn key(schema: &str, name: &str) -> String {
     format!("{}.{}", schema, name)
 }
 
+/// Fast table lookup: acquires outer read lock briefly, clones the Arc, releases.
+/// The caller then works with the per-table lock independently.
+fn get_table(schema: &str, name: &str) -> Result<Arc<RwLock<TableStore>>, String> {
+    let store = STORE.read();
+    store
+        .get(&key(schema, name))
+        .cloned()
+        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))
+}
+
 pub fn create_table(schema: &str, name: &str) {
     let mut store = STORE.write();
     store.insert(
@@ -38,30 +48,31 @@ pub fn drop_table(schema: &str, name: &str) {
 }
 
 pub fn insert(schema: &str, name: &str, row: Row) -> Result<(), String> {
-    let store = STORE.read();
-    let table = store
-        .get(&key(schema, name))
-        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
-    let mut table = table.write();
+    let tbl = get_table(schema, name)?;
+    let mut table = tbl.write();
     table.rows.push(row);
     Ok(())
 }
 
 pub fn scan(schema: &str, name: &str) -> Result<Vec<Row>, String> {
-    let store = STORE.read();
-    let table = store
-        .get(&key(schema, name))
-        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
-    let table = table.read();
+    let tbl = get_table(schema, name)?;
+    let table = tbl.read();
     Ok(table.rows.clone())
 }
 
+/// Zero-copy scan: runs callback with borrowed rows, avoids cloning.
+pub fn scan_with<F, R>(schema: &str, name: &str, f: F) -> Result<R, String>
+where
+    F: FnOnce(&[Row]) -> Result<R, String>,
+{
+    let tbl = get_table(schema, name)?;
+    let table = tbl.read();
+    f(&table.rows)
+}
+
 pub fn delete_all(schema: &str, name: &str) -> Result<u64, String> {
-    let store = STORE.read();
-    let table = store
-        .get(&key(schema, name))
-        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
-    let mut table = table.write();
+    let tbl = get_table(schema, name)?;
+    let mut table = tbl.write();
     let count = table.rows.len() as u64;
     table.rows.clear();
     Ok(count)
@@ -72,11 +83,8 @@ pub fn delete_where(
     name: &str,
     predicate: impl Fn(&Row) -> bool,
 ) -> Result<u64, String> {
-    let store = STORE.read();
-    let table = store
-        .get(&key(schema, name))
-        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
-    let mut table = table.write();
+    let tbl = get_table(schema, name)?;
+    let mut table = tbl.write();
     let before = table.rows.len();
     table.rows.retain(|row| !predicate(row));
     Ok((before - table.rows.len()) as u64)
@@ -88,11 +96,8 @@ pub fn delete_where_returning(
     name: &str,
     predicate: impl Fn(&Row) -> bool,
 ) -> Result<Vec<Row>, String> {
-    let store = STORE.read();
-    let table = store
-        .get(&key(schema, name))
-        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
-    let mut table = table.write();
+    let tbl = get_table(schema, name)?;
+    let mut table = tbl.write();
     let mut deleted = Vec::new();
     let mut kept = Vec::new();
     for row in table.rows.drain(..) {
@@ -112,11 +117,8 @@ pub fn update_rows(
     predicate: impl Fn(&Row) -> bool,
     updater: impl Fn(&mut Row),
 ) -> Result<u64, String> {
-    let store = STORE.read();
-    let table = store
-        .get(&key(schema, name))
-        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
-    let mut table = table.write();
+    let tbl = get_table(schema, name)?;
+    let mut table = tbl.write();
     let mut count = 0u64;
     for row in table.rows.iter_mut() {
         if predicate(row) {
@@ -137,11 +139,8 @@ pub fn insert_checked(
     unique_checks: &[(usize, String)],
     pk_cols: &[usize],
 ) -> Result<(), String> {
-    let store = STORE.read();
-    let table = store
-        .get(&key(schema, name))
-        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
-    let mut table = table.write();
+    let tbl = get_table(schema, name)?;
+    let mut table = tbl.write();
 
     // Composite PK check
     if pk_cols.len() > 1 {
@@ -184,11 +183,8 @@ pub fn update_rows_checked(
     updater: impl FnMut(&Row) -> Result<Row, String>,
     validator: impl Fn(&Row, &[Row], usize) -> Result<(), String>,
 ) -> Result<u64, String> {
-    let store = STORE.read();
-    let table = store
-        .get(&key(schema, name))
-        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
-    let mut table = table.write();
+    let tbl = get_table(schema, name)?;
+    let mut table = tbl.write();
 
     // First pass: compute new rows and validate
     let mut updates: Vec<(usize, Row)> = Vec::new();
@@ -213,20 +209,14 @@ pub fn update_rows_checked(
 /// Delete all rows and return them (for DELETE ... RETURNING without WHERE).
 /// Single write lock — no TOCTOU race.
 pub fn delete_all_returning(schema: &str, name: &str) -> Result<Vec<Row>, String> {
-    let store = STORE.read();
-    let table = store
-        .get(&key(schema, name))
-        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
-    let mut table = table.write();
+    let tbl = get_table(schema, name)?;
+    let mut table = tbl.write();
     Ok(std::mem::take(&mut table.rows))
 }
 
 pub fn row_count(schema: &str, name: &str) -> Result<u64, String> {
-    let store = STORE.read();
-    let table = store
-        .get(&key(schema, name))
-        .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))?;
-    let table = table.read();
+    let tbl = get_table(schema, name)?;
+    let table = tbl.read();
     Ok(table.rows.len() as u64)
 }
 

--- a/native/engine/src/types.rs
+++ b/native/engine/src/types.rs
@@ -94,8 +94,8 @@ impl Value {
             Value::Bytea(b) => Some(format!("\\x{}", hex_encode(b))),
             Value::Vector(v) => {
                 let inner: Vec<String> = v.iter().map(|f| {
-                    if *f == f.trunc() && f.is_finite() {
-                        format!("{}", *f as i64)
+                    if *f == f.trunc() && f.is_finite() && f.abs() < (i32::MAX as f32) {
+                        format!("{}", *f as i32)
                     } else {
                         format!("{}", f)
                     }

--- a/native/engine/src/types.rs
+++ b/native/engine/src/types.rs
@@ -13,6 +13,7 @@ pub enum Value {
     Float(f64),
     Text(String),
     Bytea(Vec<u8>),
+    Vector(Vec<f32>),
 }
 
 impl PartialEq for Value {
@@ -30,6 +31,7 @@ impl PartialEq for Value {
             }
             (Value::Text(a), Value::Text(b)) => a == b,
             (Value::Bytea(a), Value::Bytea(b)) => a == b,
+            (Value::Vector(a), Value::Vector(b)) => a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| x.to_bits() == y.to_bits()),
             _ => false,
         }
     }
@@ -57,6 +59,12 @@ impl std::hash::Hash for Value {
             }
             Value::Text(s) => s.hash(state),
             Value::Bytea(b) => b.hash(state),
+            Value::Vector(v) => {
+                v.len().hash(state);
+                for f in v {
+                    f.to_bits().hash(state);
+                }
+            }
         }
     }
 }
@@ -71,6 +79,7 @@ impl Value {
             (Value::Float(a), Value::Int(b)) => a.partial_cmp(&(*b as f64)),
             (Value::Text(a), Value::Text(b)) => a.partial_cmp(b),
             (Value::Bool(a), Value::Bool(b)) => a.partial_cmp(b),
+            (Value::Vector(_), Value::Vector(_)) => None, // vectors are not orderable
             _ => None,
         }
     }
@@ -83,6 +92,16 @@ impl Value {
             Value::Float(f) => Some(f.to_string()),
             Value::Text(s) => Some(s.clone()),
             Value::Bytea(b) => Some(format!("\\x{}", hex_encode(b))),
+            Value::Vector(v) => {
+                let inner: Vec<String> = v.iter().map(|f| {
+                    if *f == f.trunc() && f.is_finite() {
+                        format!("{}", *f as i64)
+                    } else {
+                        format!("{}", f)
+                    }
+                }).collect();
+                Some(format!("[{}]", inner.join(",")))
+            }
         }
     }
 }
@@ -104,6 +123,7 @@ pub enum TypeOid {
     Float8 = 701,
     Varchar = 1043,
     Numeric = 1700,
+    Vector = 16385,
 }
 
 impl TypeOid {
@@ -119,6 +139,7 @@ impl TypeOid {
             "text" => TypeOid::Text,
             "varchar" | "character varying" => TypeOid::Varchar,
             "bytea" => TypeOid::Bytea,
+            "vector" => TypeOid::Vector,
             _ => TypeOid::Text,
         }
     }
@@ -139,6 +160,7 @@ impl TypeOid {
             701 => TypeOid::Float8,
             1043 => TypeOid::Varchar,
             1700 => TypeOid::Numeric,
+            16385 => TypeOid::Vector,
             _ => TypeOid::Text,
         }
     }

--- a/rel/vm.args
+++ b/rel/vm.args
@@ -1,8 +1,8 @@
 ## Minimal memory footprint for pgrx
 
-## 2 normal schedulers, 2 dirty CPU, 1 dirty IO
+## 2 normal schedulers, 8 dirty CPU, 1 dirty IO
 +S 2:2
-+SDcpu 2:2
++SDcpu 8:8
 +SDio 1
 
 ## Disable busy-wait (saves CPU + reduces allocator pressure)

--- a/run_bottleneck.sh
+++ b/run_bottleneck.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
+export PGPASSWORD=postgres
+CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
+cd /home/jagrit/pgrx
+
+pkill -9 -f beam.smp 2>/dev/null; sleep 1
+mix run --no-halt &
+sleep 6
+
+echo "============================================"
+echo "  Bottleneck Analysis: Where Time Goes"
+echo "============================================"
+echo ""
+
+# Test 1: Pure overhead (no table access)
+echo "=== SELECT 1 (pure protocol + parse overhead) ==="
+$CLI --bench 10000 --clients 1 -c "SELECT 1;" 2>&1 | grep -E "Throughput|Avg"
+
+echo ""
+# Test 2: Empty table scan (scan overhead, no rows)
+$CLI -c "CREATE TABLE empty_t (id int, name text);" 2>/dev/null
+echo "=== SELECT * FROM empty_t (scan overhead, 0 rows) ==="
+$CLI --bench 10000 --clients 1 -c "SELECT * FROM empty_t;" 2>&1 | grep -E "Throughput|Avg"
+
+echo ""
+# Test 3: 10-row table (minimal scan)
+$CLI -c "CREATE TABLE t10 (id int, name text);" 2>/dev/null
+for i in $(seq 1 10); do $CLI -c "INSERT INTO t10 VALUES ($i, 'n$i');" 2>/dev/null; done
+echo "=== WHERE id=5 on 10 rows (scan cost @ 10 rows) ==="
+$CLI --bench 10000 --clients 1 -c "SELECT * FROM t10 WHERE id = 5;" 2>&1 | grep -E "Throughput|Avg"
+
+echo ""
+# Test 4: 100-row table
+$CLI -c "CREATE TABLE t100 (id int, name text);" 2>/dev/null
+VALS=""; for i in $(seq 1 100); do VALS="${VALS}($i, 'name_$i')"; [ $i -lt 100 ] && VALS="${VALS},"; done
+$CLI -c "INSERT INTO t100 VALUES ${VALS};" 2>/dev/null
+echo "=== WHERE id=50 on 100 rows (scan cost @ 100 rows) ==="
+$CLI --bench 10000 --clients 1 -c "SELECT * FROM t100 WHERE id = 50;" 2>&1 | grep -E "Throughput|Avg"
+
+echo ""
+# Test 5: 1000-row table (our benchmark table)
+echo "=== WHERE id=42 on 1000 rows (scan cost @ 1000 rows) ==="
+$CLI --bench 10000 --clients 1 -c "SELECT * FROM bench WHERE id = 42;" 2>&1 | grep -E "Throughput|Avg"
+
+echo ""
+# Test 6: Same query, PostgreSQL (has B-tree index on PK)
+echo "=== PostgreSQL: WHERE id=42 on 1000 rows (B-tree indexed) ==="
+$CLI -h 127.0.0.1 -p 5432 -U postgres -d postgres -W postgres --bench 10000 --clients 1 -c "SELECT * FROM bench WHERE id = 42;" 2>&1 | grep -E "Throughput|Avg"
+
+echo ""
+echo "=== Scaling: QPS vs Table Size ==="
+echo "  0 rows:    $(echo 'see above')"
+echo "  10 rows:   $(echo 'see above')"
+echo "  100 rows:  $(echo 'see above')"
+echo "  1000 rows: $(echo 'see above')"
+
+echo ""
+# Test 7: 50 clients on different query types
+echo "=== 50 clients: SELECT 1 (max protocol throughput) ==="
+$CLI --bench 5000 --clients 50 -c "SELECT 1;" 2>&1 | grep -E "Throughput|Avg"
+
+echo ""
+echo "=== 50 clients: WHERE id=5 on 10-row table ==="
+$CLI --bench 5000 --clients 50 -c "SELECT * FROM t10 WHERE id = 5;" 2>&1 | grep -E "Throughput|Avg"
+
+echo ""
+echo "=== 50 clients: WHERE id=42 on 1000-row table ==="
+$CLI --bench 5000 --clients 50 -c "SELECT * FROM bench WHERE id = 42;" 2>&1 | grep -E "Throughput|Avg"
+
+kill %1 2>/dev/null; wait 2>/dev/null

--- a/run_concurrency_bench.sh
+++ b/run_concurrency_bench.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
+export PGPASSWORD=postgres
+CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
+cd /home/jagrit/pgrx
+
+# Force NIF recompile
+mix compile --force 2>&1 | tail -3
+
+pkill -9 -f beam.smp 2>/dev/null; sleep 1
+
+# Use +SDcpu 8 from vm.args via elixir flags
+elixir --erl "+SDcpu 8:8 +sbwt none +sbwtdcpu none +sbwtdio none" -S mix run --no-halt &
+SERVER_PID=$!
+sleep 6
+
+# Setup 1000-row table
+$CLI -c "CREATE TABLE bench (id int PRIMARY KEY, name text, val int);" 2>/dev/null
+for i in $(seq 1 10); do
+  VALS=""; for j in $(seq 1 100); do N=$(((i-1)*100+j)); VALS="${VALS}($N,'n$N',$((N*10)))"; [ $j -lt 100 ] && VALS="${VALS},"; done
+  $CLI -c "INSERT INTO bench VALUES ${VALS};" 2>/dev/null
+done
+
+# Setup 100-vector table
+$CLI -c "CREATE TABLE vecs (id int, embedding vector);" 2>/dev/null
+SQL=$(python3 -c "
+import random; random.seed(42)
+vals = []
+for i in range(100):
+    vec = ','.join([f'{random.random():.4f}' for _ in range(32)])
+    vals.append(f\"({i+1}, '[{vec}]')\")
+print('INSERT INTO vecs VALUES ' + ','.join(vals) + ';')
+")
+$CLI -c "$SQL" 2>/dev/null
+
+QVEC=$(python3 -c "import random; random.seed(99); print('[' + ','.join([f'{random.random():.4f}' for _ in range(32)]) + ']')")
+
+BEAM_PID=$(pgrep -f beam.smp | head -1)
+
+echo "============================================"
+echo "  Concurrency Benchmark: After 3 Fixes"
+echo "  Per-table RwLock + RwLock parse cache + SDcpu 8"
+echo "============================================"
+echo ""
+
+echo "=== Point query: 1 client ==="
+$CLI --bench 10000 --clients 1 -c "SELECT * FROM bench WHERE id = 42;" 2>&1 | grep -E "Throughput|Avg"
+
+echo ""
+echo "=== Point query: 10 clients ==="
+$CLI --bench 5000 --clients 10 -c "SELECT * FROM bench WHERE id = 42;" 2>&1 | grep -E "Throughput|Avg"
+
+echo ""
+echo "=== Point query: 50 clients ==="
+$CLI --bench 5000 --clients 50 -c "SELECT * FROM bench WHERE id = 42;" &
+B=$!; sleep 3
+CPU=$(ps -p $BEAM_PID -o %cpu= 2>/dev/null | tr -d ' ')
+wait $B 2>/dev/null
+echo "  BEAM CPU: ${CPU}%"
+
+echo ""
+echo "=== Point query: 100 clients ==="
+$CLI --bench 2000 --clients 100 -c "SELECT * FROM bench WHERE id = 42;" &
+B=$!; sleep 3
+CPU=$(ps -p $BEAM_PID -o %cpu= 2>/dev/null | tr -d ' ')
+wait $B 2>/dev/null
+echo "  BEAM CPU: ${CPU}%"
+
+echo ""
+echo "=== Vector KNN: 1 client (32-dim, 100 vecs) ==="
+$CLI --bench 500 --clients 1 -c "SELECT id FROM vecs ORDER BY embedding <-> '${QVEC}' LIMIT 5;" 2>&1 | grep -E "Throughput|Avg"
+
+echo ""
+echo "=== Vector KNN: 10 clients ==="
+$CLI --bench 200 --clients 10 -c "SELECT id FROM vecs ORDER BY embedding <-> '${QVEC}' LIMIT 5;" 2>&1 | grep -E "Throughput|Avg"
+
+echo ""
+echo "=== Vector KNN: 50 clients ==="
+$CLI --bench 100 --clients 50 -c "SELECT id FROM vecs ORDER BY embedding <-> '${QVEC}' LIMIT 5;" 2>&1 | grep -E "Throughput|Avg"
+
+echo ""
+echo "--- PostgreSQL 17 comparison ---"
+echo ""
+echo "=== PG: Point query 50 clients ==="
+$CLI -h 127.0.0.1 -p 5432 -U postgres -d postgres -W postgres --bench 5000 --clients 50 -c "SELECT * FROM bench WHERE id = 42;" 2>&1 | grep -E "Throughput|Avg"
+
+echo ""
+echo "=== PG: pgvector KNN 10 clients (128-dim, 1000 vecs) ==="
+$CLI -h 127.0.0.1 -p 5432 -U postgres -d postgres -W postgres --bench 100 --clients 10 -c "SELECT id FROM vec_bench ORDER BY embedding <-> '$(python3 -c "import random; random.seed(99); print('[' + ','.join([f'{random.random():.4f}' for _ in range(128)]) + ']')")' LIMIT 10;" 2>&1 | grep -E "Throughput|Avg"
+
+kill $SERVER_PID 2>/dev/null; wait 2>/dev/null

--- a/run_cpu_analysis.sh
+++ b/run_cpu_analysis.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
+CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
+cd /home/jagrit/pgrx
+
+measure_idle() {
+  sleep 3
+  PID=$(pgrep -f beam.smp | head -1)
+  echo "  Threads: $(ls /proc/$PID/task/ 2>/dev/null | wc -l)"
+  C1=$(ps -p $PID -o %cpu= 2>/dev/null | tr -d ' ')
+  sleep 2
+  C2=$(ps -p $PID -o %cpu= 2>/dev/null | tr -d ' ')
+  sleep 2
+  C3=$(ps -p $PID -o %cpu= 2>/dev/null | tr -d ' ')
+  echo "  Idle CPU: ${C1}%, ${C2}%, ${C3}%"
+}
+
+echo "=== CONFIG 1: Default dev (12 schedulers, busy-wait ON) ==="
+pkill -9 -f beam.smp 2>/dev/null; sleep 1
+mix run --no-halt &
+measure_idle
+kill %1 2>/dev/null; wait 2>/dev/null; sleep 1
+
+echo ""
+echo "=== CONFIG 2: +sbwt none (busy-wait OFF, still 12 schedulers) ==="
+pkill -9 -f beam.smp 2>/dev/null; sleep 1
+elixir --erl "+sbwt none +sbwtdcpu none +sbwtdio none" -S mix run --no-halt &
+measure_idle
+# Quick speed test
+$CLI -c "CREATE TABLE t(id int PRIMARY KEY, name text);" 2>/dev/null
+VALS=""; for i in $(seq 1 1000); do VALS="${VALS}($i,'n$i')"; [ $i -lt 1000 ] && VALS="${VALS},"; done
+$CLI -c "INSERT INTO t VALUES ${VALS};" 2>/dev/null
+echo "  50-client QPS:"
+$CLI --bench 5000 --clients 50 -c "SELECT * FROM t WHERE id = 42;" 2>&1 | grep Throughput
+PID=$(pgrep -f beam.smp | head -1)
+$CLI --bench 5000 --clients 50 -c "SELECT * FROM t WHERE id = 42;" &
+B=$!; sleep 2
+echo "  Load CPU: $(ps -p $PID -o %cpu= | tr -d ' ')%"
+wait $B 2>/dev/null
+kill %1 2>/dev/null; wait 2>/dev/null; sleep 1
+
+echo ""
+echo "=== CONFIG 3: 2 schedulers + no busy-wait ==="
+pkill -9 -f beam.smp 2>/dev/null; sleep 1
+elixir --erl "+S 2:2 +SDcpu 2:2 +SDio 1 +sbwt none +sbwtdcpu none +sbwtdio none" -S mix run --no-halt &
+measure_idle
+$CLI -c "CREATE TABLE t(id int PRIMARY KEY, name text);" 2>/dev/null
+$CLI -c "INSERT INTO t VALUES ${VALS};" 2>/dev/null
+echo "  50-client QPS:"
+$CLI --bench 5000 --clients 50 -c "SELECT * FROM t WHERE id = 42;" 2>&1 | grep Throughput
+PID=$(pgrep -f beam.smp | head -1)
+$CLI --bench 5000 --clients 50 -c "SELECT * FROM t WHERE id = 42;" &
+B=$!; sleep 2
+echo "  Load CPU: $(ps -p $PID -o %cpu= | tr -d ' ')%"
+wait $B 2>/dev/null
+kill %1 2>/dev/null; wait 2>/dev/null; sleep 1
+
+echo ""
+echo "=== CONFIG 4: 4 schedulers + no busy-wait (sweet spot?) ==="
+pkill -9 -f beam.smp 2>/dev/null; sleep 1
+elixir --erl "+S 4:4 +SDcpu 2:2 +SDio 1 +sbwt none +sbwtdcpu none +sbwtdio none" -S mix run --no-halt &
+measure_idle
+$CLI -c "CREATE TABLE t(id int PRIMARY KEY, name text);" 2>/dev/null
+$CLI -c "INSERT INTO t VALUES ${VALS};" 2>/dev/null
+echo "  50-client QPS:"
+$CLI --bench 5000 --clients 50 -c "SELECT * FROM t WHERE id = 42;" 2>&1 | grep Throughput
+PID=$(pgrep -f beam.smp | head -1)
+$CLI --bench 5000 --clients 50 -c "SELECT * FROM t WHERE id = 42;" &
+B=$!; sleep 2
+echo "  Load CPU: $(ps -p $PID -o %cpu= | tr -d ' ')%"
+wait $B 2>/dev/null
+kill %1 2>/dev/null; wait 2>/dev/null

--- a/run_cpu_measure.sh
+++ b/run_cpu_measure.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
+CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
+cd /home/jagrit/pgrx
+
+pkill -9 -f beam.smp 2>/dev/null; sleep 1
+mix run --no-halt &
+sleep 6
+
+# Setup
+$CLI -c "CREATE TABLE cpu_bench (id int PRIMARY KEY, name text, val int);" 2>/dev/null
+for i in $(seq 1 10); do
+  VALS=""; for j in $(seq 1 100); do N=$(((i-1)*100+j)); VALS="${VALS}($N,'n$N',$((N*10)))"; [ $j -lt 100 ] && VALS="${VALS},"; done
+  $CLI -c "INSERT INTO cpu_bench VALUES ${VALS};" 2>/dev/null
+done
+
+BEAM_PID=$(pgrep -f beam.smp | head -1)
+
+echo "============================================"
+echo "  CPU Usage: pgrx under various loads"
+echo "  Machine: $(nproc) cores available"
+echo "============================================"
+echo ""
+
+# Idle
+sleep 2
+echo "=== IDLE (0 queries) ==="
+for i in 1 2 3; do
+  CPU=$(ps -p $BEAM_PID -o %cpu= 2>/dev/null | tr -d ' ')
+  echo "  CPU: ${CPU}%"
+  sleep 1
+done
+
+echo ""
+echo "=== 1 CLIENT sustained ==="
+$CLI --bench 20000 --clients 1 -c "SELECT * FROM cpu_bench WHERE id = 42;" &
+B=$!; sleep 2
+for i in 1 2 3; do
+  CPU=$(ps -p $BEAM_PID -o %cpu= 2>/dev/null | tr -d ' ')
+  echo "  CPU: ${CPU}%"
+  sleep 1
+done
+wait $B 2>/dev/null
+
+echo ""
+echo "=== 10 CLIENTS sustained ==="
+$CLI --bench 5000 --clients 10 -c "SELECT * FROM cpu_bench WHERE id = 42;" &
+B=$!; sleep 2
+for i in 1 2 3; do
+  CPU=$(ps -p $BEAM_PID -o %cpu= 2>/dev/null | tr -d ' ')
+  echo "  CPU: ${CPU}%"
+  sleep 1
+done
+wait $B 2>/dev/null
+
+echo ""
+echo "=== 50 CLIENTS sustained ==="
+$CLI --bench 5000 --clients 50 -c "SELECT * FROM cpu_bench WHERE id = 42;" &
+B=$!; sleep 2
+for i in 1 2 3; do
+  CPU=$(ps -p $BEAM_PID -o %cpu= 2>/dev/null | tr -d ' ')
+  echo "  CPU: ${CPU}%"
+  sleep 1
+done
+wait $B 2>/dev/null
+
+echo ""
+echo "=== 100 CLIENTS sustained ==="
+$CLI --bench 2000 --clients 100 -c "SELECT * FROM cpu_bench WHERE id = 42;" &
+B=$!; sleep 2
+for i in 1 2 3; do
+  CPU=$(ps -p $BEAM_PID -o %cpu= 2>/dev/null | tr -d ' ')
+  echo "  CPU: ${CPU}%"
+  sleep 1
+done
+wait $B 2>/dev/null
+
+echo ""
+echo "=== PostgreSQL CPU comparison: 50 clients ==="
+export PGPASSWORD=postgres
+PG_PIDS_BEFORE=$(pgrep -f "postgres:" | wc -l)
+$CLI -h 127.0.0.1 -p 5432 -U postgres -d postgres -W postgres --bench 5000 --clients 50 -c "SELECT * FROM bench WHERE id = 42;" &
+B=$!; sleep 2
+# Sum CPU of all postgres processes
+PG_CPU=0
+for pid in $(pgrep -f "postgres:"); do
+  C=$(ps -p $pid -o %cpu= 2>/dev/null | tr -d ' ')
+  PG_CPU=$(echo "$PG_CPU + ${C:-0}" | bc 2>/dev/null || echo "$PG_CPU")
+done
+echo "  Total PG CPU: ${PG_CPU}%"
+wait $B 2>/dev/null
+
+echo ""
+echo "============================================"
+echo "  Summary: CPU% = percentage of 1 core"
+echo "  100% = 1 full core, 200% = 2 cores"
+echo "  This machine has $(nproc) cores"
+echo "============================================"
+
+kill %1 2>/dev/null; wait 2>/dev/null

--- a/run_vec_mini.sh
+++ b/run_vec_mini.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
+CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
+cd /home/jagrit/pgrx
+
+pkill -9 -f beam.smp 2>/dev/null; sleep 1
+mix run --no-halt &
+sleep 6
+
+$CLI -c "CREATE TABLE vt (id int, embedding vector);" 2>/dev/null
+
+# Insert 100 vectors, 32-dim
+SQL=$(python3 -c "
+import random; random.seed(42)
+vals = []
+for i in range(100):
+    vec = ','.join([f'{random.random():.4f}' for _ in range(32)])
+    vals.append(f\"({i+1}, '[{vec}]')\")
+print('INSERT INTO vt VALUES ' + ','.join(vals) + ';')
+")
+$CLI -c "$SQL" 2>/dev/null
+
+QVEC=$(python3 -c "import random; random.seed(99); print('[' + ','.join([f'{random.random():.4f}' for _ in range(32)]) + ']')")
+
+echo "=== pgrx: KNN 32-dim, 100 vectors, 1 client ==="
+$CLI --bench 500 --clients 1 -c "SELECT id FROM vt ORDER BY embedding <-> '${QVEC}' LIMIT 5;" 2>&1
+
+echo ""
+echo "=== pgrx: KNN 32-dim, 100 vectors, 10 clients ==="
+$CLI --bench 200 --clients 10 -c "SELECT id FROM vt ORDER BY embedding <-> '${QVEC}' LIMIT 5;" 2>&1
+
+kill %1 2>/dev/null; wait 2>/dev/null

--- a/run_vec_quick.sh
+++ b/run_vec_quick.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
+export PGPASSWORD=postgres
+CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
+cd /home/jagrit/pgrx
+
+pkill -9 -f beam.smp 2>/dev/null; sleep 1
+mix run --no-halt &
+sleep 6
+
+# Setup: 1000 vectors, 128-dim (using simpler generation)
+$CLI -c "CREATE TABLE vb (id int PRIMARY KEY, embedding vector);" 2>/dev/null
+
+# Generate insert SQL with Python (much faster than bash)
+python3 -c "
+import random
+random.seed(42)
+for batch in range(10):
+    vals = []
+    for i in range(100):
+        n = batch*100 + i + 1
+        vec = ','.join([f'{random.random():.4f}' for _ in range(128)])
+        vals.append(f\"({n}, '[{vec}]')\")
+    print('INSERT INTO vb VALUES ' + ','.join(vals) + ';')
+" | while read sql; do
+    $CLI -c "$sql" 2>/dev/null
+done
+
+echo "=== pgrx: KNN 128-dim, 1000 vectors, 1 client ==="
+QVEC=$(python3 -c "import random; random.seed(99); print('[' + ','.join([f'{random.random():.4f}' for _ in range(128)]) + ']')")
+$CLI --bench 100 --clients 1 -c "SELECT id FROM vb ORDER BY embedding <-> '${QVEC}' LIMIT 10;" 2>&1 | grep -E "Throughput|Avg|P99"
+
+echo ""
+echo "=== pgrx: KNN 128-dim, 1000 vectors, 10 clients ==="
+$CLI --bench 100 --clients 10 -c "SELECT id FROM vb ORDER BY embedding <-> '${QVEC}' LIMIT 10;" 2>&1 | grep -E "Throughput|Avg|P99"
+
+echo ""
+echo "=== pgvector reference (same dataset, no index): 478 QPS (1 client), 3862 QPS (10 clients) ==="
+
+kill %1 2>/dev/null; wait 2>/dev/null

--- a/run_vector_bench.sh
+++ b/run_vector_bench.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
+export PGPASSWORD=postgres
+CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
+cd /home/jagrit/pgrx
+
+pkill -9 -f beam.smp 2>/dev/null; sleep 1
+mix run --no-halt &
+sleep 6
+
+echo "============================================"
+echo "  Vector Search Benchmark: pgrx vs pgvector"
+echo "============================================"
+echo ""
+
+# Setup pgrx
+$CLI -c "CREATE TABLE vec_bench (id int PRIMARY KEY, embedding vector);" 2>/dev/null
+
+# Insert 1000 vectors (128-dim, random-ish)
+echo "Inserting 1000 × 128-dim vectors into pgrx..."
+for i in $(seq 1 10); do
+  VALS=""
+  for j in $(seq 1 100); do
+    N=$(( (i-1)*100 + j ))
+    # Generate a simple 128-dim vector
+    VEC="["
+    for d in $(seq 1 128); do
+      V=$(echo "scale=4; ($N * $d * 0.001) % 1.0" | bc 2>/dev/null || echo "0.$((N*d % 1000))")
+      VEC="${VEC}${V}"
+      [ $d -lt 128 ] && VEC="${VEC},"
+    done
+    VEC="${VEC}]"
+    VALS="${VALS}(${N}, '${VEC}')"
+    [ $j -lt 100 ] && VALS="${VALS},"
+  done
+  $CLI -c "INSERT INTO vec_bench VALUES ${VALS};" 2>/dev/null
+done
+echo "Done."
+echo ""
+
+# Build query vector
+QVEC="["
+for d in $(seq 1 128); do
+  V="0.$((500*d % 1000))"
+  QVEC="${QVEC}${V}"
+  [ $d -lt 128 ] && QVEC="${QVEC},"
+done
+QVEC="${QVEC}]"
+
+echo "=== pgrx: KNN search (1 client, 128-dim, 1000 vectors) ==="
+$CLI --bench 100 --clients 1 -c "SELECT id FROM vec_bench ORDER BY embedding <-> '${QVEC}' LIMIT 10;" 2>&1 | grep -E "Throughput|Avg|P99"
+
+echo ""
+echo "=== pgrx: KNN search (10 clients) ==="
+$CLI --bench 100 --clients 10 -c "SELECT id FROM vec_bench ORDER BY embedding <-> '${QVEC}' LIMIT 10;" 2>&1 | grep -E "Throughput|Avg|P99"
+
+echo ""
+# Compare with pgvector on PostgreSQL
+echo "Setting up pgvector on PostgreSQL..."
+psql -h 127.0.0.1 -p 5432 -U postgres -c "CREATE EXTENSION IF NOT EXISTS vector;" 2>/dev/null
+psql -h 127.0.0.1 -p 5432 -U postgres -c "DROP TABLE IF EXISTS vec_bench; CREATE TABLE vec_bench (id int PRIMARY KEY, embedding vector(128));" 2>/dev/null
+
+echo "Inserting 1000 × 128-dim vectors into PostgreSQL..."
+for i in $(seq 1 1000); do
+  VEC="["
+  for d in $(seq 1 128); do
+    V=$(echo "scale=4; ($i * $d * 0.001) % 1.0" | bc 2>/dev/null || echo "0.$((i*d % 1000))")
+    VEC="${VEC}${V}"
+    [ $d -lt 128 ] && VEC="${VEC},"
+  done
+  VEC="${VEC}]"
+  psql -h 127.0.0.1 -p 5432 -U postgres -c "INSERT INTO vec_bench VALUES ($i, '${VEC}');" 2>/dev/null
+done
+echo "Done."
+
+echo ""
+echo "=== pgvector: KNN search (1 client, 128-dim, 1000 vectors, no index) ==="
+$CLI -h 127.0.0.1 -p 5432 -U postgres -d postgres -W postgres --bench 100 --clients 1 -c "SELECT id FROM vec_bench ORDER BY embedding <-> '${QVEC}' LIMIT 10;" 2>&1 | grep -E "Throughput|Avg|P99"
+
+echo ""
+echo "=== pgvector: KNN search (10 clients, no index) ==="
+$CLI -h 127.0.0.1 -p 5432 -U postgres -d postgres -W postgres --bench 100 --clients 10 -c "SELECT id FROM vec_bench ORDER BY embedding <-> '${QVEC}' LIMIT 10;" 2>&1 | grep -E "Throughput|Avg|P99"
+
+kill %1 2>/dev/null; wait 2>/dev/null


### PR DESCRIPTION
## Summary

Adds native vector type and distance operators, wire-compatible with pgvector clients (LangChain, LlamaIndex, pgvector-python/node).

### What's New
- `vector` type in CREATE TABLE (`CREATE TABLE items (id int, embedding vector)`)
- Vector literals: `'[1.0, 2.0, 3.0]'` parsed as native `Vec<f32>`
- Distance operators:
  - `<->` L2 (Euclidean) distance
  - `<=>` Cosine distance  
  - `<#>` Negative inner product
- KNN search: `ORDER BY embedding <-> '[1,2,3]' LIMIT 5`
- Auto-coercion: text → vector on INSERT into vector columns
- Dimension mismatch detection with clear error messages

### SQL Now Supported
```sql
CREATE TABLE items (id int, embedding vector);
INSERT INTO items VALUES (1, '[1.0, 2.0, 3.0]');
INSERT INTO items VALUES (2, '[4.0, 5.0, 6.0]');

-- KNN search (brute-force, no index yet)
SELECT id FROM items ORDER BY embedding <-> '[2.0, 3.0, 4.0]' LIMIT 5;

-- Cosine similarity
SELECT id, 1 - (embedding <=> '[1,0,0]') AS similarity FROM items ORDER BY embedding <=> '[1,0,0]';

-- Inner product
SELECT id FROM items ORDER BY embedding <#> '[1,0,0]' LIMIT 5;

-- Filter + vector search
SELECT id FROM items WHERE id > 0 ORDER BY embedding <-> '[1,2,3]' LIMIT 3;
```

### Architecture
- `Value::Vector(Vec<f32>)` — native in-memory vector storage
- `TypeOid::Vector = 16385` — custom OID (pgvector clients discover via pg_type query)
- Distance operators return `Float(f64)` — compatible with ORDER BY, WHERE comparisons
- Expression-based ORDER BY for `ORDER BY expr <-> query LIMIT K`

103 tests passing (97 existing + 6 new vector tests).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/pgrx/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
