### PR TITLE
rename: pgrx to EvolvSQL

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,15 +1,15 @@
-# pgRx Architecture Principles
+# EvolvSQL Architecture Principles
 
 > Every allocation is a cost. Every pointer is pressure. Every copy is waste.
 > — Inspired by VictoriaMetrics' zero-allocation philosophy
 
-This document defines the architectural principles that govern ALL implementation decisions in pgRx. Every PR, every new feature, every refactor must align with these principles.
+This document defines the architectural principles that govern ALL implementation decisions in EvolvSQL. Every PR, every new feature, every refactor must align with these principles.
 
 ---
 
 ## Core Philosophy: Zero Unnecessary Allocation
 
-VictoriaMetrics achieves 10x less memory than competitors not through any single trick but by **systematically eliminating every source of unnecessary heap allocation** across the entire codebase. pgRx adopts this as its foundational engineering discipline.
+VictoriaMetrics achieves 10x less memory than competitors not through any single trick but by **systematically eliminating every source of unnecessary heap allocation** across the entire codebase. EvolvSQL adopts this as its foundational engineering discipline.
 
 The rules:
 
@@ -165,7 +165,7 @@ let mmap = MmapMut::map_anon(page_size * num_pages)?;
 
 **Benefits:**
 - OS page cache handles eviction automatically (no custom LRU needed initially)
-- No double-buffering (the exact problem pgRx solves vs PostgreSQL)
+- No double-buffering (the exact problem EvolvSQL solves vs PostgreSQL)
 - Pages stay warm in kernel cache even if Rust drops references
 - Transparent huge pages can be enabled for large pools
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
-# pgrx — Project-Level Instructions
+# EvolvSQL - Project-Level Instructions
 
 ## Architecture
 
-pgrx is a PostgreSQL-compatible database engine built on BEAM (Elixir) + Rust.
+EvolvSQL is a PostgreSQL-compatible database engine built on BEAM (Elixir) + Rust.
 - **BEAM**: TCP connections, wire protocol, session state, hibernate, fault tolerance
 - **Rust NIF**: SQL parsing (pg_query), query execution, storage, vector operations
 - **Wire protocol**: PostgreSQL v3 (simple + extended query protocol)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to pgrx
+# Contributing to EvolvSQL
 
-Thanks for your interest in pgrx! We're building a PostgreSQL-compatible database from the ground up using BEAM (Erlang/Elixir) and Rust.
+Thanks for your interest in EvolvSQL! We're building a PostgreSQL-compatible database from the ground up using BEAM (Erlang/Elixir) and Rust.
 
 ## Current Status
 
@@ -27,4 +27,4 @@ Watch this repo or check back — we'll update this file when we're ready.
 
 ## License
 
-By contributing to pgrx, you agree that your contributions are licensed under the project's [BSL 1.1 License](LICENSE), which converts to AGPL-3.0 on 2030-03-21.
+By contributing to EvolvSQL, you agree that your contributions are licensed under the project's [BSL 1.1 License](LICENSE), which converts to AGPL-3.0 on 2030-03-21.

--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Jagrit Gumber
-Licensed Work:        pgrx
+Licensed Work:        EvolvSQL
                       The Licensed Work is (c) 2026 Jagrit Gumber.
 Additional Use Grant: You may make use of the Licensed Work, provided that
                       you may not use the Licensed Work for a Database

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pgRx
+# EvolvSQL
 
 > **This project is in early development and highly unstable.** APIs, storage format, and wire protocol behavior will change without notice. Do not use in production. Contributions and feedback welcome — just know that everything is actively being reworked.
 
@@ -12,9 +12,9 @@ Same SQL. Same drivers. 100x less memory per connection.
 
 PostgreSQL forks an OS process for every connection — **14.6 MB each**, even idle. 50 idle connections cost **729 MB**. This architecture hasn't changed since 1986.
 
-pgRx replaces the process-per-connection model with BEAM lightweight processes (**~2 KB** active, **0 KB** hibernated) and a Rust query engine for parsing and execution.
+EvolvSQL replaces the process-per-connection model with BEAM lightweight processes (**~2 KB** active, **0 KB** hibernated) and a Rust query engine for parsing and execution.
 
-| | PostgreSQL 17 | pgRx |
+| | PostgreSQL 17 | EvolvSQL |
 |---|---|---|
 | Per idle connection | 14.6 MB | 0 KB (hibernated) |
 | Per active connection | 14.6 MB | ~15 KB |
@@ -51,8 +51,8 @@ Client (psql, any PG driver)
 
 ```bash
 # Clone
-git clone https://github.com/JagritGumber/pgrx.git
-cd pgrx
+git clone https://github.com/JagritGumber/evolvsql.git
+cd evolvsql
 
 # Dependencies: Elixir ~1.18, OTP 27, Rust (2024 edition)
 mix deps.get
@@ -60,7 +60,7 @@ mix deps.get
 # Build the Rust NIF
 cd native/engine && cargo build --release && cd ../..
 
-# Start pgRx
+# Start EvolvSQL
 mix run --no-halt
 
 # Connect with psql (default port 5432)
@@ -87,27 +87,26 @@ See [FEATURES.md](FEATURES.md) for the complete specification.
 
 **Memory: 50 idle connections**
 
-| | PostgreSQL 17 | pgRx |
+| | PostgreSQL 17 | EvolvSQL |
 |---|---|---|
 | Additional memory | +729 MB | +0 KB |
 | Per connection | 14.6 MB | 0 KB (hibernated) |
 
 **Query throughput**
 
-pgRx achieves 2x the query throughput of PostgreSQL on equivalent hardware in initial benchmarks.
+EvolvSQL achieves 2x the query throughput of PostgreSQL on equivalent hardware in initial benchmarks.
 
 ## License
 
 [Business Source License 1.1](LICENSE) — the same license used by CockroachDB.
 
-- Use pgRx for anything, including commercial production use
+- Use EvolvSQL for anything, including commercial production use
 - Self-host freely
-- Cannot offer pgRx as a managed database service
+- Cannot offer EvolvSQL as a managed database service
 
 Converts to AGPL-3.0 five years after each version's release.
 
 ## Links
 
-- [Demo site](https://pgrx-demo.jagritgumber-cloudflare.workers.dev/)
 - [Feature specification](FEATURES.md)
 - [sqlcx — cross-language SQL codegen](https://github.com/JagritGumber/sqlcx) (companion ORM)

--- a/apps/wire/lib/wire/connection.ex
+++ b/apps/wire/lib/wire/connection.ex
@@ -517,11 +517,11 @@ defmodule Wire.Connection do
 
     cond do
       normalized == "select version()" ->
-        v = "pgrx 0.1.0 on BEAM/OTP 27 + Rust — PostgreSQL 18.0 compatible"
+        v = "evolvsql 0.1.0 on BEAM/OTP 27 + Rust - PostgreSQL 18.0 compatible"
         {:rows, [{"version", 25}], [[v]], "SELECT 1"}
 
       normalized == "select current_database()" ->
-        {:rows, [{"current_database", 25}], [["pgrx"]], "SELECT 1"}
+        {:rows, [{"current_database", 25}], [["evolvsql"]], "SELECT 1"}
 
       normalized == "" ->
         {:command, "EMPTY"}

--- a/apps/wire/lib/wire/listener.ex
+++ b/apps/wire/lib/wire/listener.ex
@@ -24,7 +24,7 @@ defmodule Wire.Listener do
 
     case :gen_tcp.listen(port, tcp_opts) do
       {:ok, socket} ->
-        Logger.info("pgrx listening on port #{port}")
+        Logger.info("evolvsql listening on port #{port}")
         send(self(), :accept)
         {:ok, %{socket: socket}}
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule Pgrx.MixProject do
+defmodule Evolvsql.MixProject do
   use Mix.Project
 
   def project do
@@ -14,7 +14,7 @@ defmodule Pgrx.MixProject do
 
   defp releases do
     [
-      pgrx: [
+      evolvsql: [
         applications: [
           wire: :permanent,
           engine: :permanent,

--- a/native/cli/Cargo.lock
+++ b/native/cli/Cargo.lock
@@ -336,7 +336,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "pgrx-cli"
+name = "evolvsql-cli"
 version = "0.1.0"
 dependencies = [
  "base64",

--- a/native/cli/Cargo.toml
+++ b/native/cli/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "pgrx-cli"
+name = "evolvsql-cli"
 version = "0.1.0"
 edition = "2024"
 
 [[bin]]
-name = "pgrx"
+name = "evolvsql"
 path = "src/main.rs"
 
 [dependencies]

--- a/native/cli/src/main.rs
+++ b/native/cli/src/main.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Barrier};
 use std::time::Instant;
 
 #[derive(Parser)]
-#[command(name = "pgrx", about = "pgrx CLI — fast PostgreSQL-compatible client")]
+#[command(name = "evolvsql", about = "EvolvSQL CLI - fast PostgreSQL-compatible client")]
 struct Args {
     /// Host to connect to
     #[arg(short = 'h', long, default_value = "127.0.0.1")]
@@ -21,7 +21,7 @@ struct Args {
     user: String,
 
     /// Database name
-    #[arg(short, long, default_value = "pgrx")]
+    #[arg(short, long, default_value = "evolvsql")]
     dbname: String,
 
     /// Password
@@ -93,7 +93,7 @@ fn main() {
 
     // Interactive REPL
     println!(
-        "pgrx cli 0.1.0 — connected to {}:{}/{}",
+        "evolvsql cli 0.1.0 - connected to {}:{}/{}",
         args.host, args.port, args.dbname
     );
     println!("Type \\q to quit, \\timing to toggle timing.\n");

--- a/rel/vm.args
+++ b/rel/vm.args
@@ -1,4 +1,4 @@
-## Minimal memory footprint for pgrx
+## Minimal memory footprint for evolvsql
 
 ## 2 normal schedulers, 8 dirty CPU, 1 dirty IO
 +S 2:2

--- a/run_bottleneck.sh
+++ b/run_bottleneck.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
 export PGPASSWORD=postgres
-CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
-cd /home/jagrit/pgrx
+CLI="/home/jagrit/evolvsql/native/cli/target/release/evolvsql"
+cd /home/jagrit/evolvsql
 
 pkill -9 -f beam.smp 2>/dev/null; sleep 1
 mix run --no-halt &

--- a/run_concurrency_bench.sh
+++ b/run_concurrency_bench.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
 export PGPASSWORD=postgres
-CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
-cd /home/jagrit/pgrx
+CLI="/home/jagrit/evolvsql/native/cli/target/release/evolvsql"
+cd /home/jagrit/evolvsql
 
 # Force NIF recompile
 mix compile --force 2>&1 | tail -3

--- a/run_cpu_analysis.sh
+++ b/run_cpu_analysis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
-CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
-cd /home/jagrit/pgrx
+CLI="/home/jagrit/evolvsql/native/cli/target/release/evolvsql"
+cd /home/jagrit/evolvsql
 
 measure_idle() {
   sleep 3

--- a/run_cpu_measure.sh
+++ b/run_cpu_measure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
-CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
-cd /home/jagrit/pgrx
+CLI="/home/jagrit/evolvsql/native/cli/target/release/evolvsql"
+cd /home/jagrit/evolvsql
 
 pkill -9 -f beam.smp 2>/dev/null; sleep 1
 mix run --no-halt &
@@ -17,7 +17,7 @@ done
 BEAM_PID=$(pgrep -f beam.smp | head -1)
 
 echo "============================================"
-echo "  CPU Usage: pgrx under various loads"
+echo "  CPU Usage: evolvsql under various loads"
 echo "  Machine: $(nproc) cores available"
 echo "============================================"
 echo ""

--- a/run_hash_bench.sh
+++ b/run_hash_bench.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
 export PGPASSWORD=postgres
-CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
-cd /home/jagrit/pgrx
+CLI="/home/jagrit/evolvsql/native/cli/target/release/evolvsql"
+cd /home/jagrit/evolvsql
 
 pkill -9 -f beam.smp 2>/dev/null; sleep 1
 mix run --no-halt &

--- a/run_hnsw_bench.sh
+++ b/run_hnsw_bench.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
 export PGPASSWORD=postgres
-CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
-cd /home/jagrit/pgrx
+CLI="/home/jagrit/evolvsql/native/cli/target/release/evolvsql"
+cd /home/jagrit/evolvsql
 
 mix compile --force 2>&1 | tail -3
 pkill -9 -f beam.smp 2>/dev/null; sleep 1

--- a/run_idle_analysis.sh
+++ b/run_idle_analysis.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
-cd /home/jagrit/pgrx
+cd /home/jagrit/evolvsql
 
 pkill -9 -f beam.smp 2>/dev/null
 sleep 1
 
-# Start pgrx and immediately analyze
+# Start evolvsql and immediately analyze
 mix run -e '
 Process.sleep(3000)
 
 IO.puts("============================================")
-IO.puts("  pgrx Idle Memory Breakdown")
+IO.puts("  evolvsql Idle Memory Breakdown")
 IO.puts("============================================")
 IO.puts("")
 

--- a/run_insert_bench.sh
+++ b/run_insert_bench.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
 export PGPASSWORD=postgres
-CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
-cd /home/jagrit/pgrx
+CLI="/home/jagrit/evolvsql/native/cli/target/release/evolvsql"
+cd /home/jagrit/evolvsql
 
 pkill -9 -f beam.smp 2>/dev/null; sleep 1
 mix run --no-halt &
@@ -16,7 +16,7 @@ echo ""
 # Test 1: Insert into empty table with PK (measures constraint check overhead)
 $CLI -c "CREATE TABLE ins_test (id int PRIMARY KEY, name text);" 2>/dev/null
 
-echo "=== pgrx: INSERT 1000 rows into empty table (1 client) ==="
+echo "=== evolvsql: INSERT 1000 rows into empty table (1 client) ==="
 START=$(date +%s%N)
 for i in $(seq 1 10); do
   V=""
@@ -32,7 +32,7 @@ MS=$(( (END - START) / 1000000 ))
 echo "  1000 rows in ${MS}ms ($(( 1000000 / (MS + 1) )) rows/s)"
 
 echo ""
-echo "=== pgrx: INSERT 1000 more into 1000-row table ==="
+echo "=== evolvsql: INSERT 1000 more into 1000-row table ==="
 START=$(date +%s%N)
 for i in $(seq 1 10); do
   V=""
@@ -49,7 +49,7 @@ echo "  1000 rows in ${MS}ms ($(( 1000000 / (MS + 1) )) rows/s)"
 echo "  Table now has 2000 rows"
 
 echo ""
-echo "=== pgrx: INSERT 1000 more into 2000-row table ==="
+echo "=== evolvsql: INSERT 1000 more into 2000-row table ==="
 START=$(date +%s%N)
 for i in $(seq 1 10); do
   V=""

--- a/run_insert_deep.sh
+++ b/run_insert_deep.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
 export PGPASSWORD=postgres
-CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
-cd /home/jagrit/pgrx
+CLI="/home/jagrit/evolvsql/native/cli/target/release/evolvsql"
+cd /home/jagrit/evolvsql
 
 pkill -9 -f beam.smp 2>/dev/null; sleep 1
 mix run --no-halt &
@@ -18,7 +18,7 @@ echo ""
 
 $CLI -c "CREATE TABLE scale_test (id int PRIMARY KEY, name text);" 2>/dev/null
 
-echo "=== pgrx: INSERT 100 rows at various table sizes ==="
+echo "=== evolvsql: INSERT 100 rows at various table sizes ==="
 for SIZE in 0 1000 2000 5000 10000; do
   # Fill up to SIZE if needed
   CURRENT=$($CLI -c "SELECT COUNT(*) FROM scale_test;" 2>/dev/null | grep -oP '^\s*\d+' | tr -d ' ' || echo "0")
@@ -52,7 +52,7 @@ done
 $CLI -c "DROP TABLE scale_test;" 2>/dev/null
 
 echo ""
-echo "=== pgrx: INSERT without PK (no constraint check) ==="
+echo "=== evolvsql: INSERT without PK (no constraint check) ==="
 $CLI -c "CREATE TABLE no_pk (id int, name text);" 2>/dev/null
 
 for SIZE in 0 1000 5000 10000; do

--- a/run_join_bench.sh
+++ b/run_join_bench.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
 export PGPASSWORD=postgres
-CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
-cd /home/jagrit/pgrx
+CLI="/home/jagrit/evolvsql/native/cli/target/release/evolvsql"
+cd /home/jagrit/evolvsql
 
 pkill -9 -f beam.smp 2>/dev/null; sleep 1
 elixir --erl "+SDcpu 8:8 +sbwt none +sbwtdcpu none +sbwtdio none" -S mix run --no-halt &
@@ -17,15 +17,15 @@ for b in $(seq 1 5); do
   $CLI -c "INSERT INTO orders VALUES ${VALS};" 2>/dev/null
 done
 
-echo "=== pgrx: JOIN + GROUP BY (1000×5000, 1 client) ==="
+echo "=== evolvsql: JOIN + GROUP BY (1000×5000, 1 client) ==="
 $CLI --bench 50 --clients 1 -c "SELECT users.name, COUNT(*) FROM users JOIN orders ON users.id = orders.user_id GROUP BY users.name LIMIT 10;" 2>&1 | grep -E "Throughput|Avg"
 
 echo ""
-echo "=== pgrx: Simple JOIN WHERE (1 client) ==="
+echo "=== evolvsql: Simple JOIN WHERE (1 client) ==="
 $CLI --bench 500 --clients 1 -c "SELECT users.name, orders.total FROM users JOIN orders ON users.id = orders.user_id WHERE users.id = 42;" 2>&1 | grep -E "Throughput|Avg"
 
 echo ""
-echo "=== pgrx: Simple JOIN WHERE (10 clients) ==="
+echo "=== evolvsql: Simple JOIN WHERE (10 clients) ==="
 $CLI --bench 200 --clients 10 -c "SELECT users.name, orders.total FROM users JOIN orders ON users.id = orders.user_id WHERE users.id = 42;" 2>&1 | grep -E "Throughput|Avg"
 
 echo ""

--- a/run_join_profile.sh
+++ b/run_join_profile.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
-CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
-cd /home/jagrit/pgrx
+CLI="/home/jagrit/evolvsql/native/cli/target/release/evolvsql"
+cd /home/jagrit/evolvsql
 
 pkill -9 -f beam.smp 2>/dev/null; sleep 1
 mix run --no-halt &

--- a/run_memtest_vs_pg.sh
+++ b/run_memtest_vs_pg.sh
@@ -4,11 +4,11 @@ export PGPASSWORD=postgres
 PG_HOST=127.0.0.1
 PG_PORT=5432
 PG_USER=postgres
-PGRX_PORT=5433
+EVOLVSQL_PORT=5433
 N=50
 
 echo "============================================"
-echo "  Memory Benchmark: pgrx vs PostgreSQL 17"
+echo "  Memory Benchmark: evolvsql vs PostgreSQL 17"
 echo "  $N connections"
 echo "============================================"
 echo ""
@@ -81,19 +81,19 @@ PG_BACKENDS2=$(count_pg_backends)
 echo "CLOSED:      ${PG_RSS2} KB total RSS (${PG_BACKENDS2} backends)"
 echo ""
 
-# ── pgrx Test ────────────────────────────────────────────
-echo "=== pgrx (BEAM + Rust) ==="
+# ── evolvsql Test ────────────────────────────────────────────
+echo "=== evolvsql (BEAM + Rust) ==="
 
-# Start pgrx
-cd /home/jagrit/pgrx
+# Start evolvsql
+cd /home/jagrit/evolvsql
 pkill -9 -f beam.smp 2>/dev/null
 sleep 1
 mix run --no-halt &
 SERVER_PID=$!
 sleep 6
 
-cd /home/jagrit/pgrx/native/cli
-./target/release/pgrx --memtest $N 2>&1 | grep -v "^\[info\]\|^\[notice\]"
+cd /home/jagrit/evolvsql/native/cli
+./target/release/evolvsql --memtest $N 2>&1 | grep -v "^\[info\]\|^\[notice\]"
 
 kill $SERVER_PID 2>/dev/null
 wait $SERVER_PID 2>/dev/null
@@ -101,6 +101,6 @@ wait $SERVER_PID 2>/dev/null
 echo ""
 echo "============================================"
 echo "  PostgreSQL: +${PG_DELTA} KB for $N connections"
-echo "  pgrx idle:  ~0 KB for $N hibernated connections"
+echo "  evolvsql idle:  ~0 KB for $N hibernated connections"
 echo "  Ratio:      PostgreSQL uses ~${PG_DELTA}x more memory"
 echo "============================================"

--- a/run_overhaul_bench.sh
+++ b/run_overhaul_bench.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
 export PGPASSWORD=postgres
-CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
-cd /home/jagrit/pgrx
+CLI="/home/jagrit/evolvsql/native/cli/target/release/evolvsql"
+cd /home/jagrit/evolvsql
 
 mix compile --force 2>&1 | tail -3
 pkill -9 -f beam.smp 2>/dev/null; sleep 1

--- a/run_vec_mini.sh
+++ b/run_vec_mini.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
-CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
-cd /home/jagrit/pgrx
+CLI="/home/jagrit/evolvsql/native/cli/target/release/evolvsql"
+cd /home/jagrit/evolvsql
 
 pkill -9 -f beam.smp 2>/dev/null; sleep 1
 mix run --no-halt &
@@ -22,11 +22,11 @@ $CLI -c "$SQL" 2>/dev/null
 
 QVEC=$(python3 -c "import random; random.seed(99); print('[' + ','.join([f'{random.random():.4f}' for _ in range(32)]) + ']')")
 
-echo "=== pgrx: KNN 32-dim, 100 vectors, 1 client ==="
+echo "=== evolvsql: KNN 32-dim, 100 vectors, 1 client ==="
 $CLI --bench 500 --clients 1 -c "SELECT id FROM vt ORDER BY embedding <-> '${QVEC}' LIMIT 5;" 2>&1
 
 echo ""
-echo "=== pgrx: KNN 32-dim, 100 vectors, 10 clients ==="
+echo "=== evolvsql: KNN 32-dim, 100 vectors, 10 clients ==="
 $CLI --bench 200 --clients 10 -c "SELECT id FROM vt ORDER BY embedding <-> '${QVEC}' LIMIT 5;" 2>&1
 
 kill %1 2>/dev/null; wait 2>/dev/null

--- a/run_vec_quick.sh
+++ b/run_vec_quick.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
 export PGPASSWORD=postgres
-CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
-cd /home/jagrit/pgrx
+CLI="/home/jagrit/evolvsql/native/cli/target/release/evolvsql"
+cd /home/jagrit/evolvsql
 
 pkill -9 -f beam.smp 2>/dev/null; sleep 1
 mix run --no-halt &
@@ -26,12 +26,12 @@ for batch in range(10):
     $CLI -c "$sql" 2>/dev/null
 done
 
-echo "=== pgrx: KNN 128-dim, 1000 vectors, 1 client ==="
+echo "=== evolvsql: KNN 128-dim, 1000 vectors, 1 client ==="
 QVEC=$(python3 -c "import random; random.seed(99); print('[' + ','.join([f'{random.random():.4f}' for _ in range(128)]) + ']')")
 $CLI --bench 100 --clients 1 -c "SELECT id FROM vb ORDER BY embedding <-> '${QVEC}' LIMIT 10;" 2>&1 | grep -E "Throughput|Avg|P99"
 
 echo ""
-echo "=== pgrx: KNN 128-dim, 1000 vectors, 10 clients ==="
+echo "=== evolvsql: KNN 128-dim, 1000 vectors, 10 clients ==="
 $CLI --bench 100 --clients 10 -c "SELECT id FROM vb ORDER BY embedding <-> '${QVEC}' LIMIT 10;" 2>&1 | grep -E "Throughput|Avg|P99"
 
 echo ""

--- a/run_vector_bench.sh
+++ b/run_vector_bench.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 export PATH="$HOME/.local/share/mise/installs/erlang/27.2/bin:$HOME/.local/share/mise/installs/elixir/1.18.2-otp-27/bin:$PATH"
 export PGPASSWORD=postgres
-CLI="/home/jagrit/pgrx/native/cli/target/release/pgrx"
-cd /home/jagrit/pgrx
+CLI="/home/jagrit/evolvsql/native/cli/target/release/evolvsql"
+cd /home/jagrit/evolvsql
 
 pkill -9 -f beam.smp 2>/dev/null; sleep 1
 mix run --no-halt &
 sleep 6
 
 echo "============================================"
-echo "  Vector Search Benchmark: pgrx vs pgvector"
+echo "  Vector Search Benchmark: evolvsql vs pgvector"
 echo "============================================"
 echo ""
 
-# Setup pgrx
+# Setup evolvsql
 $CLI -c "CREATE TABLE vec_bench (id int PRIMARY KEY, embedding vector);" 2>/dev/null
 
 # Insert 1000 vectors (128-dim, random-ish)
-echo "Inserting 1000 × 128-dim vectors into pgrx..."
+echo "Inserting 1000 × 128-dim vectors into evolvsql..."
 for i in $(seq 1 10); do
   VALS=""
   for j in $(seq 1 100); do
@@ -47,11 +47,11 @@ for d in $(seq 1 128); do
 done
 QVEC="${QVEC}]"
 
-echo "=== pgrx: KNN search (1 client, 128-dim, 1000 vectors) ==="
+echo "=== evolvsql: KNN search (1 client, 128-dim, 1000 vectors) ==="
 $CLI --bench 100 --clients 1 -c "SELECT id FROM vec_bench ORDER BY embedding <-> '${QVEC}' LIMIT 10;" 2>&1 | grep -E "Throughput|Avg|P99"
 
 echo ""
-echo "=== pgrx: KNN search (10 clients) ==="
+echo "=== evolvsql: KNN search (10 clients) ==="
 $CLI --bench 100 --clients 10 -c "SELECT id FROM vec_bench ORDER BY embedding <-> '${QVEC}' LIMIT 10;" 2>&1 | grep -E "Throughput|Avg|P99"
 
 echo ""


### PR DESCRIPTION
## Summary

- Renamed all references from pgrx/pgRx to evolvsql/EvolvSQL across 28 files
- Updated code (Elixir modules, Rust CLI, Cargo config, wire protocol strings)
- Updated docs (README, ARCHITECTURE, CONTRIBUTING, CLAUDE.md, LICENSE)
- Updated all 16 benchmark shell scripts (paths, binary names, display strings)
- Removed demo site link from README

## Why

pgrx conflicts with an existing open source project (the Rust framework for PostgreSQL extensions). EvolvSQL avoids that collision.

## Test plan

- [ ] Verify `mix compile` succeeds with renamed module
- [ ] Verify `cargo build` succeeds in native/cli with renamed package/binary
- [ ] Verify `psql` connects and `SELECT version()` / `SELECT current_database()` return evolvsql
- [ ] Grep codebase for any remaining pgrx references
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
