### PR TITLE
feat: LRU parse cache eviction

### DIFF
--- a/native/engine/Cargo.toml
+++ b/native/engine/Cargo.toml
@@ -14,6 +14,7 @@ pg_query = "6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 parking_lot = "0.12"
+lru = "0.12"
 
 [profile.release]
 strip = true

--- a/native/engine/src/executor/mod.rs
+++ b/native/engine/src/executor/mod.rs
@@ -64,8 +64,10 @@ pub fn execute(sql: &str) -> Result<QueryResult, String> {
         if let Some(cached) = cache.get(sql) {
             cached.clone()
         } else {
+            drop(cache); // release lock before expensive parse
             let parsed = pg_query::parse(sql).map_err(|e| e.to_string())?;
             let proto = parsed.protobuf;
+            let mut cache = PARSE_CACHE.lock();
             cache.put(sql.to_string(), proto.clone());
             proto
         }

--- a/native/engine/src/executor/mod.rs
+++ b/native/engine/src/executor/mod.rs
@@ -40,10 +40,11 @@ mod insert_conflict;
 mod delete;
 mod update;
 
-use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::sync::LazyLock;
 
-use parking_lot::RwLock;
+use lru::LruCache;
+use parking_lot::Mutex;
 use pg_query::NodeEnum;
 
 pub use types::QueryResult;
@@ -54,21 +55,18 @@ pub(crate) use helpers::eval_const_i64;
 pub(crate) use sort::compare_rows;
 
 const MAX_PARSE_CACHE: usize = 1024;
-static PARSE_CACHE: LazyLock<RwLock<HashMap<String, pg_query::protobuf::ParseResult>>> =
-    LazyLock::new(|| RwLock::new(HashMap::with_capacity(MAX_PARSE_CACHE)));
+static PARSE_CACHE: LazyLock<Mutex<LruCache<String, pg_query::protobuf::ParseResult>>> =
+    LazyLock::new(|| Mutex::new(LruCache::new(NonZeroUsize::new(MAX_PARSE_CACHE).unwrap())));
 
 pub fn execute(sql: &str) -> Result<QueryResult, String> {
     let protobuf = {
-        let cache = PARSE_CACHE.read();
+        let mut cache = PARSE_CACHE.lock();
         if let Some(cached) = cache.get(sql) {
             cached.clone()
         } else {
-            drop(cache);
             let parsed = pg_query::parse(sql).map_err(|e| e.to_string())?;
             let proto = parsed.protobuf;
-            let mut cache = PARSE_CACHE.write();
-            if cache.len() >= MAX_PARSE_CACHE { cache.clear(); }
-            cache.insert(sql.to_string(), proto.clone());
+            cache.put(sql.to_string(), proto.clone());
             proto
         }
     };


### PR DESCRIPTION
## Summary

- Replace parse cache `cache.clear()` on overflow with LRU eviction
- Add `lru` crate (0.12) for O(1) bounded cache with automatic eviction
- Switch from `RwLock<HashMap>` to `Mutex<LruCache>` (LRU needs mutable access on reads)
- Simpler code, better behavior under workloads with >1024 unique queries

## Before vs after

| | Before | After |
|---|---|---|
| At capacity | `cache.clear()` (nuke all 1024 entries) | Evict 1 least-recently-used entry |
| Cache miss after eviction | Cold start for all queries | Only evicted query re-parsed |
| Lock type | RwLock (read contention on miss) | Mutex (simpler, no RwLock benefit since LRU mutates on read) |

## Test plan

- [x] All 236 tests pass
- [x] No behavioral changes for queries under 1024 cache limit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
