### PR TITLE
fix: HNSW row_id race, PK NULL enforcement, DEFAULT error

### DIFF
--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -717,7 +717,7 @@ fn exec_insert(
         if storage::has_hnsw_index(schema, table_name).is_some() {
             for (i, row) in inserted_rows.iter().enumerate() {
                 if let Some(crate::types::Value::Vector(v)) = row.get(col_idx) {
-                    storage::hnsw_insert(schema, table_name, base_row_id + i, v.clone())?;
+                    let _ = storage::hnsw_insert(schema, table_name, base_row_id + i, v.clone());
                 }
             }
         }

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -261,8 +261,12 @@ fn exec_create_table(
     };
 
     let mut columns = Vec::new();
+    let mut created_sequences: Vec<(String, String)> = Vec::new();
     for elt in &create.table_elts {
-        let node = elt.node.as_ref().ok_or("missing table element")?;
+        let node = elt.node.as_ref().ok_or_else(|| {
+            for (s, n) in &created_sequences { crate::sequence::drop_sequence(s, n); }
+            "missing table element".to_string()
+        })?;
         if let NodeEnum::ColumnDef(col) = node {
             let type_name = extract_type_name(col);
             let mut nullable = !col.is_not_null;
@@ -277,7 +281,11 @@ fn exec_create_table(
             );
             if is_serial {
                 let seq_name = format!("{}_{}_seq", table_name, col.colname);
-                crate::sequence::create_sequence(schema, &seq_name, 1, 1)?;
+                crate::sequence::create_sequence(schema, &seq_name, 1, 1).map_err(|e| {
+                    for (s, n) in &created_sequences { crate::sequence::drop_sequence(s, n); }
+                    e
+                })?;
+                created_sequences.push((schema.to_string(), seq_name.clone()));
                 default_expr = Some(catalog::DefaultExpr::NextVal(
                     format!("{}.{}", schema, seq_name),
                 ));
@@ -316,6 +324,7 @@ fn exec_create_table(
                                         .filter_map(|n| n.node.as_ref())
                                         .filter_map(|n| if let NodeEnum::String(s) = n { Some(s.sval.as_str()) } else { None })
                                         .collect::<Vec<_>>().join(".");
+                                    for (s, n) in &created_sequences { crate::sequence::drop_sequence(s, n); }
                                     return Err(format!(
                                         "DEFAULT function expressions are not yet supported: {}",
                                         func_name

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -302,9 +302,23 @@ fn exec_create_table(
                         x if x == pg_query::protobuf::ConstrType::ConstrDefault as i32 => {
                             // Parse DEFAULT expression
                             if let Some(raw) = c.raw_expr.as_ref().and_then(|n| n.node.as_ref()) {
-                                default_expr = Some(catalog::DefaultExpr::Literal(
-                                    eval_const(Some(raw)),
-                                ));
+                                match raw {
+                                    NodeEnum::FuncCall(fc) => {
+                                        let func_name: String = fc.funcname.iter()
+                                            .filter_map(|n| n.node.as_ref())
+                                            .filter_map(|n| if let NodeEnum::String(s) = n { Some(s.sval.as_str()) } else { None })
+                                            .collect::<Vec<_>>().join(".");
+                                        return Err(format!(
+                                            "DEFAULT function expressions are not yet supported: {}",
+                                            func_name
+                                        ));
+                                    }
+                                    _ => {
+                                        default_expr = Some(catalog::DefaultExpr::Literal(
+                                            eval_const(Some(raw)),
+                                        ));
+                                    }
+                                }
                             }
                         }
                         _ => {}
@@ -661,7 +675,6 @@ fn exec_insert(
     // then insert all at once. If any row fails, nothing is committed. (#4)
     let (unique_checks, pk_cols) = build_unique_checks(&table_def);
     let row_count = all_rows.len() as u64;
-    let inserted_rows = if has_returning { all_rows.clone() } else { Vec::new() };
 
     // Auto-create HNSW index on first INSERT if table has a vector column
     let vector_col_idx = table_def
@@ -678,36 +691,22 @@ fn exec_insert(
         );
     }
 
-    // Collect vectors for HNSW insertion (before batch moves the rows)
-    let hnsw_vectors: Vec<(usize, Vec<f32>)> = if let Some(col_idx) = vector_col_idx {
-        if storage::has_hnsw_index(schema, table_name).is_some() {
-            // Get current row count to compute row_ids for the new rows
-            let base_row_id = storage::row_count(schema, table_name).unwrap_or(0) as usize;
-            all_rows
-                .iter()
-                .enumerate()
-                .filter_map(|(i, row)| {
-                    if let Some(crate::types::Value::Vector(v)) = row.get(col_idx) {
-                        Some((base_row_id + i, v.clone()))
-                    } else {
-                        None
-                    }
-                })
-                .collect()
-        } else {
-            Vec::new()
-        }
-    } else {
-        Vec::new()
-    };
+    let needs_row_copy = has_returning || vector_col_idx.is_some();
+    let inserted_rows = if needs_row_copy { all_rows.clone() } else { Vec::new() };
 
-    storage::insert_batch_checked(
+    let base_row_id = storage::insert_batch_checked(
         schema, table_name, all_rows, &unique_checks, &pk_cols,
     )?;
 
-    // Insert vectors into HNSW index after successful row insertion
-    for (row_id, vector) in hnsw_vectors {
-        let _ = storage::hnsw_insert(schema, table_name, row_id, vector);
+    // Insert vectors into HNSW index using the correct base_row_id from inside the write lock
+    if let Some(col_idx) = vector_col_idx {
+        if storage::has_hnsw_index(schema, table_name).is_some() {
+            for (i, row) in inserted_rows.iter().enumerate() {
+                if let Some(crate::types::Value::Vector(v)) = row.get(col_idx) {
+                    let _ = storage::hnsw_insert(schema, table_name, base_row_id + i, v.clone());
+                }
+            }
+        }
     }
 
     let tag = format!("INSERT 0 {}", row_count);
@@ -4893,5 +4892,36 @@ mod tests {
             overlap,
             k
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn hnsw_insert_correct_row_ids() {
+        setup();
+        execute("CREATE TABLE vec_t (id INT, v VECTOR)").unwrap();
+        execute("INSERT INTO vec_t VALUES (1, '[1,0,0]'), (2, '[0,1,0]'), (3, '[0,0,1]')").unwrap();
+        // KNN should find the correct nearest neighbor
+        let r = execute("SELECT id FROM vec_t ORDER BY v <-> '[1,0,0]' LIMIT 1").unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][0], Some("1".to_string()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn pk_null_rejected_at_storage() {
+        setup();
+        execute("CREATE TABLE pk_t (id INT PRIMARY KEY, name TEXT)").unwrap();
+        // This should fail - NULL in a PK column must be rejected
+        let r = execute("INSERT INTO pk_t VALUES (NULL, 'test')");
+        assert!(r.is_err());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn default_function_error() {
+        setup();
+        let r = execute("CREATE TABLE df_t (id INT, created_at TEXT DEFAULT now())");
+        assert!(r.is_err());
+        assert!(r.unwrap_err().contains("not yet supported"));
     }
 }

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -302,23 +302,28 @@ fn exec_create_table(
                         x if x == pg_query::protobuf::ConstrType::ConstrDefault as i32 => {
                             // Parse DEFAULT expression
                             if let Some(raw) = c.raw_expr.as_ref().and_then(|n| n.node.as_ref()) {
-                                match raw {
-                                    NodeEnum::FuncCall(fc) => {
-                                        let func_name: String = fc.funcname.iter()
-                                            .filter_map(|n| n.node.as_ref())
-                                            .filter_map(|n| if let NodeEnum::String(s) = n { Some(s.sval.as_str()) } else { None })
-                                            .collect::<Vec<_>>().join(".");
-                                        return Err(format!(
-                                            "DEFAULT function expressions are not yet supported: {}",
-                                            func_name
-                                        ));
+                                let func_node = match raw {
+                                    NodeEnum::FuncCall(_) => Some(raw),
+                                    NodeEnum::TypeCast(tc) => {
+                                        tc.arg.as_ref()
+                                            .and_then(|a| a.node.as_ref())
+                                            .filter(|n| matches!(n, NodeEnum::FuncCall(_)))
                                     }
-                                    _ => {
-                                        default_expr = Some(catalog::DefaultExpr::Literal(
-                                            eval_const(Some(raw)),
-                                        ));
-                                    }
+                                    _ => None,
+                                };
+                                if let Some(NodeEnum::FuncCall(fc)) = func_node {
+                                    let func_name: String = fc.funcname.iter()
+                                        .filter_map(|n| n.node.as_ref())
+                                        .filter_map(|n| if let NodeEnum::String(s) = n { Some(s.sval.as_str()) } else { None })
+                                        .collect::<Vec<_>>().join(".");
+                                    return Err(format!(
+                                        "DEFAULT function expressions are not yet supported: {}",
+                                        func_name
+                                    ));
                                 }
+                                default_expr = Some(catalog::DefaultExpr::Literal(
+                                    eval_const(Some(raw)),
+                                ));
                             }
                         }
                         _ => {}
@@ -703,7 +708,7 @@ fn exec_insert(
         if storage::has_hnsw_index(schema, table_name).is_some() {
             for (i, row) in inserted_rows.iter().enumerate() {
                 if let Some(crate::types::Value::Vector(v)) = row.get(col_idx) {
-                    let _ = storage::hnsw_insert(schema, table_name, base_row_id + i, v.clone());
+                    storage::hnsw_insert(schema, table_name, base_row_id + i, v.clone())?;
                 }
             }
         }

--- a/native/engine/src/storage.rs
+++ b/native/engine/src/storage.rs
@@ -238,6 +238,15 @@ pub fn insert_checked(
     let tbl = get_table(schema, name)?;
     let mut table = tbl.write();
 
+    // Reject NULL in any PK column (PK implies NOT NULL)
+    for &pk_col in pk_cols {
+        if pk_col < row.len() && matches!(row[pk_col], Value::Null) {
+            return Err(
+                "null value in column violates not-null constraint".to_string(),
+            );
+        }
+    }
+
     // Composite PK check — O(1) via hash index
     if pk_cols.len() > 1 {
         if let Some(ref pk_idx) = table.pk_index {
@@ -282,7 +291,7 @@ pub fn insert_batch_checked(
     rows: Vec<Row>,
     unique_checks: &[(usize, String)],
     pk_cols: &[usize],
-) -> Result<(), String> {
+) -> Result<usize, String> {
     let tbl = get_table(schema, name)?;
     let mut table = tbl.write();
 
@@ -291,6 +300,15 @@ pub fn insert_batch_checked(
     let mut batch_pk: HashSet<Vec<Value>> = HashSet::new();
 
     for row in rows.iter() {
+        // Reject NULL in any PK column (PK implies NOT NULL)
+        for &pk_col in pk_cols {
+            if pk_col < row.len() && matches!(row[pk_col], Value::Null) {
+                return Err(
+                    "null value in column violates not-null constraint".to_string(),
+                );
+            }
+        }
+
         // Composite PK check — O(1) against index + batch set
         if pk_cols.len() > 1 {
             let key: Vec<Value> = pk_cols.iter().map(|&ci| row[ci].clone()).collect();
@@ -334,11 +352,12 @@ pub fn insert_batch_checked(
     }
 
     // All validated — push all atomically and update indexes
+    let base_row_id = table.rows.len();
     for row in rows {
         add_to_indexes(&mut table, &row);
         table.rows.push(row);
     }
-    Ok(())
+    Ok(base_row_id)
 }
 
 /// Update matching rows with validation. Returns error if any updater fails.


### PR DESCRIPTION
## Summary

Fixes 3 storage-layer safety bugs found during implementation review:

- **HNSW row_id race** - `row_count()` was called before `insert_batch_checked()`, creating a TOCTOU window where concurrent INSERTs could shift row IDs. HNSW would then index wrong rows, producing silently incorrect KNN results. Fix: `insert_batch_checked` now returns `base_row_id` computed inside the write lock.
- **PK NULL enforcement** - Storage layer did not independently reject NULL in PK columns. If executor-level `check_not_null` was bypassed, NULL PKs could be stored. Fix: added NULL rejection in `insert_batch_checked`/`insert_checked` as a safety net.
- **Non-literal DEFAULT** - `CREATE TABLE t (x TEXT DEFAULT now())` silently inserted NULL. Fix: function-call defaults now return a clear "not yet supported" error.

3 new tests added.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/pgrx/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
