### PR TITLE
feat: window value functions - LAG, LEAD, FIRST_VALUE, LAST_VALUE, NTH_VALUE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ Currently supported:
 - Subqueries: IN, EXISTS, scalar, ALL, derived tables (correlated supported)
 - Expressions: arithmetic (+ - * / %), comparison, boolean logic, IS NULL, LIKE, ILIKE, CASE WHEN, COALESCE, NULLIF
 - Aggregates: COUNT, SUM, AVG, MIN, MAX, STRING_AGG, BOOL_AND, BOOL_OR (with DISTINCT support)
-- Window functions: ROW_NUMBER, RANK, DENSE_RANK, NTILE (PARTITION BY + ORDER BY)
+- Window functions: ROW_NUMBER, RANK, DENSE_RANK, NTILE, LAG, LEAD, FIRST_VALUE, LAST_VALUE, NTH_VALUE
 - String functions: upper, lower, length, concat, substring, trim, replace, position, left, right
 - Math functions: abs, ceil, floor, round, mod, power, sqrt
 - Sequence functions: nextval, currval, setval

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -134,7 +134,7 @@ Each feature is categorized by priority tier and assigned to a layer (BEAM or Ru
 - [ ] CTE inlining — MATERIALIZED / NOT MATERIALIZED (PG 12)
 - [ ] LATERAL joins (PG 9.3)
 - [x] Window functions (ranking) — ROW_NUMBER, RANK, DENSE_RANK, NTILE with PARTITION BY + ORDER BY (PG 8.4)
-- [ ] Window functions (value) — LAG, LEAD, FIRST_VALUE, LAST_VALUE, NTH_VALUE (PG 8.4)
+- [x] Window functions (value) — LAG, LEAD, FIRST_VALUE, LAST_VALUE, NTH_VALUE (PG 8.4)
 - [ ] Window functions (aggregate) — SUM/COUNT/AVG/MIN/MAX OVER (...) (PG 8.4)
 - [ ] Window RANGE/GROUPS modes, frame exclusion (PG 11)
 - [ ] GROUPING SETS, CUBE, ROLLUP (PG 9.5)

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -1089,7 +1089,7 @@ fn eval_const(node: Option<&NodeEnum>) -> Value {
 }
 
 #[inline(always)]
-fn eval_expr(node: &NodeEnum, row: &[ArenaValue], ctx: &JoinContext, arena: &mut QueryArena) -> Result<ArenaValue, String> {
+pub(crate) fn eval_expr(node: &NodeEnum, row: &[ArenaValue], ctx: &JoinContext, arena: &mut QueryArena) -> Result<ArenaValue, String> {
     match node {
         NodeEnum::ColumnRef(cref) => {
             let idx = resolve_column(cref, ctx)?;
@@ -3407,7 +3407,7 @@ fn exec_select_raw_post_filter(
     let window_offset = if rows.is_empty() { 0 } else { rows[0].len() };
     if !window_targets.is_empty() {
         let window_results =
-            crate::window::evaluate_window_functions(&window_targets, &rows, arena)?;
+            crate::window::evaluate_window_functions(&window_targets, &rows, &merged_ctx, arena)?;
         for (i, row) in rows.iter_mut().enumerate() {
             row.extend_from_slice(&window_results[i]);
         }
@@ -3425,7 +3425,12 @@ fn exec_select_raw_post_filter(
             SelectTarget::Expr { name, expr } => {
                 if let NodeEnum::FuncCall(fc) = expr {
                     if fc.over.is_some() {
-                        return Ok((name.clone(), TypeOid::Int8.oid()));
+                        let fname = extract_func_name(fc);
+                        let oid = match fname.as_str() {
+                            "row_number" | "rank" | "dense_rank" | "ntile" => TypeOid::Int8.oid(),
+                            _ => TypeOid::Text.oid(),
+                        };
+                        return Ok((name.clone(), oid));
                     }
                 }
                 Ok((name.clone(), TypeOid::Text.oid()))
@@ -6705,6 +6710,152 @@ mod tests {
             "SELECT id, ROW_NUMBER() OVER (ORDER BY id) AS rn FROM wempty",
         ).unwrap();
         assert_eq!(r.rows.len(), 0);
+    }
+
+    // ---- Window value function tests ----
+
+    #[test]
+    #[serial_test::serial]
+    fn window_lag_basic() {
+        setup();
+        execute("CREATE TABLE wlag (id int, val int)").unwrap();
+        execute("INSERT INTO wlag VALUES (1, 10)").unwrap();
+        execute("INSERT INTO wlag VALUES (2, 20)").unwrap();
+        execute("INSERT INTO wlag VALUES (3, 30)").unwrap();
+        let r = execute(
+            "SELECT id, val, LAG(val) OVER (ORDER BY id) AS prev_val FROM wlag ORDER BY id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 3);
+        assert_eq!(r.rows[0][2], None); // first row has no previous
+        assert_eq!(r.rows[1][2], Some("10".into()));
+        assert_eq!(r.rows[2][2], Some("20".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn window_lag_with_offset() {
+        setup();
+        execute("CREATE TABLE wlag2 (id int, val int)").unwrap();
+        execute("INSERT INTO wlag2 VALUES (1, 10)").unwrap();
+        execute("INSERT INTO wlag2 VALUES (2, 20)").unwrap();
+        execute("INSERT INTO wlag2 VALUES (3, 30)").unwrap();
+        execute("INSERT INTO wlag2 VALUES (4, 40)").unwrap();
+        let r = execute(
+            "SELECT id, LAG(val, 2) OVER (ORDER BY id) AS prev2 FROM wlag2 ORDER BY id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 4);
+        assert_eq!(r.rows[0][1], None);
+        assert_eq!(r.rows[1][1], None);
+        assert_eq!(r.rows[2][1], Some("10".into()));
+        assert_eq!(r.rows[3][1], Some("20".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn window_lag_with_default() {
+        setup();
+        execute("CREATE TABLE wlagd (id int, val int)").unwrap();
+        execute("INSERT INTO wlagd VALUES (1, 10)").unwrap();
+        execute("INSERT INTO wlagd VALUES (2, 20)").unwrap();
+        let r = execute(
+            "SELECT id, LAG(val, 1, 0) OVER (ORDER BY id) AS prev_val FROM wlagd ORDER BY id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 2);
+        assert_eq!(r.rows[0][1], Some("0".into())); // default value
+        assert_eq!(r.rows[1][1], Some("10".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn window_lead_basic() {
+        setup();
+        execute("CREATE TABLE wlead (id int, val int)").unwrap();
+        execute("INSERT INTO wlead VALUES (1, 10)").unwrap();
+        execute("INSERT INTO wlead VALUES (2, 20)").unwrap();
+        execute("INSERT INTO wlead VALUES (3, 30)").unwrap();
+        let r = execute(
+            "SELECT id, val, LEAD(val) OVER (ORDER BY id) AS next_val FROM wlead ORDER BY id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 3);
+        assert_eq!(r.rows[0][2], Some("20".into()));
+        assert_eq!(r.rows[1][2], Some("30".into()));
+        assert_eq!(r.rows[2][2], None); // last row has no next
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn window_first_value() {
+        setup();
+        execute("CREATE TABLE wfirst (id int, dept text, salary int)").unwrap();
+        execute("INSERT INTO wfirst VALUES (1, 'eng', 100)").unwrap();
+        execute("INSERT INTO wfirst VALUES (2, 'eng', 200)").unwrap();
+        execute("INSERT INTO wfirst VALUES (3, 'sales', 300)").unwrap();
+        let r = execute(
+            "SELECT id, FIRST_VALUE(salary) OVER (PARTITION BY dept ORDER BY id) AS fv \
+             FROM wfirst ORDER BY id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 3);
+        assert_eq!(r.rows[0][1], Some("100".into())); // eng first
+        assert_eq!(r.rows[1][1], Some("100".into())); // eng first
+        assert_eq!(r.rows[2][1], Some("300".into())); // sales first
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn window_last_value() {
+        setup();
+        execute("CREATE TABLE wlast (id int, val int)").unwrap();
+        execute("INSERT INTO wlast VALUES (1, 10)").unwrap();
+        execute("INSERT INTO wlast VALUES (2, 20)").unwrap();
+        execute("INSERT INTO wlast VALUES (3, 30)").unwrap();
+        // Default frame: UNBOUNDED PRECEDING to CURRENT ROW
+        // So LAST_VALUE returns the current row's value
+        let r = execute(
+            "SELECT id, LAST_VALUE(val) OVER (ORDER BY id) AS lv FROM wlast ORDER BY id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 3);
+        assert_eq!(r.rows[0][1], Some("10".into()));
+        assert_eq!(r.rows[1][1], Some("20".into()));
+        assert_eq!(r.rows[2][1], Some("30".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn window_nth_value() {
+        setup();
+        execute("CREATE TABLE wnth (id int, val int)").unwrap();
+        execute("INSERT INTO wnth VALUES (1, 10)").unwrap();
+        execute("INSERT INTO wnth VALUES (2, 20)").unwrap();
+        execute("INSERT INTO wnth VALUES (3, 30)").unwrap();
+        let r = execute(
+            "SELECT id, NTH_VALUE(val, 2) OVER (ORDER BY id) AS nv FROM wnth ORDER BY id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 3);
+        // Frame: UNBOUNDED PRECEDING to CURRENT ROW
+        // Row 1: frame [1], 2nd value doesn't exist -> NULL
+        // Row 2: frame [1,2], 2nd value = 20
+        // Row 3: frame [1,2,3], 2nd value = 20
+        assert_eq!(r.rows[0][1], None);
+        assert_eq!(r.rows[1][1], Some("20".into()));
+        assert_eq!(r.rows[2][1], Some("20".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn window_lag_with_partition() {
+        setup();
+        execute("CREATE TABLE wlagp (id int, dept text, salary int)").unwrap();
+        execute("INSERT INTO wlagp VALUES (1, 'eng', 100)").unwrap();
+        execute("INSERT INTO wlagp VALUES (2, 'eng', 200)").unwrap();
+        execute("INSERT INTO wlagp VALUES (3, 'sales', 300)").unwrap();
+        let r = execute(
+            "SELECT id, dept, LAG(salary) OVER (PARTITION BY dept ORDER BY id) AS prev \
+             FROM wlagp ORDER BY id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 3);
+        assert_eq!(r.rows[0][2], None); // first in eng partition
+        assert_eq!(r.rows[1][2], Some("100".into())); // prev in eng
+        assert_eq!(r.rows[2][2], None); // first in sales partition
     }
 
 }

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -3428,6 +3428,16 @@ fn exec_select_raw_post_filter(
                         let fname = extract_func_name(fc);
                         let oid = match fname.as_str() {
                             "row_number" | "rank" | "dense_rank" | "ntile" => TypeOid::Int8.oid(),
+                            "lag" | "lead" | "first_value" | "last_value" | "nth_value" => {
+                                fc.args.first()
+                                    .and_then(|a| a.node.as_ref())
+                                    .and_then(|node| match node {
+                                        NodeEnum::ColumnRef(cref) => resolve_column(cref, &merged_ctx).ok(),
+                                        _ => None,
+                                    })
+                                    .and_then(|idx| column_type_oid(idx, &merged_ctx).ok())
+                                    .unwrap_or(TypeOid::Text.oid())
+                            }
                             _ => TypeOid::Text.oid(),
                         };
                         return Ok((name.clone(), oid));
@@ -6808,8 +6818,8 @@ mod tests {
         execute("INSERT INTO wlast VALUES (1, 10)").unwrap();
         execute("INSERT INTO wlast VALUES (2, 20)").unwrap();
         execute("INSERT INTO wlast VALUES (3, 30)").unwrap();
-        // Default frame: UNBOUNDED PRECEDING to CURRENT ROW
-        // So LAST_VALUE returns the current row's value
+        // Default frame: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        // No peers (unique ORDER BY values), so LAST_VALUE = current row
         let r = execute(
             "SELECT id, LAST_VALUE(val) OVER (ORDER BY id) AS lv FROM wlast ORDER BY id",
         ).unwrap();
@@ -6817,6 +6827,27 @@ mod tests {
         assert_eq!(r.rows[0][1], Some("10".into()));
         assert_eq!(r.rows[1][1], Some("20".into()));
         assert_eq!(r.rows[2][1], Some("30".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn window_last_value_peers() {
+        setup();
+        execute("CREATE TABLE wlastp (id int, val int)").unwrap();
+        execute("INSERT INTO wlastp VALUES (1, 10)").unwrap();
+        execute("INSERT INTO wlastp VALUES (2, 20)").unwrap();
+        execute("INSERT INTO wlastp VALUES (3, 20)").unwrap();
+        execute("INSERT INTO wlastp VALUES (4, 30)").unwrap();
+        // RANGE frame: peers with val=20 (id=2,3) share frame end
+        // LAST_VALUE for id=2 and id=3 should both be id=3's value (20)
+        let r = execute(
+            "SELECT id, LAST_VALUE(id) OVER (ORDER BY val) AS lv FROM wlastp ORDER BY id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 4);
+        assert_eq!(r.rows[0][1], Some("1".into())); // val=10, no peers, last=self
+        assert_eq!(r.rows[1][1], Some("3".into())); // val=20, peer group [2,3], last=3
+        assert_eq!(r.rows[2][1], Some("3".into())); // val=20, peer group [2,3], last=3
+        assert_eq!(r.rows[3][1], Some("4".into())); // val=30, no peers, last=self
     }
 
     #[test]

--- a/native/engine/src/window.rs
+++ b/native/engine/src/window.rs
@@ -245,7 +245,7 @@ pub(crate) fn evaluate_window_functions(
                     compute_ranking(&wt.kind, partition, &wt.spec.sort_keys, rows, arena, wf_idx, &mut results);
                 }
                 _ => {
-                    compute_value(&wt.kind, partition, rows, ctx, arena, wf_idx, &mut results)?;
+                    compute_value(&wt.kind, partition, &wt.spec.sort_keys, rows, ctx, arena, wf_idx, &mut results)?;
                 }
             }
         }
@@ -319,11 +319,36 @@ fn compute_ranking(
     }
 }
 
+/// Find the last peer position for RANGE frame semantics.
+/// Peers are rows with equal ORDER BY values.
+fn last_peer_pos(
+    pos: usize,
+    partition: &[usize],
+    sort_keys: &[SortKey],
+    rows: &[Vec<ArenaValue>],
+    arena: &QueryArena,
+) -> usize {
+    if sort_keys.is_empty() {
+        return partition.len() - 1;
+    }
+    let mut end = pos;
+    while end + 1 < partition.len() {
+        if compare_rows(sort_keys, &rows[partition[pos]], &rows[partition[end + 1]], arena)
+            != std::cmp::Ordering::Equal
+        {
+            break;
+        }
+        end += 1;
+    }
+    end
+}
+
 /// Compute value function results (LAG, LEAD, FIRST_VALUE, LAST_VALUE, NTH_VALUE)
 /// for one partition.
 fn compute_value(
     kind: &WindowFuncKind,
     partition: &[usize],
+    sort_keys: &[SortKey],
     rows: &[Vec<ArenaValue>],
     ctx: &JoinContext,
     arena: &mut QueryArena,
@@ -372,19 +397,22 @@ fn compute_value(
             }
         }
         WindowFuncKind::LastValue { expr } => {
-            // Default frame: UNBOUNDED PRECEDING to CURRENT ROW
-            // LAST_VALUE returns the value at the current row position
+            // Default frame: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            // In RANGE mode, CURRENT ROW means the last peer row
             for (pos, &row_idx) in partition.iter().enumerate() {
-                let current_row = partition[pos];
-                let val = eval_expr(expr, &rows[current_row], ctx, arena)?;
+                let peer_end = last_peer_pos(pos, partition, sort_keys, rows, arena);
+                let target_row = partition[peer_end];
+                let val = eval_expr(expr, &rows[target_row], ctx, arena)?;
                 results[row_idx][wf_idx] = val;
             }
         }
         WindowFuncKind::NthValue { expr, n } => {
-            // Default frame: UNBOUNDED PRECEDING to CURRENT ROW
+            // Default frame: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            // In RANGE mode, frame end is the last peer row
             let target_pos = (*n - 1) as usize; // 1-indexed to 0-indexed
             for (pos, &row_idx) in partition.iter().enumerate() {
-                let val = if target_pos <= pos {
+                let peer_end = last_peer_pos(pos, partition, sort_keys, rows, arena);
+                let val = if target_pos <= peer_end {
                     let target_row = partition[target_pos];
                     eval_expr(expr, &rows[target_row], ctx, arena)?
                 } else {

--- a/native/engine/src/window.rs
+++ b/native/engine/src/window.rs
@@ -5,7 +5,8 @@ use pg_query::NodeEnum;
 
 use crate::arena::{ArenaValue, QueryArena};
 use crate::executor::{
-    JoinContext, SortKey, compare_rows, eval_const_i64, extract_func_name, resolve_column,
+    JoinContext, SortKey, compare_rows, eval_const_i64, eval_expr, extract_func_name,
+    resolve_column,
 };
 
 pub(crate) struct WindowSpec {
@@ -18,6 +19,11 @@ pub(crate) enum WindowFuncKind {
     Rank,
     DenseRank,
     Ntile(i64),
+    Lag { expr: NodeEnum, offset: i64, default: Option<NodeEnum> },
+    Lead { expr: NodeEnum, offset: i64, default: Option<NodeEnum> },
+    FirstValue { expr: NodeEnum },
+    LastValue { expr: NodeEnum },
+    NthValue { expr: NodeEnum, n: i64 },
 }
 
 pub(crate) struct WindowTarget {
@@ -93,6 +99,52 @@ pub(crate) fn extract_window_targets(
                                 return Err("NTILE argument must be positive".into());
                             }
                             WindowFuncKind::Ntile(n)
+                        }
+                        "lag" | "lead" => {
+                            let expr_node = fc.args.first()
+                                .and_then(|a| a.node.as_ref())
+                                .ok_or("LAG/LEAD requires an expression argument")?
+                                .clone();
+                            let offset = fc.args.get(1)
+                                .and_then(|a| a.node.as_ref())
+                                .and_then(|n| eval_const_i64(Some(n)))
+                                .unwrap_or(1);
+                            let default = fc.args.get(2)
+                                .and_then(|a| a.node.as_ref())
+                                .cloned();
+                            if name == "lag" {
+                                WindowFuncKind::Lag { expr: expr_node, offset, default }
+                            } else {
+                                WindowFuncKind::Lead { expr: expr_node, offset, default }
+                            }
+                        }
+                        "first_value" => {
+                            let expr_node = fc.args.first()
+                                .and_then(|a| a.node.as_ref())
+                                .ok_or("FIRST_VALUE requires an expression argument")?
+                                .clone();
+                            WindowFuncKind::FirstValue { expr: expr_node }
+                        }
+                        "last_value" => {
+                            let expr_node = fc.args.first()
+                                .and_then(|a| a.node.as_ref())
+                                .ok_or("LAST_VALUE requires an expression argument")?
+                                .clone();
+                            WindowFuncKind::LastValue { expr: expr_node }
+                        }
+                        "nth_value" => {
+                            let expr_node = fc.args.first()
+                                .and_then(|a| a.node.as_ref())
+                                .ok_or("NTH_VALUE requires an expression argument")?
+                                .clone();
+                            let n = fc.args.get(1)
+                                .and_then(|a| a.node.as_ref())
+                                .and_then(|n| eval_const_i64(Some(n)))
+                                .ok_or("NTH_VALUE requires an integer second argument")?;
+                            if n <= 0 {
+                                return Err("NTH_VALUE argument must be positive".into());
+                            }
+                            WindowFuncKind::NthValue { expr: expr_node, n }
                         }
                         _ => {
                             let _ = arena;
@@ -174,7 +226,8 @@ fn sort_partition(
 pub(crate) fn evaluate_window_functions(
     targets: &[WindowTarget],
     rows: &[Vec<ArenaValue>],
-    arena: &QueryArena,
+    ctx: &JoinContext,
+    arena: &mut QueryArena,
 ) -> Result<Vec<Vec<ArenaValue>>, String> {
     let n = rows.len();
     let m = targets.len();
@@ -184,7 +237,17 @@ pub(crate) fn evaluate_window_functions(
         let mut partitions = partition_rows(rows, &wt.spec.partition_keys, arena);
         for partition in &mut partitions {
             sort_partition(partition, &wt.spec.sort_keys, rows, arena);
-            compute_ranking(&wt.kind, partition, &wt.spec.sort_keys, rows, arena, wf_idx, &mut results);
+            match &wt.kind {
+                WindowFuncKind::RowNumber
+                | WindowFuncKind::Rank
+                | WindowFuncKind::DenseRank
+                | WindowFuncKind::Ntile(_) => {
+                    compute_ranking(&wt.kind, partition, &wt.spec.sort_keys, rows, arena, wf_idx, &mut results);
+                }
+                _ => {
+                    compute_value(&wt.kind, partition, rows, ctx, arena, wf_idx, &mut results)?;
+                }
+            }
         }
     }
 
@@ -241,7 +304,6 @@ fn compute_ranking(
             let base_size = plen / n;
             let extra = plen % n;
             let mut bucket = 1usize;
-            let mut count = 0usize;
             let bucket_size = if extra > 0 { base_size + 1 } else { base_size };
             let mut threshold = bucket_size;
             for (pos, &row_idx) in partition.iter().enumerate() {
@@ -251,9 +313,87 @@ fn compute_ranking(
                     threshold += bs;
                 }
                 results[row_idx][wf_idx] = ArenaValue::Int(bucket as i64);
-                count = pos + 1;
             }
-            let _ = count;
         }
+        _ => {}
     }
+}
+
+/// Compute value function results (LAG, LEAD, FIRST_VALUE, LAST_VALUE, NTH_VALUE)
+/// for one partition.
+fn compute_value(
+    kind: &WindowFuncKind,
+    partition: &[usize],
+    rows: &[Vec<ArenaValue>],
+    ctx: &JoinContext,
+    arena: &mut QueryArena,
+    wf_idx: usize,
+    results: &mut [Vec<ArenaValue>],
+) -> Result<(), String> {
+    match kind {
+        WindowFuncKind::Lag { expr, offset, default } => {
+            for (pos, &row_idx) in partition.iter().enumerate() {
+                let target_pos = pos as i64 - offset;
+                let val = if target_pos >= 0 && (target_pos as usize) < partition.len() {
+                    let target_row = partition[target_pos as usize];
+                    eval_expr(expr, &rows[target_row], ctx, arena)?
+                } else if let Some(def_expr) = default {
+                    eval_expr(def_expr, &rows[row_idx], ctx, arena)?
+                } else {
+                    ArenaValue::Null
+                };
+                results[row_idx][wf_idx] = val;
+            }
+        }
+        WindowFuncKind::Lead { expr, offset, default } => {
+            for (pos, &row_idx) in partition.iter().enumerate() {
+                let target_pos = pos as i64 + offset;
+                let val = if target_pos >= 0 && (target_pos as usize) < partition.len() {
+                    let target_row = partition[target_pos as usize];
+                    eval_expr(expr, &rows[target_row], ctx, arena)?
+                } else if let Some(def_expr) = default {
+                    eval_expr(def_expr, &rows[row_idx], ctx, arena)?
+                } else {
+                    ArenaValue::Null
+                };
+                results[row_idx][wf_idx] = val;
+            }
+        }
+        WindowFuncKind::FirstValue { expr } => {
+            if partition.is_empty() {
+                return Ok(());
+            }
+            // Default frame: UNBOUNDED PRECEDING to CURRENT ROW
+            // FIRST_VALUE always returns the first row in the frame
+            let first_row = partition[0];
+            let val = eval_expr(expr, &rows[first_row], ctx, arena)?;
+            for &row_idx in partition {
+                results[row_idx][wf_idx] = val;
+            }
+        }
+        WindowFuncKind::LastValue { expr } => {
+            // Default frame: UNBOUNDED PRECEDING to CURRENT ROW
+            // LAST_VALUE returns the value at the current row position
+            for (pos, &row_idx) in partition.iter().enumerate() {
+                let current_row = partition[pos];
+                let val = eval_expr(expr, &rows[current_row], ctx, arena)?;
+                results[row_idx][wf_idx] = val;
+            }
+        }
+        WindowFuncKind::NthValue { expr, n } => {
+            // Default frame: UNBOUNDED PRECEDING to CURRENT ROW
+            let target_pos = (*n - 1) as usize; // 1-indexed to 0-indexed
+            for (pos, &row_idx) in partition.iter().enumerate() {
+                let val = if target_pos <= pos {
+                    let target_row = partition[target_pos];
+                    eval_expr(expr, &rows[target_row], ctx, arena)?
+                } else {
+                    ArenaValue::Null
+                };
+                results[row_idx][wf_idx] = val;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- Add 5 value window functions: LAG, LEAD, FIRST_VALUE, LAST_VALUE, NTH_VALUE
- LAG/LEAD support optional offset and default arguments
- Frame-aware: FIRST_VALUE/LAST_VALUE/NTH_VALUE use default frame (UNBOUNDED PRECEDING to CURRENT ROW)
- Make eval_expr pub(crate) for expression evaluation in window.rs
- 8 new tests, 207 total passing

## Functions

| Function | Description | Example |
|----------|-------------|---------|
| LAG(expr [, offset [, default]]) | Value N rows before current | LAG(salary, 1, 0) |
| LEAD(expr [, offset [, default]]) | Value N rows after current | LEAD(salary) |
| FIRST_VALUE(expr) | First value in frame | FIRST_VALUE(salary) |
| LAST_VALUE(expr) | Current row value (default frame) | LAST_VALUE(salary) |
| NTH_VALUE(expr, n) | Nth value in frame (1-indexed) | NTH_VALUE(salary, 2) |

## Test plan

- [x] LAG basic (previous row value)
- [x] LAG with offset=2
- [x] LAG with default value
- [x] LAG with PARTITION BY
- [x] LEAD basic (next row value)
- [x] FIRST_VALUE with partitions
- [x] LAST_VALUE (default frame behavior)
- [x] NTH_VALUE (frame-aware, NULL before nth row)
- [x] All 199 existing tests still pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
