### PR TITLE
feat: Common Table Expressions (WITH) support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ Currently supported:
 - Expressions: arithmetic (+ - * / %), comparison, boolean logic, IS NULL, LIKE, ILIKE, CASE WHEN, COALESCE, NULLIF
 - Aggregates: COUNT, SUM, AVG, MIN, MAX, STRING_AGG, BOOL_AND, BOOL_OR (with DISTINCT support)
 - Window functions: ROW_NUMBER, RANK, DENSE_RANK, NTILE, LAG, LEAD, FIRST_VALUE, LAST_VALUE, NTH_VALUE, SUM/COUNT/AVG/MIN/MAX OVER
+- CTEs: WITH (non-recursive), column aliases, chained CTEs, CTE in subqueries
 - String functions: upper, lower, length, concat, substring, trim, replace, position, left, right
 - Math functions: abs, ceil, floor, round, mod, power, sqrt
 - Sequence functions: nextval, currval, setval

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -128,7 +128,7 @@ Each feature is categorized by priority tier and assigned to a layer (BEAM or Ru
 - [ ] UNION / INTERSECT / EXCEPT (and ALL variants)
 - [ ] GROUP BY / HAVING
 - [ ] DISTINCT / DISTINCT ON
-- [ ] Common Table Expressions — WITH (PG 8.4)
+- [x] Common Table Expressions — WITH (PG 8.4)
 - [ ] WITH RECURSIVE (PG 8.4)
 - [ ] Data-modifying CTEs (PG 9.1)
 - [ ] CTE inlining — MATERIALIZED / NOT MATERIALIZED (PG 12)

--- a/native/engine/src/arena.rs
+++ b/native/engine/src/arena.rs
@@ -4,14 +4,23 @@
 //! ArenaValue is Copy (16 bytes) — no Arc, no Drop, no refcount.
 //! All memory freed at once when QueryArena drops.
 
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
+/// Materialized CTE result stored in the query arena.
+#[derive(Debug, Clone)]
+pub(crate) struct CteEntry {
+    pub columns: Vec<(String, i32)>,
+    pub rows: Vec<Vec<ArenaValue>>,
+}
+
 /// Per-query byte arena. Strings and vectors are packed contiguously.
-/// Created at query start, dropped at query end — single deallocation.
+/// Created at query start, dropped at query end - single deallocation.
 #[derive(Debug)]
 pub struct QueryArena {
     bytes: Vec<u8>,
     floats: Vec<f32>,
+    pub(crate) cte_registry: HashMap<String, CteEntry>,
 }
 
 /// Reference to a string in the arena's byte buffer. 8 bytes, Copy.
@@ -47,6 +56,7 @@ impl QueryArena {
         Self {
             bytes: Vec::with_capacity(4096),
             floats: Vec::with_capacity(256),
+            cte_registry: HashMap::new(),
         }
     }
 
@@ -54,6 +64,7 @@ impl QueryArena {
         Self {
             bytes: Vec::with_capacity(bytes),
             floats: Vec::with_capacity(floats),
+            cte_registry: HashMap::new(),
         }
     }
 

--- a/native/engine/src/arena.rs
+++ b/native/engine/src/arena.rs
@@ -8,10 +8,12 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
 /// Materialized CTE result stored in the query arena.
+/// Uses Value (heap-allocated) instead of ArenaValue so CTE data is
+/// self-contained and independent of any arena's byte/float buffers.
 #[derive(Debug, Clone)]
 pub(crate) struct CteEntry {
     pub columns: Vec<(String, i32)>,
-    pub rows: Vec<Vec<ArenaValue>>,
+    pub rows: Vec<Vec<crate::types::Value>>,
 }
 
 /// Per-query byte arena. Strings and vectors are packed contiguously.

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -2556,6 +2556,35 @@ fn execute_from(node: &NodeEnum, arena: &mut QueryArena) -> Result<(Vec<Vec<Aren
                 .as_ref()
                 .map(|a| a.aliasname.clone())
                 .unwrap_or_else(|| rv.relname.clone());
+
+            // Check CTE registry first (CTEs shadow real tables per SQL standard)
+            if let Some(cte) = arena.cte_registry.get(&rv.relname) {
+                let rows = cte.rows.clone();
+                let columns: Vec<Column> = cte.columns.iter()
+                    .map(|(name, oid)| Column {
+                        name: name.clone(),
+                        type_oid: TypeOid::from_oid(*oid),
+                        nullable: true,
+                        primary_key: false,
+                        unique: false,
+                        default_expr: None,
+                    })
+                    .collect();
+                let ncols = columns.len();
+                let table_def = Table { name: alias.clone(), schema: String::new(), columns };
+                let ctx = JoinContext {
+                    sources: vec![JoinSource {
+                        alias,
+                        table_name: rv.relname.clone(),
+                        schema: String::new(),
+                        table_def,
+                        col_offset: 0,
+                    }],
+                    total_columns: ncols,
+                };
+                return Ok((rows, ctx));
+            }
+
             let schema = if rv.schemaname.is_empty() {
                 "public"
             } else {
@@ -3078,6 +3107,42 @@ fn exec_select_raw(
     outer: Option<(&[ArenaValue], &JoinContext)>,
     arena: &mut QueryArena,
 ) -> Result<(Vec<(String, i32)>, Vec<Vec<ArenaValue>>), String> {
+    // Execute CTEs before anything else (must be visible to all downstream paths)
+    if let Some(ref wc) = select.with_clause {
+        if wc.recursive {
+            return Err("WITH RECURSIVE is not yet supported".into());
+        }
+        for cte_node in &wc.ctes {
+            if let Some(NodeEnum::CommonTableExpr(cte)) = cte_node.node.as_ref() {
+                let inner = cte.ctequery.as_ref()
+                    .and_then(|n| n.node.as_ref())
+                    .ok_or("CTE missing query")?;
+                let NodeEnum::SelectStmt(sel) = inner else {
+                    return Err("data-modifying CTEs are not yet supported".into());
+                };
+                let (mut cols, rows) = exec_select_raw(sel, None, arena)?;
+                // Apply column aliases if specified
+                if !cte.aliascolnames.is_empty() {
+                    if cte.aliascolnames.len() != cols.len() {
+                        return Err(format!(
+                            "WITH query \"{}\" has {} columns but {} aliases specified",
+                            cte.ctename, cols.len(), cte.aliascolnames.len()
+                        ));
+                    }
+                    for (i, alias_node) in cte.aliascolnames.iter().enumerate() {
+                        if let Some(NodeEnum::String(s)) = alias_node.node.as_ref() {
+                            cols[i].0 = s.sval.clone();
+                        }
+                    }
+                }
+                arena.cte_registry.insert(
+                    cte.ctename.clone(),
+                    crate::arena::CteEntry { columns: cols, rows },
+                );
+            }
+        }
+    }
+
     // Handle UNION / INTERSECT / EXCEPT (set operations)
     let set_op = select.op;
     if set_op == pg_query::protobuf::SetOperation::SetopUnion as i32
@@ -3161,10 +3226,14 @@ fn exec_select_raw(
         return exec_select_raw_no_from(select, outer, arena);
     }
 
-    // Fast path: single-table query with no outer context — use scan_with
+    // Fast path: single-table query with no outer context - use scan_with
     // to filter inside the lock and clone only matching rows.
+    // Skip fast path if the table name matches a CTE (CTEs have no storage backing).
     if select.from_clause.len() == 1 && outer.is_none() {
         if let Some(NodeEnum::RangeVar(rv)) = select.from_clause[0].node.as_ref() {
+            if arena.cte_registry.contains_key(&rv.relname) {
+                // Fall through to general path which handles CTE lookup in execute_from
+            } else {
             let schema = if rv.schemaname.is_empty() { "public" } else { &rv.schemaname };
             let table_def = catalog::get_table(schema, &rv.relname)
                 .ok_or_else(|| format!("relation \"{}\" does not exist", rv.relname))?;
@@ -3259,6 +3328,7 @@ fn exec_select_raw(
                 } else {
                     // Single arena shared across all rows (not per-row).
                     let mut scan_arena = QueryArena::new();
+                    scan_arena.cte_registry = arena.cte_registry.clone();
                     for row in all_rows {
                         if eval_where_value(&select.where_clause, row, &ctx, &mut scan_arena)? {
                             filtered.push(row.clone());
@@ -3271,6 +3341,7 @@ fn exec_select_raw(
 
             let result = exec_select_raw_post_filter(select, ctx, rows, 0, arena);
             return result;
+        } // end else (not a CTE)
         }
     }
 
@@ -7020,6 +7091,165 @@ mod tests {
         assert_eq!(r.rows[0][1], Some("1".into()));
         assert_eq!(r.rows[1][1], Some("1".into())); // NULL skipped
         assert_eq!(r.rows[2][1], Some("2".into()));
+    }
+
+    // ---- CTE tests ----
+
+    #[test]
+    #[serial_test::serial]
+    fn cte_basic() {
+        setup();
+        let r = execute("WITH cte AS (SELECT 1 AS x) SELECT * FROM cte").unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][0], Some("1".into()));
+        assert_eq!(r.columns[0].0, "x");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cte_from_table() {
+        setup();
+        execute("CREATE TABLE cte_t (id int, name text)").unwrap();
+        execute("INSERT INTO cte_t VALUES (1, 'alice')").unwrap();
+        execute("INSERT INTO cte_t VALUES (2, 'bob')").unwrap();
+        let r = execute(
+            "WITH active AS (SELECT * FROM cte_t WHERE id = 1) SELECT * FROM active",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][1], Some("alice".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cte_with_where() {
+        setup();
+        execute("CREATE TABLE cte_w (id int, val int)").unwrap();
+        execute("INSERT INTO cte_w VALUES (1, 10)").unwrap();
+        execute("INSERT INTO cte_w VALUES (2, 20)").unwrap();
+        execute("INSERT INTO cte_w VALUES (3, 30)").unwrap();
+        let r = execute(
+            "WITH data AS (SELECT * FROM cte_w) SELECT * FROM data WHERE val > 15 ORDER BY id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 2);
+        assert_eq!(r.rows[0][0], Some("2".into()));
+        assert_eq!(r.rows[1][0], Some("3".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cte_multiple() {
+        setup();
+        let r = execute(
+            "WITH a AS (SELECT 1 AS x), b AS (SELECT 2 AS y) SELECT * FROM a, b",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][0], Some("1".into()));
+        assert_eq!(r.rows[0][1], Some("2".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cte_with_join() {
+        setup();
+        execute("CREATE TABLE cte_users (id int, name text)").unwrap();
+        execute("CREATE TABLE cte_orders (id int, user_id int, amount int)").unwrap();
+        execute("INSERT INTO cte_users VALUES (1, 'alice')").unwrap();
+        execute("INSERT INTO cte_orders VALUES (1, 1, 100)").unwrap();
+        let r = execute(
+            "WITH u AS (SELECT * FROM cte_users) \
+             SELECT u.name, o.amount FROM u JOIN cte_orders o ON u.id = o.user_id",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][0], Some("alice".into()));
+        assert_eq!(r.rows[0][1], Some("100".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cte_column_alias() {
+        setup();
+        execute("CREATE TABLE cte_ca (id int, name text)").unwrap();
+        execute("INSERT INTO cte_ca VALUES (1, 'alice')").unwrap();
+        let r = execute(
+            "WITH cte(x, y) AS (SELECT id, name FROM cte_ca) SELECT x, y FROM cte",
+        ).unwrap();
+        assert_eq!(r.columns[0].0, "x");
+        assert_eq!(r.columns[1].0, "y");
+        assert_eq!(r.rows[0][0], Some("1".into()));
+        assert_eq!(r.rows[0][1], Some("alice".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cte_referenced_twice() {
+        setup();
+        let r = execute(
+            "WITH nums AS (SELECT 1 AS n UNION ALL SELECT 2) \
+             SELECT a.n, b.n FROM nums a, nums b ORDER BY a.n, b.n",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 4); // 2x2 cross join
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cte_chained() {
+        setup();
+        let r = execute(
+            "WITH a AS (SELECT 1 AS x), b AS (SELECT x + 1 AS y FROM a) SELECT * FROM b",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][0], Some("2".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cte_shadows_table() {
+        setup();
+        execute("CREATE TABLE shadow_t (id int)").unwrap();
+        execute("INSERT INTO shadow_t VALUES (999)").unwrap();
+        // CTE named "shadow_t" should shadow the real table
+        let r = execute(
+            "WITH shadow_t AS (SELECT 1 AS id) SELECT * FROM shadow_t",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][0], Some("1".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cte_empty() {
+        setup();
+        execute("CREATE TABLE cte_e (id int)").unwrap();
+        let r = execute(
+            "WITH empty AS (SELECT * FROM cte_e) SELECT * FROM empty",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 0);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cte_in_subquery() {
+        setup();
+        execute("CREATE TABLE cte_sq (id int, val int)").unwrap();
+        execute("INSERT INTO cte_sq VALUES (1, 10)").unwrap();
+        execute("INSERT INTO cte_sq VALUES (2, 20)").unwrap();
+        let r = execute(
+            "WITH target_ids AS (SELECT 1 AS tid) \
+             SELECT * FROM cte_sq WHERE id IN (SELECT tid FROM target_ids)",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][0], Some("1".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cte_recursive_error() {
+        setup();
+        let r = execute(
+            "WITH RECURSIVE cte AS (SELECT 1 UNION ALL SELECT 1) SELECT * FROM cte",
+        );
+        assert!(r.is_err());
+        assert!(r.unwrap_err().contains("WITH RECURSIVE"));
     }
 
 }

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -2558,6 +2558,8 @@ fn execute_from(node: &NodeEnum, arena: &mut QueryArena) -> Result<(Vec<Vec<Aren
                 .unwrap_or_else(|| rv.relname.clone());
 
             // Check CTE registry first (CTEs shadow real tables per SQL standard)
+            // Only unqualified names - schema-qualified refs (e.g. public.foo) bypass CTEs
+            if rv.schemaname.is_empty() {
             if let Some(cte) = arena.cte_registry.get(&rv.relname) {
                 // Clone CTE data out before mutable arena borrow for rows_to_arena
                 let cte_value_rows = cte.rows.clone();
@@ -2587,6 +2589,7 @@ fn execute_from(node: &NodeEnum, arena: &mut QueryArena) -> Result<(Vec<Vec<Aren
                 };
                 return Ok((rows, ctx));
             }
+            } // end schema check for CTE
 
             let schema = if rv.schemaname.is_empty() {
                 "public"
@@ -3239,7 +3242,7 @@ fn exec_select_raw(
     // Skip fast path if the table name matches a CTE (CTEs have no storage backing).
     if select.from_clause.len() == 1 && outer.is_none() {
         if let Some(NodeEnum::RangeVar(rv)) = select.from_clause[0].node.as_ref() {
-            if arena.cte_registry.contains_key(&rv.relname) {
+            if rv.schemaname.is_empty() && arena.cte_registry.contains_key(&rv.relname) {
                 // Fall through to general path which handles CTE lookup in execute_from
             } else {
             let schema = if rv.schemaname.is_empty() { "public" } else { &rv.schemaname };

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -2559,7 +2559,8 @@ fn execute_from(node: &NodeEnum, arena: &mut QueryArena) -> Result<(Vec<Vec<Aren
 
             // Check CTE registry first (CTEs shadow real tables per SQL standard)
             if let Some(cte) = arena.cte_registry.get(&rv.relname) {
-                let rows = cte.rows.clone();
+                // Clone CTE data out before mutable arena borrow for rows_to_arena
+                let cte_value_rows = cte.rows.clone();
                 let columns: Vec<Column> = cte.columns.iter()
                     .map(|(name, oid)| Column {
                         name: name.clone(),
@@ -2570,6 +2571,8 @@ fn execute_from(node: &NodeEnum, arena: &mut QueryArena) -> Result<(Vec<Vec<Aren
                         default_expr: None,
                     })
                     .collect();
+                drop(cte); // release immutable borrow
+                let rows = rows_to_arena(&cte_value_rows, arena);
                 let ncols = columns.len();
                 let table_def = Table { name: alias.clone(), schema: String::new(), columns };
                 let ctx = JoinContext {
@@ -3135,9 +3138,14 @@ fn exec_select_raw(
                         }
                     }
                 }
+                // Convert ArenaValue rows to self-contained Value rows
+                // so CTE data is independent of this arena's buffers
+                let value_rows: Vec<Vec<Value>> = rows.iter()
+                    .map(|row| row.iter().map(|v| v.to_value(arena)).collect())
+                    .collect();
                 arena.cte_registry.insert(
                     cte.ctename.clone(),
-                    crate::arena::CteEntry { columns: cols, rows },
+                    crate::arena::CteEntry { columns: cols, rows: value_rows },
                 );
             }
         }
@@ -7239,6 +7247,23 @@ mod tests {
         ).unwrap();
         assert_eq!(r.rows.len(), 1);
         assert_eq!(r.rows[0][0], Some("1".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn cte_text_in_subquery() {
+        setup();
+        execute("CREATE TABLE cte_txt (id int, name text)").unwrap();
+        execute("INSERT INTO cte_txt VALUES (1, 'alice')").unwrap();
+        execute("INSERT INTO cte_txt VALUES (2, 'bob')").unwrap();
+        // CTE with text data referenced in WHERE subquery - tests that
+        // ArenaValue text offsets don't dangle across arena boundaries
+        let r = execute(
+            "WITH names AS (SELECT 'alice' AS n) \
+             SELECT * FROM cte_txt WHERE name IN (SELECT n FROM names)",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][1], Some("alice".into()));
     }
 
     #[test]

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -3113,6 +3113,28 @@ fn exec_select_raw(
     outer: Option<(&[ArenaValue], &JoinContext)>,
     arena: &mut QueryArena,
 ) -> Result<(Vec<(String, i32)>, Vec<Vec<ArenaValue>>), String> {
+    // Snapshot CTE registry so CTEs defined here don't leak to callers.
+    let cte_snapshot = if select.with_clause.is_some() {
+        Some(arena.cte_registry.clone())
+    } else {
+        None
+    };
+
+    let result = exec_select_raw_body(select, outer, arena);
+
+    // Restore CTE registry to prevent scope leakage
+    if let Some(snapshot) = cte_snapshot {
+        arena.cte_registry = snapshot;
+    }
+
+    result
+}
+
+fn exec_select_raw_body(
+    select: &pg_query::protobuf::SelectStmt,
+    outer: Option<(&[ArenaValue], &JoinContext)>,
+    arena: &mut QueryArena,
+) -> Result<(Vec<(String, i32)>, Vec<Vec<ArenaValue>>), String> {
     // Execute CTEs before anything else (must be visible to all downstream paths)
     if let Some(ref wc) = select.with_clause {
         if wc.recursive {


### PR DESCRIPTION
## Summary

- Add non-recursive CTE support (WITH ... AS ...)
- CTE registry stored in `QueryArena` - zero signature changes to existing functions
- CTEs automatically visible in subqueries, JOINs, and WHERE clauses
- 12 new tests, 227 total passing

## Design

CTE results are materialized into a `HashMap<String, CteEntry>` field on `QueryArena`. Since every function already takes `&mut QueryArena`, CTE visibility comes for free across the entire query execution pipeline - no parameter threading needed.

Key integration points:
- `exec_select_raw()`: extracts and executes CTEs before any other processing
- `execute_from()`: checks CTE registry before `catalog::get_table` (CTEs shadow real tables per SQL standard)
- Fast path: guarded to skip `storage::scan_with` for CTE references
- Scan arena: inherits CTE registry for WHERE subquery visibility

## Test plan

- [x] Basic CTE (`WITH cte AS (SELECT 1) SELECT * FROM cte`)
- [x] CTE from real table with WHERE filter
- [x] Outer query WHERE on CTE columns
- [x] Multiple CTEs in one query
- [x] CTE with JOIN
- [x] Column aliases (`WITH cte(x, y) AS (...)`)
- [x] CTE referenced twice (cross join)
- [x] Chained CTEs (b references a)
- [x] CTE shadows real table (CTE takes priority)
- [x] Empty CTE (0 rows)
- [x] CTE visible in IN subquery
- [x] WITH RECURSIVE errors cleanly
- [x] All 215 existing tests still pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
