### PR TITLE
Add stability warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pgRx
 
+> **This project is in early development and highly unstable.** APIs, storage format, and wire protocol behavior will change without notice. Do not use in production. Contributions and feedback welcome — just know that everything is actively being reworked.
+
 **PostgreSQL-compatible database built on BEAM + Rust.**
 
 Same SQL. Same drivers. 100x less memory per connection.


### PR DESCRIPTION
Adds a clear early-development warning at the top of the README so visitors know the project is actively being reworked and not production-ready.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/pgrx/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
