### PR TITLE
fix: float infinity wire format + vector to_text i32 overflow

### DIFF
--- a/native/engine/src/arena.rs
+++ b/native/engine/src/arena.rs
@@ -150,7 +150,7 @@ impl ArenaValue {
             ArenaValue::Null => None,
             ArenaValue::Bool(b) => Some(if *b { "t" } else { "f" }.into()),
             ArenaValue::Int(i) => Some(i.to_string()),
-            ArenaValue::Float(f) => Some(f.to_string()),
+            ArenaValue::Float(f) => Some(crate::types::format_float(*f)),
             ArenaValue::Text(s) => Some(arena.get_str(*s).to_string()),
             ArenaValue::Bytea(s) => {
                 let start = s.offset as usize;
@@ -166,8 +166,13 @@ impl ArenaValue {
             ArenaValue::Vector(v) => {
                 let data = arena.get_vec(*v);
                 let inner: Vec<String> = data.iter().map(|f| {
-                    if *f == f.trunc() && f.is_finite() && f.abs() < (i32::MAX as f32) {
-                        format!("{}", *f as i32)
+                    if *f == f.trunc() && f.is_finite() && *f > -2_147_483_649.0 && *f < 2_147_483_648.0 {
+                        let i = *f as i32;
+                        if i as f32 == *f {
+                            format!("{}", i)
+                        } else {
+                            format!("{}", f)
+                        }
                     } else {
                         format!("{}", f)
                     }
@@ -434,5 +439,16 @@ mod tests {
     #[test]
     fn arena_value_size() {
         assert_eq!(std::mem::size_of::<ArenaValue>(), 16);
+    }
+
+    #[test]
+    fn arena_float_infinity_wire_format() {
+        let arena = QueryArena::new();
+        let inf = ArenaValue::Float(f64::INFINITY);
+        assert_eq!(inf.to_text(&arena), Some("Infinity".to_string()));
+        let neg_inf = ArenaValue::Float(f64::NEG_INFINITY);
+        assert_eq!(neg_inf.to_text(&arena), Some("-Infinity".to_string()));
+        let nan = ArenaValue::Float(f64::NAN);
+        assert_eq!(nan.to_text(&arena), Some("NaN".to_string()));
     }
 }

--- a/native/engine/src/arena.rs
+++ b/native/engine/src/arena.rs
@@ -166,7 +166,7 @@ impl ArenaValue {
             ArenaValue::Vector(v) => {
                 let data = arena.get_vec(*v);
                 let inner: Vec<String> = data.iter().map(|f| {
-                    if *f == f.trunc() && f.is_finite() && *f > -2_147_483_649.0 && *f < 2_147_483_648.0 {
+                    if *f == f.trunc() && f.is_finite() && *f >= -2_147_483_648.0 && *f < 2_147_483_648.0 {
                         let i = *f as i32;
                         if i as f32 == *f {
                             format!("{}", i)

--- a/native/engine/src/types.rs
+++ b/native/engine/src/types.rs
@@ -133,13 +133,18 @@ impl Value {
             Value::Null => None,
             Value::Bool(b) => Some(if *b { "t" } else { "f" }.to_string()),
             Value::Int(i) => Some(i.to_string()),
-            Value::Float(f) => Some(f.to_string()),
+            Value::Float(f) => Some(format_float(*f)),
             Value::Text(s) => Some(s.to_string()),
             Value::Bytea(b) => Some(format!("\\x{}", hex_encode(b))),
             Value::Vector(v) => {
                 let inner: Vec<String> = v.iter().map(|f| {
-                    if *f == f.trunc() && f.is_finite() && f.abs() < (i32::MAX as f32) {
-                        format!("{}", *f as i32)
+                    if *f == f.trunc() && f.is_finite() && *f > -2_147_483_649.0 && *f < 2_147_483_648.0 {
+                        let i = *f as i32;
+                        if i as f32 == *f {
+                            format!("{}", i)
+                        } else {
+                            format!("{}", f)
+                        }
                     } else {
                         format!("{}", f)
                     }
@@ -147,6 +152,18 @@ impl Value {
                 Some(format!("[{}]", inner.join(",")))
             }
         }
+    }
+}
+
+pub fn format_float(f: f64) -> String {
+    if f.is_nan() {
+        "NaN".to_string()
+    } else if f == f64::INFINITY {
+        "Infinity".to_string()
+    } else if f == f64::NEG_INFINITY {
+        "-Infinity".to_string()
+    } else {
+        f.to_string()
     }
 }
 
@@ -207,5 +224,17 @@ impl TypeOid {
             16385 => TypeOid::Vector,
             _ => TypeOid::Text,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn float_infinity_wire_format() {
+        assert_eq!(Value::Float(f64::INFINITY).to_text(), Some("Infinity".to_string()));
+        assert_eq!(Value::Float(f64::NEG_INFINITY).to_text(), Some("-Infinity".to_string()));
+        assert_eq!(Value::Float(f64::NAN).to_text(), Some("NaN".to_string()));
     }
 }

--- a/native/engine/src/types.rs
+++ b/native/engine/src/types.rs
@@ -138,7 +138,7 @@ impl Value {
             Value::Bytea(b) => Some(format!("\\x{}", hex_encode(b))),
             Value::Vector(v) => {
                 let inner: Vec<String> = v.iter().map(|f| {
-                    if *f == f.trunc() && f.is_finite() && *f > -2_147_483_649.0 && *f < 2_147_483_648.0 {
+                    if *f == f.trunc() && f.is_finite() && *f >= -2_147_483_648.0 && *f < 2_147_483_648.0 {
                         let i = *f as i32;
                         if i as f32 == *f {
                             format!("{}", i)


### PR DESCRIPTION
## Summary

Fixes 2 wire protocol bugs found during implementation review:

- **Float infinity format** - `f64::INFINITY` was sent as `"inf"` but PostgreSQL wire protocol expects `"Infinity"`. Clients parsing PG wire format would reject this. Added `format_float()` helper handling `Infinity`, `-Infinity`, `NaN`.
- **Vector to_text i32 overflow** - Integer shortcut `f.abs() < (i32::MAX as f32)` was unsafe because `i32::MAX as f32` rounds up to `2147483648.0`. Values near the boundary could produce wrong output. Now uses explicit range check with roundtrip verification.

Both fixes applied to `Value::to_text` (types.rs) and `ArenaValue::to_text` (arena.rs). 2 new tests added.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/pgrx/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
