### PR TITLE
feat: UPSERT - INSERT ... ON CONFLICT DO UPDATE/DO NOTHING

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ Currently supported:
 - Set operations: UNION, UNION ALL, INTERSECT, EXCEPT
 - JOINs: INNER, LEFT, RIGHT, FULL, CROSS, implicit (hash join for equi, nested loop for theta)
 - Subqueries: IN, EXISTS, scalar, ALL, derived tables (correlated supported)
+- UPSERT: INSERT ... ON CONFLICT DO NOTHING / DO UPDATE SET (with EXCLUDED pseudo-table)
 - Expressions: arithmetic (+ - * / %), comparison, boolean logic, IS NULL, LIKE, ILIKE, CASE WHEN, COALESCE, NULLIF
 - Aggregates: COUNT, SUM, AVG, MIN, MAX, STRING_AGG, BOOL_AND, BOOL_OR (with DISTINCT support)
 - Window functions: ROW_NUMBER, RANK, DENSE_RANK, NTILE, LAG, LEAD, FIRST_VALUE, LAST_VALUE, NTH_VALUE, SUM/COUNT/AVG/MIN/MAX OVER

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -115,7 +115,7 @@ Each feature is categorized by priority tier and assigned to a layer (BEAM or Ru
 - [ ] INSERT ... RETURNING (PG 8.2)
 - [ ] UPDATE ... RETURNING (PG 8.2)
 - [ ] DELETE ... RETURNING (PG 8.2)
-- [ ] UPSERT — INSERT ... ON CONFLICT DO UPDATE/NOTHING (PG 9.5)
+- [x] UPSERT — INSERT ... ON CONFLICT DO UPDATE/NOTHING (PG 9.5)
 - [ ] MERGE (PG 15)
 - [ ] Multi-row VALUES (PG 8.2)
 - [ ] COPY TO/FROM with CSV (PG 8.0)

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -874,7 +874,6 @@ fn exec_insert(
     // Atomic batch insert: validate ALL rows against existing data AND each other,
     // then insert all at once. If any row fails, nothing is committed. (#4)
     let (unique_checks, pk_cols) = build_unique_checks(&table_def);
-    let row_count = all_rows.len() as u64;
 
     // Auto-create HNSW index on first INSERT if table has a vector column
     let vector_col_idx = table_def
@@ -882,7 +881,6 @@ fn exec_insert(
         .iter()
         .position(|c| c.type_oid == crate::types::TypeOid::Vector);
     if let Some(col_idx) = vector_col_idx {
-        // Ensure index exists (no-op if already created)
         let _ = storage::ensure_hnsw_index(
             schema,
             table_name,
@@ -891,29 +889,57 @@ fn exec_insert(
         );
     }
 
-    let needs_row_copy = has_returning || vector_col_idx.is_some();
-    let inserted_rows = if needs_row_copy { all_rows.clone() } else { Vec::new() };
+    // ON CONFLICT handling (UPSERT)
+    if let Some(ref oc) = insert.on_conflict_clause {
+        let do_update = oc.action == pg_query::protobuf::OnConflictAction::OnconflictUpdate as i32;
+        let set_clauses: Vec<(usize, NodeEnum)> = if do_update {
+            parse_on_conflict_set(&oc.target_list, &table_def)?
+        } else {
+            Vec::new()
+        };
+        let td_clone = table_def.clone();
 
-    let base_row_id = storage::insert_batch_checked(
-        schema, table_name, all_rows, &unique_checks, &pk_cols,
-    )?;
+        let (inserted, updated, affected_rows) = storage::insert_upsert(
+            schema, table_name, all_rows, &unique_checks, &pk_cols,
+            do_update,
+            |existing, excluded| {
+                apply_on_conflict_update(existing, excluded, &set_clauses, &td_clone)
+            },
+        )?;
 
-    // Insert vectors into HNSW index using the correct base_row_id from inside the write lock
-    if let Some(col_idx) = vector_col_idx {
-        if storage::has_hnsw_index(schema, table_name).is_some() {
-            for (i, row) in inserted_rows.iter().enumerate() {
-                if let Some(crate::types::Value::Vector(v)) = row.get(col_idx) {
-                    let _ = storage::hnsw_insert(schema, table_name, base_row_id + i, v.clone());
+        let total = inserted + updated;
+        let tag = format!("INSERT 0 {}", total);
+        if has_returning {
+            eval_returning(&insert.returning_list, &affected_rows, &table_def, schema, table_name, &tag)
+        } else {
+            Ok(QueryResult { tag, columns: vec![], rows: vec![] })
+        }
+    } else {
+        // Standard INSERT (no ON CONFLICT)
+        let row_count = all_rows.len() as u64;
+        let needs_row_copy = has_returning || vector_col_idx.is_some();
+        let inserted_rows = if needs_row_copy { all_rows.clone() } else { Vec::new() };
+
+        let base_row_id = storage::insert_batch_checked(
+            schema, table_name, all_rows, &unique_checks, &pk_cols,
+        )?;
+
+        if let Some(col_idx) = vector_col_idx {
+            if storage::has_hnsw_index(schema, table_name).is_some() {
+                for (i, row) in inserted_rows.iter().enumerate() {
+                    if let Some(crate::types::Value::Vector(v)) = row.get(col_idx) {
+                        let _ = storage::hnsw_insert(schema, table_name, base_row_id + i, v.clone());
+                    }
                 }
             }
         }
-    }
 
-    let tag = format!("INSERT 0 {}", row_count);
-    if has_returning {
-        eval_returning(&insert.returning_list, &inserted_rows, &table_def, schema, table_name, &tag)
-    } else {
-        Ok(QueryResult { tag, columns: vec![], rows: vec![] })
+        let tag = format!("INSERT 0 {}", row_count);
+        if has_returning {
+            eval_returning(&insert.returning_list, &inserted_rows, &table_def, schema, table_name, &tag)
+        } else {
+            Ok(QueryResult { tag, columns: vec![], rows: vec![] })
+        }
     }
 }
 
@@ -970,6 +996,85 @@ fn build_unique_checks(table: &Table) -> (Vec<(usize, String)>, Vec<usize>) {
     }
 
     (unique_checks, pk_cols)
+}
+
+/// Parse ON CONFLICT DO UPDATE SET clauses into (col_idx, expr) pairs.
+fn parse_on_conflict_set(
+    target_list: &[pg_query::protobuf::Node],
+    table: &Table,
+) -> Result<Vec<(usize, NodeEnum)>, String> {
+    let mut result = Vec::new();
+    for node in target_list {
+        if let Some(NodeEnum::ResTarget(rt)) = node.node.as_ref() {
+            let col_idx = table.columns.iter()
+                .position(|c| c.name == rt.name)
+                .ok_or_else(|| format!("column \"{}\" does not exist", rt.name))?;
+            let expr = rt.val.as_ref()
+                .and_then(|v| v.node.as_ref())
+                .ok_or("ON CONFLICT SET missing value expression")?
+                .clone();
+            result.push((col_idx, expr));
+        }
+    }
+    Ok(result)
+}
+
+/// Apply ON CONFLICT DO UPDATE SET assignments.
+/// Handles EXCLUDED pseudo-table references by substituting with the proposed row values.
+fn apply_on_conflict_update(
+    existing: &[Value],
+    excluded: &[Value],
+    set_clauses: &[(usize, NodeEnum)],
+    table: &Table,
+) -> Result<Vec<Value>, String> {
+    let mut new_row = existing.to_vec();
+    let ncols = table.columns.len();
+
+    // Build a combined row: [existing_cols..., excluded_cols...]
+    // so that column references to EXCLUDED.col resolve to offset ncols + col_idx
+    let mut combined: Vec<Value> = existing.to_vec();
+    combined.extend_from_slice(excluded);
+
+    // Build a JoinContext with two sources: the table and EXCLUDED
+    let table_cols: Vec<Column> = table.columns.clone();
+    let excluded_cols: Vec<Column> = table.columns.iter()
+        .map(|c| Column { name: c.name.clone(), ..c.clone() })
+        .collect();
+    let excluded_table = Table {
+        name: "excluded".into(),
+        schema: String::new(),
+        columns: excluded_cols,
+    };
+    let ctx = JoinContext {
+        sources: vec![
+            JoinSource {
+                alias: table.name.clone(),
+                table_name: table.name.clone(),
+                schema: table.schema.clone(),
+                table_def: Table { columns: table_cols, ..table.clone() },
+                col_offset: 0,
+            },
+            JoinSource {
+                alias: "excluded".into(),
+                table_name: "excluded".into(),
+                schema: String::new(),
+                table_def: excluded_table,
+                col_offset: ncols,
+            },
+        ],
+        total_columns: ncols * 2,
+    };
+
+    let mut arena = QueryArena::new();
+    let arena_row = crate::arena::rows_to_arena(&[combined], &mut arena);
+    let arena_combined = &arena_row[0];
+
+    for &(col_idx, ref expr) in set_clauses {
+        let val = eval_expr(expr, arena_combined, &ctx, &mut arena)?;
+        new_row[col_idx] = val.to_value(&arena);
+    }
+
+    Ok(new_row)
 }
 
 /// Validate uniqueness of `new_row` against `all_rows`, excluding row at `skip_idx`.
@@ -7300,6 +7405,135 @@ mod tests {
         );
         assert!(r.is_err());
         assert!(r.unwrap_err().contains("WITH RECURSIVE"));
+    }
+
+    // ---- UPSERT tests ----
+
+    #[test]
+    #[serial_test::serial]
+    fn upsert_do_nothing() {
+        setup();
+        execute("CREATE TABLE udn (id int PRIMARY KEY, name text)").unwrap();
+        execute("INSERT INTO udn VALUES (1, 'alice')").unwrap();
+        // Conflicting insert should be silently skipped
+        let r = execute("INSERT INTO udn VALUES (1, 'bob') ON CONFLICT DO NOTHING").unwrap();
+        assert_eq!(r.tag, "INSERT 0 0");
+        // Original row unchanged
+        let r = execute("SELECT * FROM udn").unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][1], Some("alice".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn upsert_do_nothing_no_conflict() {
+        setup();
+        execute("CREATE TABLE udnn (id int PRIMARY KEY, name text)").unwrap();
+        execute("INSERT INTO udnn VALUES (1, 'alice')").unwrap();
+        // No conflict - should insert normally
+        let r = execute("INSERT INTO udnn VALUES (2, 'bob') ON CONFLICT DO NOTHING").unwrap();
+        assert_eq!(r.tag, "INSERT 0 1");
+        let r = execute("SELECT * FROM udnn ORDER BY id").unwrap();
+        assert_eq!(r.rows.len(), 2);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn upsert_do_update() {
+        setup();
+        execute("CREATE TABLE udu (id int PRIMARY KEY, name text, val int)").unwrap();
+        execute("INSERT INTO udu VALUES (1, 'alice', 10)").unwrap();
+        let r = execute(
+            "INSERT INTO udu VALUES (1, 'bob', 20) \
+             ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, val = EXCLUDED.val",
+        ).unwrap();
+        assert_eq!(r.tag, "INSERT 0 1");
+        let r = execute("SELECT * FROM udu").unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][1], Some("bob".into()));
+        assert_eq!(r.rows[0][2], Some("20".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn upsert_do_update_partial() {
+        setup();
+        execute("CREATE TABLE udup (id int PRIMARY KEY, name text, val int)").unwrap();
+        execute("INSERT INTO udup VALUES (1, 'alice', 10)").unwrap();
+        // Only update val, keep existing name
+        let r = execute(
+            "INSERT INTO udup VALUES (1, 'bob', 20) \
+             ON CONFLICT (id) DO UPDATE SET val = EXCLUDED.val",
+        ).unwrap();
+        assert_eq!(r.tag, "INSERT 0 1");
+        let r = execute("SELECT * FROM udup").unwrap();
+        assert_eq!(r.rows[0][1], Some("alice".into())); // unchanged
+        assert_eq!(r.rows[0][2], Some("20".into()));    // updated
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn upsert_do_update_expression() {
+        setup();
+        execute("CREATE TABLE udue (id int PRIMARY KEY, counter int)").unwrap();
+        execute("INSERT INTO udue VALUES (1, 10)").unwrap();
+        // Increment counter using existing value + excluded value
+        let r = execute(
+            "INSERT INTO udue VALUES (1, 5) \
+             ON CONFLICT (id) DO UPDATE SET counter = udue.counter + EXCLUDED.counter",
+        ).unwrap();
+        assert_eq!(r.tag, "INSERT 0 1");
+        let r = execute("SELECT * FROM udue").unwrap();
+        assert_eq!(r.rows[0][1], Some("15".into())); // 10 + 5
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn upsert_batch_mixed() {
+        setup();
+        execute("CREATE TABLE ubm (id int PRIMARY KEY, val int)").unwrap();
+        execute("INSERT INTO ubm VALUES (1, 10)").unwrap();
+        // Batch: id=1 conflicts (update), id=2 is new (insert)
+        let r = execute(
+            "INSERT INTO ubm VALUES (1, 100), (2, 200) \
+             ON CONFLICT (id) DO UPDATE SET val = EXCLUDED.val",
+        ).unwrap();
+        assert_eq!(r.tag, "INSERT 0 2");
+        let r = execute("SELECT * FROM ubm ORDER BY id").unwrap();
+        assert_eq!(r.rows.len(), 2);
+        assert_eq!(r.rows[0][1], Some("100".into())); // updated
+        assert_eq!(r.rows[1][1], Some("200".into())); // inserted
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn upsert_unique_constraint() {
+        setup();
+        execute("CREATE TABLE uuc (id int, email text UNIQUE, name text)").unwrap();
+        execute("INSERT INTO uuc VALUES (1, 'a@b.com', 'alice')").unwrap();
+        let r = execute(
+            "INSERT INTO uuc VALUES (2, 'a@b.com', 'bob') ON CONFLICT DO NOTHING",
+        ).unwrap();
+        assert_eq!(r.tag, "INSERT 0 0");
+        let r = execute("SELECT * FROM uuc").unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][2], Some("alice".into()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn upsert_returning() {
+        setup();
+        execute("CREATE TABLE ur (id int PRIMARY KEY, val int)").unwrap();
+        execute("INSERT INTO ur VALUES (1, 10)").unwrap();
+        let r = execute(
+            "INSERT INTO ur VALUES (1, 20) \
+             ON CONFLICT (id) DO UPDATE SET val = EXCLUDED.val \
+             RETURNING id, val",
+        ).unwrap();
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0][0], Some("1".into()));
+        assert_eq!(r.rows[0][1], Some("20".into()));
     }
 
 }

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -897,11 +897,17 @@ fn exec_insert(
         } else {
             Vec::new()
         };
+        // Parse conflict target columns from InferClause
+        let conflict_cols: Vec<usize> = if let Some(ref infer) = oc.infer {
+            parse_conflict_columns(&infer.index_elems, &table_def)?
+        } else {
+            Vec::new() // empty = check all unique/PK constraints
+        };
         let td_clone = table_def.clone();
 
         let (inserted, updated, affected_rows) = storage::insert_upsert(
             schema, table_name, all_rows, &unique_checks, &pk_cols,
-            do_update,
+            &conflict_cols, do_update,
             |existing, excluded| {
                 apply_on_conflict_update(existing, excluded, &set_clauses, &td_clone)
             },
@@ -996,6 +1002,23 @@ fn build_unique_checks(table: &Table) -> (Vec<(usize, String)>, Vec<usize>) {
     }
 
     (unique_checks, pk_cols)
+}
+
+/// Parse ON CONFLICT (col1, col2) conflict target into column indices.
+fn parse_conflict_columns(
+    index_elems: &[pg_query::protobuf::Node],
+    table: &Table,
+) -> Result<Vec<usize>, String> {
+    let mut cols = Vec::new();
+    for elem in index_elems {
+        if let Some(NodeEnum::IndexElem(ie)) = elem.node.as_ref() {
+            let col_idx = table.columns.iter()
+                .position(|c| c.name == ie.name)
+                .ok_or_else(|| format!("column \"{}\" does not exist", ie.name))?;
+            cols.push(col_idx);
+        }
+    }
+    Ok(cols)
 }
 
 /// Parse ON CONFLICT DO UPDATE SET clauses into (col_idx, expr) pairs.

--- a/native/engine/src/executor.rs
+++ b/native/engine/src/executor.rs
@@ -1074,6 +1074,7 @@ fn apply_on_conflict_update(
         new_row[col_idx] = val.to_value(&arena);
     }
 
+    check_not_null(table, &new_row)?;
     Ok(new_row)
 }
 

--- a/native/engine/src/storage.rs
+++ b/native/engine/src/storage.rs
@@ -19,13 +19,13 @@ type Row = Vec<Value>;
 
 struct TableStore {
     rows: Vec<Row>,
-    /// Hash indexes for unique constraints: column_index -> set of values.
-    /// O(1) constraint checks instead of O(N) full table scan.
-    unique_indexes: HashMap<usize, HashSet<Value>>,
+    /// Hash indexes for unique constraints: column_index -> value -> row_index.
+    /// O(1) constraint checks and O(1) conflicting row lookup.
+    unique_indexes: HashMap<usize, HashMap<Value, usize>>,
     /// Composite PK column indices (stored for index rebuild).
     pk_cols: Vec<usize>,
-    /// Composite PK index: set of composite key tuples.
-    pk_index: Option<HashSet<Vec<Value>>>,
+    /// Composite PK index: composite key -> row_index.
+    pk_index: Option<HashMap<Vec<Value>, usize>>,
     /// Optional HNSW index for vector KNN queries.
     hnsw_index: Option<HnswIndex>,
 }
@@ -62,10 +62,10 @@ pub fn create_table(schema: &str, name: &str) {
 pub fn add_unique_index(schema: &str, name: &str, col_idx: usize) -> Result<(), String> {
     let tbl = get_table(schema, name)?;
     let mut table = tbl.write();
-    let mut idx = HashSet::new();
-    for row in &table.rows {
+    let mut idx = HashMap::new();
+    for (row_idx, row) in table.rows.iter().enumerate() {
         if col_idx < row.len() && !matches!(row[col_idx], Value::Null) {
-            idx.insert(row[col_idx].clone());
+            idx.insert(row[col_idx].clone(), row_idx);
         }
     }
     table.unique_indexes.insert(col_idx, idx);
@@ -76,10 +76,10 @@ pub fn add_unique_index(schema: &str, name: &str, col_idx: usize) -> Result<(), 
 pub fn add_pk_index(schema: &str, name: &str, pk_cols: &[usize]) -> Result<(), String> {
     let tbl = get_table(schema, name)?;
     let mut table = tbl.write();
-    let mut idx = HashSet::new();
-    for row in &table.rows {
+    let mut idx = HashMap::new();
+    for (row_idx, row) in table.rows.iter().enumerate() {
         let key: Vec<Value> = pk_cols.iter().map(|&i| row[i].clone()).collect();
-        idx.insert(key);
+        idx.insert(key, row_idx);
     }
     table.pk_cols = pk_cols.to_vec();
     table.pk_index = Some(idx);
@@ -175,16 +175,16 @@ pub fn delete_where_returning(
 // ── Index maintenance helpers ─────────────────────────────────────────
 
 /// Add a row's values to all applicable indexes.
-fn add_to_indexes(table: &mut TableStore, row: &Row) {
+fn add_to_indexes(table: &mut TableStore, row: &Row, row_idx: usize) {
     for (&col_idx, idx) in table.unique_indexes.iter_mut() {
         if col_idx < row.len() && !matches!(row[col_idx], Value::Null) {
-            idx.insert(row[col_idx].clone());
+            idx.insert(row[col_idx].clone(), row_idx);
         }
     }
     if table.pk_cols.len() > 1 {
         if let Some(pk_idx) = &mut table.pk_index {
             let key: Vec<Value> = table.pk_cols.iter().map(|&i| row[i].clone()).collect();
-            pk_idx.insert(key);
+            pk_idx.insert(key, row_idx);
         }
     }
 }
@@ -194,17 +194,17 @@ fn add_to_indexes(table: &mut TableStore, row: &Row) {
 fn rebuild_indexes(table: &mut TableStore) {
     for (&col_idx, idx) in table.unique_indexes.iter_mut() {
         idx.clear();
-        for row in &table.rows {
+        for (row_idx, row) in table.rows.iter().enumerate() {
             if col_idx < row.len() && !matches!(row[col_idx], Value::Null) {
-                idx.insert(row[col_idx].clone());
+                idx.insert(row[col_idx].clone(), row_idx);
             }
         }
     }
     if let Some(pk_idx) = &mut table.pk_index {
         pk_idx.clear();
-        for row in &table.rows {
+        for (row_idx, row) in table.rows.iter().enumerate() {
             let key: Vec<Value> = table.pk_cols.iter().map(|&i| row[i].clone()).collect();
-            pk_idx.insert(key);
+            pk_idx.insert(key, row_idx);
         }
     }
     // Rebuild HNSW index — row_ids are positional, so any row shift invalidates them
@@ -247,11 +247,11 @@ pub fn insert_checked(
         }
     }
 
-    // Composite PK check — O(1) via hash index
+    // Composite PK check - O(1) via hash index
     if pk_cols.len() > 1 {
         if let Some(ref pk_idx) = table.pk_index {
             let key: Vec<Value> = pk_cols.iter().map(|&i| row[i].clone()).collect();
-            if pk_idx.contains(&key) {
+            if pk_idx.contains_key(&key) {
                 return Err(format!(
                     "duplicate key value violates unique constraint \"{}.{}_pkey\"",
                     schema, name
@@ -260,13 +260,13 @@ pub fn insert_checked(
         }
     }
 
-    // Per-column unique checks — O(1) via hash index
+    // Per-column unique checks - O(1) via hash index
     for &(col_idx, ref cname) in unique_checks {
         if matches!(row[col_idx], Value::Null) {
             continue; // NULLs don't violate UNIQUE
         }
         if let Some(idx) = table.unique_indexes.get(&col_idx) {
-            if idx.contains(&row[col_idx]) {
+            if idx.contains_key(&row[col_idx]) {
                 return Err(format!(
                     "duplicate key value violates unique constraint \"{}\"",
                     cname
@@ -276,7 +276,8 @@ pub fn insert_checked(
     }
 
     // Update indexes after successful validation
-    add_to_indexes(&mut table, &row);
+    let row_idx = table.rows.len();
+    add_to_indexes(&mut table, &row, row_idx);
     table.rows.push(row);
     Ok(())
 }
@@ -309,11 +310,11 @@ pub fn insert_batch_checked(
             }
         }
 
-        // Composite PK check — O(1) against index + batch set
+        // Composite PK check - O(1) against index + batch set
         if pk_cols.len() > 1 {
             let key: Vec<Value> = pk_cols.iter().map(|&ci| row[ci].clone()).collect();
             if let Some(ref pk_idx) = table.pk_index {
-                if pk_idx.contains(&key) {
+                if pk_idx.contains_key(&key) {
                     return Err(format!(
                         "duplicate key value violates unique constraint \"{}.{}_pkey\"",
                         schema, name
@@ -328,13 +329,13 @@ pub fn insert_batch_checked(
             }
         }
 
-        // Per-column unique checks — O(1) against index + batch set
+        // Per-column unique checks - O(1) against index + batch set
         for &(col_idx, ref cname) in unique_checks {
             if matches!(row[col_idx], Value::Null) {
                 continue;
             }
             if let Some(idx) = table.unique_indexes.get(&col_idx) {
-                if idx.contains(&row[col_idx]) {
+                if idx.contains_key(&row[col_idx]) {
                     return Err(format!(
                         "duplicate key value violates unique constraint \"{}\"",
                         cname
@@ -351,26 +352,21 @@ pub fn insert_batch_checked(
         }
     }
 
-    // All validated — push all atomically and update indexes
+    // All validated - push all atomically and update indexes
     let base_row_id = table.rows.len();
-    for row in rows {
-        add_to_indexes(&mut table, &row);
+    for (i, row) in rows.into_iter().enumerate() {
+        add_to_indexes(&mut table, &row, base_row_id + i);
         table.rows.push(row);
     }
     Ok(base_row_id)
 }
 
-/// Result of an upsert operation for a single row.
-pub enum UpsertAction {
-    Inserted,
-    Updated(usize),  // index of the conflicting row that was updated
-    Skipped,         // DO NOTHING
-}
-
 /// Insert rows with ON CONFLICT handling. For each row:
-/// - If no conflict: insert normally
+/// - If no conflict on specified columns: insert normally
 /// - If conflict + DO NOTHING: skip
 /// - If conflict + DO UPDATE: call updater on conflicting row
+/// conflict_cols: column indices to check for conflicts (from ON CONFLICT (col) clause).
+/// If empty, checks all unique/PK constraints.
 /// Returns (inserted_count, updated_count, all affected rows for RETURNING).
 pub fn insert_upsert(
     schema: &str,
@@ -378,8 +374,9 @@ pub fn insert_upsert(
     rows: Vec<Row>,
     unique_checks: &[(usize, String)],
     pk_cols: &[usize],
+    conflict_cols: &[usize],
     do_update: bool,
-    mut updater: impl FnMut(&Row, &Row) -> Result<Row, String>, // (existing, excluded) -> new
+    mut updater: impl FnMut(&Row, &Row) -> Result<Row, String>,
 ) -> Result<(u64, u64, Vec<Row>), String> {
     let tbl = get_table(schema, name)?;
     let mut table = tbl.write();
@@ -389,26 +386,25 @@ pub fn insert_upsert(
     let mut affected_rows: Vec<Row> = Vec::new();
 
     for row in rows {
-        // Check for conflict against existing data
-        let conflict_idx = find_conflict(&table, &row, unique_checks, pk_cols);
+        let conflict_idx = find_conflict(&table, &row, unique_checks, pk_cols, conflict_cols);
 
         match conflict_idx {
             None => {
-                // No conflict: insert
+                let row_idx = table.rows.len();
                 affected_rows.push(row.clone());
-                add_to_indexes(&mut table, &row);
+                add_to_indexes(&mut table, &row, row_idx);
                 table.rows.push(row);
                 inserted += 1;
             }
             Some(idx) if do_update => {
-                // Conflict + DO UPDATE
                 let existing = &table.rows[idx];
                 let new_row = updater(existing, &row)?;
                 affected_rows.push(new_row.clone());
+                // Targeted index update: remove old values, set new row, add new values
+                remove_from_indexes(&mut table, idx);
                 table.rows[idx] = new_row;
-                // Rebuild indexes immediately so subsequent rows in this
-                // batch see up-to-date unique constraints
-                rebuild_indexes(&mut table);
+                let row_ref = table.rows[idx].clone();
+                add_to_indexes(&mut table, &row_ref, idx);
                 updated += 1;
             }
             Some(_) => {
@@ -417,42 +413,82 @@ pub fn insert_upsert(
         }
     }
 
-    // Rebuild indexes if any inserts occurred (for HNSW vector index)
-    if inserted > 0 {
-        rebuild_indexes(&mut table);
+    // Rebuild HNSW if any mutations (HNSW needs full rebuild since row positions matter)
+    if (inserted > 0 || updated > 0) && table.hnsw_index.is_some() {
+        rebuild_hnsw(&mut table);
     }
 
     Ok((inserted, updated, affected_rows))
 }
 
+/// Remove a row's values from unique/PK indexes (before update or delete).
+fn remove_from_indexes(table: &mut TableStore, row_idx: usize) {
+    let row = &table.rows[row_idx];
+    for (&col_idx, idx) in table.unique_indexes.iter_mut() {
+        if col_idx < row.len() && !matches!(row[col_idx], Value::Null) {
+            idx.remove(&row[col_idx]);
+        }
+    }
+    if table.pk_cols.len() > 1 {
+        if let Some(pk_idx) = &mut table.pk_index {
+            let key: Vec<Value> = table.pk_cols.iter().map(|&i| row[i].clone()).collect();
+            pk_idx.remove(&key);
+        }
+    }
+}
+
+/// Rebuild only the HNSW vector index (row positions are positional).
+fn rebuild_hnsw(table: &mut TableStore) {
+    if let Some(ref old_hnsw) = table.hnsw_index {
+        let col_idx = old_hnsw.col_idx();
+        let metric = old_hnsw.metric();
+        let mut new_hnsw = crate::hnsw::HnswIndex::new(metric, col_idx);
+        for (i, row) in table.rows.iter().enumerate() {
+            if col_idx < row.len() {
+                if let Value::Vector(v) = &row[col_idx] {
+                    new_hnsw.insert(i, v.clone());
+                }
+            }
+        }
+        table.hnsw_index = Some(new_hnsw);
+    }
+}
+
 /// Find the index of a conflicting row, if any.
+/// Uses O(1) hash index lookup for both detection and row position.
+/// conflict_cols: only check these columns. If empty, check all unique/PK.
 fn find_conflict(
     table: &TableStore,
     row: &Row,
     unique_checks: &[(usize, String)],
     pk_cols: &[usize],
+    conflict_cols: &[usize],
 ) -> Option<usize> {
-    // Check composite PK
+    // Check composite PK (only if conflict_cols is empty or matches PK)
     if pk_cols.len() > 1 {
-        let key: Vec<Value> = pk_cols.iter().map(|&ci| row[ci].clone()).collect();
-        if let Some(ref pk_idx) = table.pk_index {
-            if pk_idx.contains(&key) {
-                // Find the actual row index
-                return table.rows.iter().position(|r| {
-                    pk_cols.iter().all(|&ci| r[ci] == row[ci])
-                });
+        let pk_matches = conflict_cols.is_empty()
+            || conflict_cols.iter().all(|c| pk_cols.contains(c));
+        if pk_matches {
+            let key: Vec<Value> = pk_cols.iter().map(|&ci| row[ci].clone()).collect();
+            if let Some(ref pk_idx) = table.pk_index {
+                if let Some(&row_idx) = pk_idx.get(&key) {
+                    return Some(row_idx);
+                }
             }
         }
     }
 
-    // Check per-column unique constraints (including single-column PK)
+    // Check per-column unique constraints
     for &(col_idx, _) in unique_checks {
+        if !conflict_cols.is_empty() && !conflict_cols.contains(&col_idx) {
+            continue; // skip constraints not in the conflict target
+        }
         if matches!(row[col_idx], Value::Null) {
             continue;
         }
         if let Some(idx) = table.unique_indexes.get(&col_idx) {
-            if idx.contains(&row[col_idx]) {
-                return table.rows.iter().position(|r| r[col_idx] == row[col_idx]);
+            if let Some(&row_idx) = idx.get(&row[col_idx]) {
+                return Some(row_idx);
             }
         }
     }

--- a/native/engine/src/storage.rs
+++ b/native/engine/src/storage.rs
@@ -406,6 +406,9 @@ pub fn insert_upsert(
                 let new_row = updater(existing, &row)?;
                 affected_rows.push(new_row.clone());
                 table.rows[idx] = new_row;
+                // Rebuild indexes immediately so subsequent rows in this
+                // batch see up-to-date unique constraints
+                rebuild_indexes(&mut table);
                 updated += 1;
             }
             Some(_) => {
@@ -414,8 +417,8 @@ pub fn insert_upsert(
         }
     }
 
-    // Rebuild indexes after mutations
-    if updated > 0 {
+    // Rebuild indexes if any inserts occurred (for HNSW vector index)
+    if inserted > 0 {
         rebuild_indexes(&mut table);
     }
 

--- a/native/engine/src/storage.rs
+++ b/native/engine/src/storage.rs
@@ -360,6 +360,103 @@ pub fn insert_batch_checked(
     Ok(base_row_id)
 }
 
+/// Result of an upsert operation for a single row.
+pub enum UpsertAction {
+    Inserted,
+    Updated(usize),  // index of the conflicting row that was updated
+    Skipped,         // DO NOTHING
+}
+
+/// Insert rows with ON CONFLICT handling. For each row:
+/// - If no conflict: insert normally
+/// - If conflict + DO NOTHING: skip
+/// - If conflict + DO UPDATE: call updater on conflicting row
+/// Returns (inserted_count, updated_count, all affected rows for RETURNING).
+pub fn insert_upsert(
+    schema: &str,
+    name: &str,
+    rows: Vec<Row>,
+    unique_checks: &[(usize, String)],
+    pk_cols: &[usize],
+    do_update: bool,
+    mut updater: impl FnMut(&Row, &Row) -> Result<Row, String>, // (existing, excluded) -> new
+) -> Result<(u64, u64, Vec<Row>), String> {
+    let tbl = get_table(schema, name)?;
+    let mut table = tbl.write();
+
+    let mut inserted: u64 = 0;
+    let mut updated: u64 = 0;
+    let mut affected_rows: Vec<Row> = Vec::new();
+
+    for row in rows {
+        // Check for conflict against existing data
+        let conflict_idx = find_conflict(&table, &row, unique_checks, pk_cols);
+
+        match conflict_idx {
+            None => {
+                // No conflict: insert
+                affected_rows.push(row.clone());
+                add_to_indexes(&mut table, &row);
+                table.rows.push(row);
+                inserted += 1;
+            }
+            Some(idx) if do_update => {
+                // Conflict + DO UPDATE
+                let existing = &table.rows[idx];
+                let new_row = updater(existing, &row)?;
+                affected_rows.push(new_row.clone());
+                table.rows[idx] = new_row;
+                updated += 1;
+            }
+            Some(_) => {
+                // Conflict + DO NOTHING
+            }
+        }
+    }
+
+    // Rebuild indexes after mutations
+    if updated > 0 {
+        rebuild_indexes(&mut table);
+    }
+
+    Ok((inserted, updated, affected_rows))
+}
+
+/// Find the index of a conflicting row, if any.
+fn find_conflict(
+    table: &TableStore,
+    row: &Row,
+    unique_checks: &[(usize, String)],
+    pk_cols: &[usize],
+) -> Option<usize> {
+    // Check composite PK
+    if pk_cols.len() > 1 {
+        let key: Vec<Value> = pk_cols.iter().map(|&ci| row[ci].clone()).collect();
+        if let Some(ref pk_idx) = table.pk_index {
+            if pk_idx.contains(&key) {
+                // Find the actual row index
+                return table.rows.iter().position(|r| {
+                    pk_cols.iter().all(|&ci| r[ci] == row[ci])
+                });
+            }
+        }
+    }
+
+    // Check per-column unique constraints (including single-column PK)
+    for &(col_idx, _) in unique_checks {
+        if matches!(row[col_idx], Value::Null) {
+            continue;
+        }
+        if let Some(idx) = table.unique_indexes.get(&col_idx) {
+            if idx.contains(&row[col_idx]) {
+                return table.rows.iter().position(|r| r[col_idx] == row[col_idx]);
+            }
+        }
+    }
+
+    None
+}
+
 /// Update matching rows with validation. Returns error if any updater fails.
 /// Fixes: intra-batch uniqueness check (#3) and panic-safe atomic swap (#6).
 pub fn update_rows_checked(

--- a/native/engine/src/storage.rs
+++ b/native/engine/src/storage.rs
@@ -381,30 +381,52 @@ pub fn insert_upsert(
     let tbl = get_table(schema, name)?;
     let mut table = tbl.write();
 
+    // Atomic: work on a clone, swap only if all rows succeed
+    let mut working_rows = table.rows.clone();
+    let mut working_indexes = table.unique_indexes.clone();
+    let mut working_pk = table.pk_index.clone();
+    let pk_cols_vec = table.pk_cols.clone();
+
     let mut inserted: u64 = 0;
     let mut updated: u64 = 0;
     let mut affected_rows: Vec<Row> = Vec::new();
 
     for row in rows {
-        let conflict_idx = find_conflict(&table, &row, unique_checks, pk_cols, conflict_cols);
+        let conflict_idx = find_conflict_on(
+            &working_rows, &working_indexes, &working_pk, &pk_cols_vec,
+            &row, unique_checks, pk_cols, conflict_cols,
+        );
 
         match conflict_idx {
             None => {
-                let row_idx = table.rows.len();
+                // Validate ALL unique constraints before inserting (not just conflict target)
+                check_all_unique(
+                    &working_indexes, &working_pk, &pk_cols_vec,
+                    &row, unique_checks, pk_cols,
+                )?;
+                let row_idx = working_rows.len();
+                add_to_working_indexes(
+                    &mut working_indexes, &mut working_pk, &pk_cols_vec,
+                    &row, row_idx,
+                );
                 affected_rows.push(row.clone());
-                add_to_indexes(&mut table, &row, row_idx);
-                table.rows.push(row);
+                working_rows.push(row);
                 inserted += 1;
             }
             Some(idx) if do_update => {
-                let existing = &table.rows[idx];
+                let existing = &working_rows[idx];
                 let new_row = updater(existing, &row)?;
-                affected_rows.push(new_row.clone());
-                // Targeted index update: remove old values, set new row, add new values
-                remove_from_indexes(&mut table, idx);
-                table.rows[idx] = new_row;
-                let row_ref = table.rows[idx].clone();
-                add_to_indexes(&mut table, &row_ref, idx);
+                // Remove old values from working indexes
+                remove_from_working_indexes(
+                    &mut working_indexes, &mut working_pk, &pk_cols_vec,
+                    &working_rows[idx], idx,
+                );
+                working_rows[idx] = new_row.clone();
+                add_to_working_indexes(
+                    &mut working_indexes, &mut working_pk, &pk_cols_vec,
+                    &new_row, idx,
+                );
+                affected_rows.push(new_row);
                 updated += 1;
             }
             Some(_) => {
@@ -413,9 +435,15 @@ pub fn insert_upsert(
         }
     }
 
-    // Rebuild HNSW if any mutations (HNSW needs full rebuild since row positions matter)
-    if (inserted > 0 || updated > 0) && table.hnsw_index.is_some() {
-        rebuild_hnsw(&mut table);
+    // All rows succeeded - commit atomically
+    if inserted > 0 || updated > 0 {
+        table.rows = working_rows;
+        table.unique_indexes = working_indexes;
+        table.pk_index = working_pk;
+        // HNSW needs full rebuild since row positions matter
+        if table.hnsw_index.is_some() {
+            rebuild_hnsw(&mut table);
+        }
     }
 
     Ok((inserted, updated, affected_rows))
@@ -452,6 +480,115 @@ fn rebuild_hnsw(table: &mut TableStore) {
         }
         table.hnsw_index = Some(new_hnsw);
     }
+}
+
+/// Add a row's values to working (cloned) indexes.
+fn add_to_working_indexes(
+    unique_indexes: &mut HashMap<usize, HashMap<Value, usize>>,
+    pk_index: &mut Option<HashMap<Vec<Value>, usize>>,
+    pk_cols: &[usize],
+    row: &Row,
+    row_idx: usize,
+) {
+    for (&col_idx, idx) in unique_indexes.iter_mut() {
+        if col_idx < row.len() && !matches!(row[col_idx], Value::Null) {
+            idx.insert(row[col_idx].clone(), row_idx);
+        }
+    }
+    if pk_cols.len() > 1 {
+        if let Some(pk_idx) = pk_index {
+            let key: Vec<Value> = pk_cols.iter().map(|&i| row[i].clone()).collect();
+            pk_idx.insert(key, row_idx);
+        }
+    }
+}
+
+/// Remove a row's values from working (cloned) indexes.
+fn remove_from_working_indexes(
+    unique_indexes: &mut HashMap<usize, HashMap<Value, usize>>,
+    pk_index: &mut Option<HashMap<Vec<Value>, usize>>,
+    pk_cols: &[usize],
+    row: &Row,
+    _row_idx: usize,
+) {
+    for (&col_idx, idx) in unique_indexes.iter_mut() {
+        if col_idx < row.len() && !matches!(row[col_idx], Value::Null) {
+            idx.remove(&row[col_idx]);
+        }
+    }
+    if pk_cols.len() > 1 {
+        if let Some(pk_idx) = pk_index {
+            let key: Vec<Value> = pk_cols.iter().map(|&i| row[i].clone()).collect();
+            pk_idx.remove(&key);
+        }
+    }
+}
+
+/// Validate ALL unique constraints for a row (not filtered by conflict target).
+fn check_all_unique(
+    unique_indexes: &HashMap<usize, HashMap<Value, usize>>,
+    pk_index: &Option<HashMap<Vec<Value>, usize>>,
+    pk_cols: &[usize],
+    row: &Row,
+    unique_checks: &[(usize, String)],
+    all_pk_cols: &[usize],
+) -> Result<(), String> {
+    if all_pk_cols.len() > 1 {
+        let key: Vec<Value> = all_pk_cols.iter().map(|&ci| row[ci].clone()).collect();
+        if let Some(pk_idx) = pk_index {
+            if pk_idx.contains_key(&key) {
+                return Err("duplicate key value violates unique constraint (pkey)".into());
+            }
+        }
+    }
+    for &(col_idx, ref cname) in unique_checks {
+        if matches!(row[col_idx], Value::Null) { continue; }
+        if let Some(idx) = unique_indexes.get(&col_idx) {
+            if idx.contains_key(&row[col_idx]) {
+                return Err(format!(
+                    "duplicate key value violates unique constraint \"{}\"", cname
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Find conflict on working (cloned) state. O(1) via hash index.
+fn find_conflict_on(
+    _rows: &[Row],
+    unique_indexes: &HashMap<usize, HashMap<Value, usize>>,
+    pk_index: &Option<HashMap<Vec<Value>, usize>>,
+    pk_cols_vec: &[usize],
+    row: &Row,
+    unique_checks: &[(usize, String)],
+    pk_cols: &[usize],
+    conflict_cols: &[usize],
+) -> Option<usize> {
+    if pk_cols.len() > 1 {
+        let pk_matches = conflict_cols.is_empty()
+            || conflict_cols.iter().all(|c| pk_cols.contains(c));
+        if pk_matches {
+            let key: Vec<Value> = pk_cols_vec.iter().map(|&ci| row[ci].clone()).collect();
+            if let Some(pk_idx) = pk_index {
+                if let Some(&row_idx) = pk_idx.get(&key) {
+                    return Some(row_idx);
+                }
+            }
+        }
+    }
+    for &(col_idx, _) in unique_checks {
+        if !conflict_cols.is_empty() && !conflict_cols.contains(&col_idx) {
+            continue;
+        }
+        if matches!(row[col_idx], Value::Null) { continue; }
+        if let Some(idx) = unique_indexes.get(&col_idx) {
+            if let Some(&row_idx) = idx.get(&row[col_idx]) {
+                return Some(row_idx);
+            }
+        }
+    }
+    None
 }
 
 /// Find the index of a conflicting row, if any.


### PR DESCRIPTION
## Summary

- Add PostgreSQL-compatible UPSERT (INSERT ... ON CONFLICT)
- DO NOTHING: silently skip conflicting rows
- DO UPDATE SET: update conflicting row with new values
- EXCLUDED pseudo-table for referencing proposed insert values
- Works with PK and UNIQUE constraints
- New `storage::insert_upsert` with per-row conflict detection via hash indexes
- 8 new tests, 236 total passing

## Examples

```sql
-- Skip duplicates
INSERT INTO users VALUES (1, 'alice') ON CONFLICT DO NOTHING;

-- Update on conflict
INSERT INTO users VALUES (1, 'bob')
ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;

-- Increment counter
INSERT INTO stats VALUES (1, 5)
ON CONFLICT (id) DO UPDATE SET counter = stats.counter + EXCLUDED.counter;

-- Batch upsert
INSERT INTO kv VALUES (1, 'a'), (2, 'b'), (3, 'c')
ON CONFLICT (id) DO UPDATE SET val = EXCLUDED.val;
```

## Test plan

- [x] DO NOTHING skips conflicting row
- [x] DO NOTHING inserts non-conflicting row
- [x] DO UPDATE replaces all columns
- [x] DO UPDATE partial (only specified columns)
- [x] DO UPDATE with expression (existing + excluded)
- [x] Batch mixed insert/update
- [x] UNIQUE constraint conflict (not just PK)
- [x] RETURNING with upsert
- [x] All 228 existing tests still pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
