### PR TITLE
feat: aggregate window functions - SUM, COUNT, AVG, MIN, MAX OVER

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ Currently supported:
 - Subqueries: IN, EXISTS, scalar, ALL, derived tables (correlated supported)
 - Expressions: arithmetic (+ - * / %), comparison, boolean logic, IS NULL, LIKE, ILIKE, CASE WHEN, COALESCE, NULLIF
 - Aggregates: COUNT, SUM, AVG, MIN, MAX, STRING_AGG, BOOL_AND, BOOL_OR (with DISTINCT support)
-- Window functions: ROW_NUMBER, RANK, DENSE_RANK, NTILE, LAG, LEAD, FIRST_VALUE, LAST_VALUE, NTH_VALUE
+- Window functions: ROW_NUMBER, RANK, DENSE_RANK, NTILE, LAG, LEAD, FIRST_VALUE, LAST_VALUE, NTH_VALUE, SUM/COUNT/AVG/MIN/MAX OVER
 - String functions: upper, lower, length, concat, substring, trim, replace, position, left, right
 - Math functions: abs, ceil, floor, round, mod, power, sqrt
 - Sequence functions: nextval, currval, setval

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -135,7 +135,7 @@ Each feature is categorized by priority tier and assigned to a layer (BEAM or Ru
 - [ ] LATERAL joins (PG 9.3)
 - [x] Window functions (ranking) — ROW_NUMBER, RANK, DENSE_RANK, NTILE with PARTITION BY + ORDER BY (PG 8.4)
 - [x] Window functions (value) — LAG, LEAD, FIRST_VALUE, LAST_VALUE, NTH_VALUE (PG 8.4)
-- [ ] Window functions (aggregate) — SUM/COUNT/AVG/MIN/MAX OVER (...) (PG 8.4)
+- [x] Window functions (aggregate) — SUM/COUNT/AVG/MIN/MAX OVER (...) (PG 8.4)
 - [ ] Window RANGE/GROUPS modes, frame exclusion (PG 11)
 - [ ] GROUPING SETS, CUBE, ROLLUP (PG 9.5)
 - [ ] FETCH FIRST ... WITH TIES (PG 13)

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -3428,7 +3428,8 @@ fn exec_select_raw_post_filter(
                         let fname = extract_func_name(fc);
                         let oid = match fname.as_str() {
                             "row_number" | "rank" | "dense_rank" | "ntile" => TypeOid::Int8.oid(),
-                            "lag" | "lead" | "first_value" | "last_value" | "nth_value" => {
+                            "lag" | "lead" | "first_value" | "last_value" | "nth_value"
+                            | "sum" | "min" | "max" => {
                                 fc.args.first()
                                     .and_then(|a| a.node.as_ref())
                                     .and_then(|node| match node {
@@ -3438,6 +3439,8 @@ fn exec_select_raw_post_filter(
                                     .and_then(|idx| column_type_oid(idx, &merged_ctx).ok())
                                     .unwrap_or(TypeOid::Text.oid())
                             }
+                            "count" => TypeOid::Int8.oid(),
+                            "avg" => TypeOid::Float8.oid(),
                             _ => TypeOid::Text.oid(),
                         };
                         return Ok((name.clone(), oid));
@@ -6887,6 +6890,136 @@ mod tests {
         assert_eq!(r.rows[0][2], None); // first in eng partition
         assert_eq!(r.rows[1][2], Some("100".into())); // prev in eng
         assert_eq!(r.rows[2][2], None); // first in sales partition
+    }
+
+    // ---- Aggregate window function tests ----
+
+    #[test]
+    #[serial_test::serial]
+    fn window_sum_over() {
+        setup();
+        execute("CREATE TABLE wsum (id int, val int)").unwrap();
+        execute("INSERT INTO wsum VALUES (1, 10)").unwrap();
+        execute("INSERT INTO wsum VALUES (2, 20)").unwrap();
+        execute("INSERT INTO wsum VALUES (3, 30)").unwrap();
+        let r = execute(
+            "SELECT id, val, SUM(val) OVER (ORDER BY id) AS running_sum FROM wsum ORDER BY id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 3);
+        assert_eq!(r.rows[0][2], Some("10".into()));
+        assert_eq!(r.rows[1][2], Some("30".into()));
+        assert_eq!(r.rows[2][2], Some("60".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn window_count_over() {
+        setup();
+        execute("CREATE TABLE wcnt (id int, val int)").unwrap();
+        execute("INSERT INTO wcnt VALUES (1, 10)").unwrap();
+        execute("INSERT INTO wcnt VALUES (2, 20)").unwrap();
+        execute("INSERT INTO wcnt VALUES (3, 30)").unwrap();
+        let r = execute(
+            "SELECT id, COUNT(*) OVER (ORDER BY id) AS running_count FROM wcnt ORDER BY id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 3);
+        assert_eq!(r.rows[0][1], Some("1".into()));
+        assert_eq!(r.rows[1][1], Some("2".into()));
+        assert_eq!(r.rows[2][1], Some("3".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn window_avg_over() {
+        setup();
+        execute("CREATE TABLE wavg (id int, val int)").unwrap();
+        execute("INSERT INTO wavg VALUES (1, 10)").unwrap();
+        execute("INSERT INTO wavg VALUES (2, 20)").unwrap();
+        execute("INSERT INTO wavg VALUES (3, 30)").unwrap();
+        let r = execute(
+            "SELECT id, AVG(val) OVER (ORDER BY id) AS running_avg FROM wavg ORDER BY id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 3);
+        assert_eq!(r.rows[0][1], Some("10".into()));
+        assert_eq!(r.rows[1][1], Some("15".into()));
+        assert_eq!(r.rows[2][1], Some("20".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn window_min_max_over() {
+        setup();
+        execute("CREATE TABLE wmm (id int, val int)").unwrap();
+        execute("INSERT INTO wmm VALUES (1, 30)").unwrap();
+        execute("INSERT INTO wmm VALUES (2, 10)").unwrap();
+        execute("INSERT INTO wmm VALUES (3, 20)").unwrap();
+        let r = execute(
+            "SELECT id, MIN(val) OVER (ORDER BY id) AS rmin, \
+             MAX(val) OVER (ORDER BY id) AS rmax FROM wmm ORDER BY id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 3);
+        // Running min: 30, min(30,10)=10, min(30,10,20)=10
+        assert_eq!(r.rows[0][1], Some("30".into()));
+        assert_eq!(r.rows[1][1], Some("10".into()));
+        assert_eq!(r.rows[2][1], Some("10".into()));
+        // Running max: 30, max(30,10)=30, max(30,10,20)=30
+        assert_eq!(r.rows[0][2], Some("30".into()));
+        assert_eq!(r.rows[1][2], Some("30".into()));
+        assert_eq!(r.rows[2][2], Some("30".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn window_sum_partition() {
+        setup();
+        execute("CREATE TABLE wsump (id int, dept text, salary int)").unwrap();
+        execute("INSERT INTO wsump VALUES (1, 'eng', 100)").unwrap();
+        execute("INSERT INTO wsump VALUES (2, 'eng', 200)").unwrap();
+        execute("INSERT INTO wsump VALUES (3, 'sales', 300)").unwrap();
+        let r = execute(
+            "SELECT id, dept, SUM(salary) OVER (PARTITION BY dept ORDER BY id) AS rsum \
+             FROM wsump ORDER BY id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 3);
+        assert_eq!(r.rows[0][2], Some("100".into())); // eng: 100
+        assert_eq!(r.rows[1][2], Some("300".into())); // eng: 100+200
+        assert_eq!(r.rows[2][2], Some("300".into())); // sales: 300
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn window_sum_no_order() {
+        setup();
+        execute("CREATE TABLE wsumno (id int, val int)").unwrap();
+        execute("INSERT INTO wsumno VALUES (1, 10)").unwrap();
+        execute("INSERT INTO wsumno VALUES (2, 20)").unwrap();
+        execute("INSERT INTO wsumno VALUES (3, 30)").unwrap();
+        // No ORDER BY means all rows are peers -> total sum for all rows
+        let r = execute(
+            "SELECT id, SUM(val) OVER () AS total FROM wsumno ORDER BY id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 3);
+        assert_eq!(r.rows[0][1], Some("60".into()));
+        assert_eq!(r.rows[1][1], Some("60".into()));
+        assert_eq!(r.rows[2][1], Some("60".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn window_count_column() {
+        setup();
+        execute("CREATE TABLE wcntc (id int, val int)").unwrap();
+        execute("INSERT INTO wcntc VALUES (1, 10)").unwrap();
+        execute("INSERT INTO wcntc VALUES (2, NULL)").unwrap();
+        execute("INSERT INTO wcntc VALUES (3, 30)").unwrap();
+        // COUNT(val) skips NULLs
+        let r = execute(
+            "SELECT id, COUNT(val) OVER (ORDER BY id) AS cnt FROM wcntc ORDER BY id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 3);
+        assert_eq!(r.rows[0][1], Some("1".into()));
+        assert_eq!(r.rows[1][1], Some("1".into())); // NULL skipped
+        assert_eq!(r.rows[2][1], Some("2".into()));
     }
 
 }

--- a/native/engine/src/window.rs
+++ b/native/engine/src/window.rs
@@ -24,6 +24,7 @@ pub(crate) enum WindowFuncKind {
     FirstValue { expr: NodeEnum },
     LastValue { expr: NodeEnum },
     NthValue { expr: NodeEnum, n: i64 },
+    AggregateOver { name: String, expr: Option<NodeEnum>, agg_star: bool },
 }
 
 pub(crate) struct WindowTarget {
@@ -146,6 +147,16 @@ pub(crate) fn extract_window_targets(
                             }
                             WindowFuncKind::NthValue { expr: expr_node, n }
                         }
+                        "count" | "sum" | "avg" | "min" | "max" => {
+                            let expr_node = fc.args.first()
+                                .and_then(|a| a.node.as_ref())
+                                .cloned();
+                            WindowFuncKind::AggregateOver {
+                                name: name.clone(),
+                                expr: expr_node,
+                                agg_star: fc.agg_star,
+                            }
+                        }
                         _ => {
                             let _ = arena;
                             return Err(format!(
@@ -243,6 +254,9 @@ pub(crate) fn evaluate_window_functions(
                 | WindowFuncKind::DenseRank
                 | WindowFuncKind::Ntile(_) => {
                     compute_ranking(&wt.kind, partition, &wt.spec.sort_keys, rows, arena, wf_idx, &mut results);
+                }
+                WindowFuncKind::AggregateOver { .. } => {
+                    compute_aggregate_window(&wt.kind, partition, &wt.spec.sort_keys, rows, ctx, arena, wf_idx, &mut results)?;
                 }
                 _ => {
                     compute_value(&wt.kind, partition, &wt.spec.sort_keys, rows, ctx, arena, wf_idx, &mut results)?;
@@ -424,4 +438,121 @@ fn compute_value(
         _ => {}
     }
     Ok(())
+}
+
+/// Compute aggregate window function (SUM/COUNT/AVG/MIN/MAX OVER).
+/// Uses default RANGE frame: UNBOUNDED PRECEDING to CURRENT ROW with peer groups.
+fn compute_aggregate_window(
+    kind: &WindowFuncKind,
+    partition: &[usize],
+    sort_keys: &[SortKey],
+    rows: &[Vec<ArenaValue>],
+    ctx: &JoinContext,
+    arena: &mut QueryArena,
+    wf_idx: usize,
+    results: &mut [Vec<ArenaValue>],
+) -> Result<(), String> {
+    let (name, expr, agg_star) = match kind {
+        WindowFuncKind::AggregateOver { name, expr, agg_star } => (name.as_str(), expr, *agg_star),
+        _ => return Ok(()),
+    };
+
+    // Evaluate expressions for all rows in partition order
+    let vals: Vec<ArenaValue> = if agg_star {
+        vec![ArenaValue::Int(1); partition.len()]
+    } else if let Some(expr_node) = expr {
+        let mut v = Vec::with_capacity(partition.len());
+        for &row_idx in partition.iter() {
+            v.push(eval_expr(expr_node, &rows[row_idx], ctx, arena)?);
+        }
+        v
+    } else {
+        return Err(format!("{} requires an argument", name.to_uppercase()));
+    };
+
+    // Compute running aggregate with RANGE peer group handling.
+    // All peers share the same accumulated value (inclusive of all peers).
+    let mut pos = 0usize;
+    while pos < partition.len() {
+        let peer_end = last_peer_pos(pos, partition, sort_keys, rows, arena);
+        // Frame: all values from 0..=peer_end
+        let frame_vals = &vals[0..=peer_end];
+        let agg_val = compute_frame_aggregate(name, frame_vals, arena)?;
+        for i in pos..=peer_end {
+            results[partition[i]][wf_idx] = agg_val;
+        }
+        pos = peer_end + 1;
+    }
+
+    Ok(())
+}
+
+/// Compute an aggregate over a frame slice of pre-evaluated values.
+fn compute_frame_aggregate(
+    name: &str,
+    vals: &[ArenaValue],
+    arena: &QueryArena,
+) -> Result<ArenaValue, String> {
+    match name {
+        "count" => {
+            let count = vals.iter().filter(|v| !v.is_null()).count();
+            Ok(ArenaValue::Int(count as i64))
+        }
+        "sum" => {
+            let mut si: i64 = 0;
+            let mut sf: f64 = 0.0;
+            let mut is_float = false;
+            let mut any = false;
+            for v in vals {
+                match v {
+                    ArenaValue::Int(n) => { si = si.wrapping_add(*n); any = true; }
+                    ArenaValue::Float(f) => { sf += f; is_float = true; any = true; }
+                    ArenaValue::Null => {}
+                    _ => return Err("SUM requires numeric input".into()),
+                }
+            }
+            if !any { return Ok(ArenaValue::Null); }
+            Ok(if is_float { ArenaValue::Float(sf + si as f64) } else { ArenaValue::Int(si) })
+        }
+        "avg" => {
+            let mut sum: f64 = 0.0;
+            let mut count: i64 = 0;
+            for v in vals {
+                match v {
+                    ArenaValue::Int(n) => { sum += *n as f64; count += 1; }
+                    ArenaValue::Float(f) => { sum += f; count += 1; }
+                    ArenaValue::Null => {}
+                    _ => return Err("AVG requires numeric input".into()),
+                }
+            }
+            if count == 0 { Ok(ArenaValue::Null) } else { Ok(ArenaValue::Float(sum / count as f64)) }
+        }
+        "min" => {
+            let mut best: Option<ArenaValue> = None;
+            for v in vals {
+                if v.is_null() { continue; }
+                best = Some(match best {
+                    None => *v,
+                    Some(cur) => {
+                        if v.compare(&cur, arena) == Some(std::cmp::Ordering::Less) { *v } else { cur }
+                    }
+                });
+            }
+            Ok(best.unwrap_or(ArenaValue::Null))
+        }
+        "max" => {
+            let mut best: Option<ArenaValue> = None;
+            for v in vals {
+                if v.is_null() { continue; }
+                best = Some(match best {
+                    None => *v,
+                    Some(cur) => {
+                        if v.compare(&cur, arena) == Some(std::cmp::Ordering::Greater) { *v } else { cur }
+                    }
+                });
+            }
+            Ok(best.unwrap_or(ArenaValue::Null))
+        }
+        _ => Err(format!("aggregate window function \"{}\" not supported", name)),
+    }
 }


### PR DESCRIPTION
## Summary

- Add aggregate-as-window functions: SUM, COUNT, AVG, MIN, MAX with OVER clause
- Running aggregates with RANGE frame semantics (peer groups share values)
- COUNT(*) and COUNT(expr) both supported, NULL-aware
- OID inference: COUNT -> int8, AVG -> float8, SUM/MIN/MAX -> argument type
- 7 new tests, 215 total passing

## Examples

```sql
-- Running sum
SELECT id, SUM(val) OVER (ORDER BY id) FROM t;

-- Running count (skips NULLs)
SELECT id, COUNT(val) OVER (ORDER BY id) FROM t;

-- Total per partition (no ORDER BY = all rows are peers)
SELECT dept, SUM(salary) OVER (PARTITION BY dept) FROM emp;

-- Running min/max
SELECT id, MIN(val) OVER (ORDER BY id), MAX(val) OVER (ORDER BY id) FROM t;
```

## Test plan

- [x] SUM running total (ORDER BY)
- [x] COUNT(*) running count
- [x] AVG running average
- [x] MIN/MAX running min and max
- [x] SUM with PARTITION BY
- [x] SUM without ORDER BY (total for all rows)
- [x] COUNT(col) skips NULLs
- [x] All 208 existing tests still pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
