### PR TITLE
feat: WAL foundation (PR 1/10) - entry, writer, reader

### DIFF
--- a/native/engine/Cargo.lock
+++ b/native/engine/Cargo.lock
@@ -12,10 +12,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bindgen"
@@ -89,6 +104,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +122,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 name = "engine"
 version = "0.1.0"
 dependencies = [
+ "bincode",
+ "crc32fast",
+ "lru",
  "parking_lot",
  "pg_query",
  "rustler",
@@ -212,6 +239,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -347,6 +376,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "memchr"

--- a/native/engine/Cargo.toml
+++ b/native/engine/Cargo.toml
@@ -15,6 +15,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 parking_lot = "0.12"
 lru = "0.12"
+bincode = "1.3"
+crc32fast = "1.4"
 
 [profile.release]
 strip = true

--- a/native/engine/src/lib.rs
+++ b/native/engine/src/lib.rs
@@ -6,6 +6,7 @@ mod parser;
 mod sequence;
 mod storage;
 mod types;
+mod wal;
 mod window;
 
 use rustler::{Encoder, Env, Term};

--- a/native/engine/src/wal/entry.rs
+++ b/native/engine/src/wal/entry.rs
@@ -1,0 +1,57 @@
+use serde::{Deserialize, Serialize};
+
+use crate::types::Value;
+use super::Lsn;
+
+/// A single WAL entry: a log sequence number + the operation it records.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WalEntry {
+    pub lsn: Lsn,
+    pub op: WalOp,
+}
+
+/// The operation recorded by a WAL entry.
+///
+/// Insert/Update/Delete target (schema, table). Commit and Checkpoint
+/// are control records. Recovery replays operations in LSN order into
+/// the memtable.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum WalOp {
+    Insert { schema: String, table: String, row: Vec<Value> },
+    Update { schema: String, table: String, row_id: u64, new_row: Vec<Value> },
+    Delete { schema: String, table: String, row_id: u64 },
+    /// Marks a transaction boundary for group commit.
+    Commit { txn_id: u64 },
+    /// Marks the LSN up to which a memtable flush has persisted data.
+    /// Entries with LSN <= this are safe to truncate.
+    Checkpoint { up_to: Lsn },
+}
+
+// Op tag byte used in the on-disk frame. Kept stable: never renumber.
+pub(super) const OP_INSERT: u8 = 1;
+pub(super) const OP_UPDATE: u8 = 2;
+pub(super) const OP_DELETE: u8 = 3;
+pub(super) const OP_COMMIT: u8 = 4;
+pub(super) const OP_CHECKPOINT: u8 = 5;
+
+impl WalOp {
+    pub(super) fn tag(&self) -> u8 {
+        match self {
+            WalOp::Insert { .. } => OP_INSERT,
+            WalOp::Update { .. } => OP_UPDATE,
+            WalOp::Delete { .. } => OP_DELETE,
+            WalOp::Commit { .. } => OP_COMMIT,
+            WalOp::Checkpoint { .. } => OP_CHECKPOINT,
+        }
+    }
+
+    /// Encode the operation payload using bincode.
+    pub(super) fn encode_payload(&self) -> Result<Vec<u8>, String> {
+        bincode::serialize(self).map_err(|e| format!("WAL encode: {}", e))
+    }
+
+    /// Decode an operation from its tag and payload bytes.
+    pub(super) fn decode(_tag: u8, payload: &[u8]) -> Result<WalOp, String> {
+        bincode::deserialize(payload).map_err(|e| format!("WAL decode: {}", e))
+    }
+}

--- a/native/engine/src/wal/mod.rs
+++ b/native/engine/src/wal/mod.rs
@@ -1,0 +1,31 @@
+//! Write-Ahead Log for crash recovery and durability.
+//!
+//! The WAL is an append-only file of serialized mutations. Every entry
+//! includes a CRC32 checksum so torn writes are detectable on recovery.
+//! The log is truncated when a memtable flush makes older entries
+//! redundant (PR 3+ wires this into storage).
+//!
+//! Durability contract: a write is durable once its entry is fsynced to
+//! the WAL. The writer batches entries into groups for fsync amortization
+//! (PR 8 refines this).
+//!
+//! Frame layout on disk:
+//! ```text
+//! [frame_len: u32] [lsn: u64] [op_tag: u8] [payload: bytes] [crc32: u32]
+//! ```
+//! `frame_len` counts bytes after itself (lsn + op_tag + payload + crc).
+//! `crc32` covers lsn + op_tag + payload.
+
+mod entry;
+mod writer;
+mod reader;
+
+#[cfg(test)]
+mod tests;
+
+pub use entry::{WalEntry, WalOp};
+pub use writer::WalWriter;
+pub use reader::WalReader;
+
+/// Log Sequence Number: monotonic u64, unique per WAL entry.
+pub type Lsn = u64;

--- a/native/engine/src/wal/reader.rs
+++ b/native/engine/src/wal/reader.rs
@@ -1,0 +1,78 @@
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::Path;
+
+use super::entry::WalOp;
+use super::{Lsn, WalEntry};
+
+/// Iterator over WAL entries on disk. Stops at the first torn/corrupt
+/// frame (common case: crash mid-write) so recovery gets all durable
+/// entries up to the damage point.
+pub struct WalReader {
+    reader: BufReader<File>,
+}
+
+impl WalReader {
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, String> {
+        let file = File::open(path.as_ref())
+            .map_err(|e| format!("WAL reader open: {}", e))?;
+        Ok(Self {
+            reader: BufReader::with_capacity(64 * 1024, file),
+        })
+    }
+
+    /// Read the next entry, or Ok(None) at clean EOF, or Err on
+    /// corruption beyond the durable prefix.
+    ///
+    /// Torn writes (partial frame at tail) are treated as EOF: the
+    /// caller should trust the last successfully-returned entry as the
+    /// durable frontier.
+    pub fn next_entry(&mut self) -> Result<Option<WalEntry>, String> {
+        // Read frame_len (4 bytes)
+        let mut len_buf = [0u8; 4];
+        match self.reader.read_exact(&mut len_buf) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+            Err(e) => return Err(format!("WAL read len: {}", e)),
+        }
+        let frame_len = u32::from_le_bytes(len_buf) as usize;
+        // Bound-check before allocating: torn writes can produce u32::MAX here
+        // which would OOM. 64MB is larger than any legitimate frame (vectors
+        // and rows are far smaller), so this safely rejects garbage.
+        const MAX_FRAME: usize = 64 * 1024 * 1024;
+        if frame_len < 8 + 1 + 4 || frame_len > MAX_FRAME {
+            return Ok(None); // malformed frame, treat as torn tail
+        }
+
+        let mut frame = vec![0u8; frame_len];
+        if let Err(e) = self.reader.read_exact(&mut frame) {
+            if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                return Ok(None); // torn write at tail
+            }
+            return Err(format!("WAL read frame: {}", e));
+        }
+
+        // Split: lsn(8) | tag(1) | payload | crc(4)
+        let payload_end = frame_len - 4;
+        let crc_stored = u32::from_le_bytes(frame[payload_end..].try_into().unwrap());
+        let crc_actual = crc32fast::hash(&frame[..payload_end]);
+        if crc_stored != crc_actual {
+            return Ok(None); // corrupt frame, treat as end of durable log
+        }
+
+        let lsn = Lsn::from_le_bytes(frame[0..8].try_into().unwrap());
+        let tag = frame[8];
+        let payload = &frame[9..payload_end];
+        let op = WalOp::decode(tag, payload)?;
+        Ok(Some(WalEntry { lsn, op }))
+    }
+
+    /// Collect all entries into a Vec. Convenience for recovery.
+    pub fn read_all(mut self) -> Result<Vec<WalEntry>, String> {
+        let mut entries = Vec::new();
+        while let Some(e) = self.next_entry()? {
+            entries.push(e);
+        }
+        Ok(entries)
+    }
+}

--- a/native/engine/src/wal/tests/basic.rs
+++ b/native/engine/src/wal/tests/basic.rs
@@ -1,0 +1,45 @@
+use super::super::*;
+use super::{insert_op, tmp_wal_path};
+
+#[test]
+fn append_and_read_single_entry() {
+    let path = tmp_wal_path("single");
+    let writer = WalWriter::open(&path, 1).unwrap();
+    let entry = writer.append_sync(insert_op(1, "alice")).unwrap();
+    assert_eq!(entry.lsn, 1);
+    drop(writer);
+
+    let entries = WalReader::open(&path).unwrap().read_all().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].lsn, 1);
+    assert_eq!(entries[0].op, insert_op(1, "alice"));
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn append_multiple_preserves_order() {
+    let path = tmp_wal_path("multi");
+    let writer = WalWriter::open(&path, 1).unwrap();
+    for i in 1..=50 {
+        writer.append(insert_op(i, "row")).unwrap();
+    }
+    writer.flush_sync().unwrap();
+    drop(writer);
+
+    let entries = WalReader::open(&path).unwrap().read_all().unwrap();
+    assert_eq!(entries.len(), 50);
+    for (i, e) in entries.iter().enumerate() {
+        assert_eq!(e.lsn, (i + 1) as Lsn);
+    }
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn lsn_starts_from_passed_value() {
+    let path = tmp_wal_path("lsn_start");
+    let writer = WalWriter::open(&path, 100).unwrap();
+    let e = writer.append_sync(insert_op(1, "x")).unwrap();
+    assert_eq!(e.lsn, 100);
+    assert_eq!(writer.peek_next_lsn(), 101);
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/wal/tests/corruption.rs
+++ b/native/engine/src/wal/tests/corruption.rs
@@ -1,0 +1,26 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+
+use super::super::*;
+use super::{insert_op, tmp_wal_path};
+
+#[test]
+fn corrupt_tail_treated_as_eof() {
+    let path = tmp_wal_path("corrupt");
+    let writer = WalWriter::open(&path, 1).unwrap();
+    writer.append_sync(insert_op(1, "a")).unwrap();
+    writer.append_sync(insert_op(2, "b")).unwrap();
+    drop(writer);
+
+    // Append garbage bytes to the end of the file to simulate torn write
+    let mut f = OpenOptions::new().append(true).open(&path).unwrap();
+    f.write_all(&[0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00]).unwrap();
+    drop(f);
+
+    // Reader should return the 2 valid entries and stop at the torn frame
+    let entries = WalReader::open(&path).unwrap().read_all().unwrap();
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].lsn, 1);
+    assert_eq!(entries[1].lsn, 2);
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/wal/tests/mod.rs
+++ b/native/engine/src/wal/tests/mod.rs
@@ -1,0 +1,23 @@
+//! WAL test modules. Helpers shared across test files.
+
+use super::*;
+use crate::types::Value;
+
+mod basic;
+mod corruption;
+mod payload;
+
+pub(super) fn tmp_wal_path(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("evolvsql_wal_test_{}_{}.log", name, std::process::id()));
+    let _ = std::fs::remove_file(&p);
+    p
+}
+
+pub(super) fn insert_op(id: i64, name: &str) -> WalOp {
+    WalOp::Insert {
+        schema: "public".into(),
+        table: "users".into(),
+        row: vec![Value::Int(id), Value::Text(std::sync::Arc::from(name))],
+    }
+}

--- a/native/engine/src/wal/tests/payload.rs
+++ b/native/engine/src/wal/tests/payload.rs
@@ -1,0 +1,50 @@
+use super::super::*;
+use super::{insert_op, tmp_wal_path};
+use crate::types::Value;
+
+#[test]
+fn all_op_variants_round_trip() {
+    let path = tmp_wal_path("variants");
+    let writer = WalWriter::open(&path, 1).unwrap();
+    writer.append(insert_op(1, "a")).unwrap();
+    writer.append(WalOp::Update {
+        schema: "public".into(), table: "users".into(),
+        row_id: 42, new_row: vec![Value::Int(99)],
+    }).unwrap();
+    writer.append(WalOp::Delete {
+        schema: "public".into(), table: "users".into(), row_id: 7,
+    }).unwrap();
+    writer.append(WalOp::Commit { txn_id: 123 }).unwrap();
+    writer.append(WalOp::Checkpoint { up_to: 50 }).unwrap();
+    writer.flush_sync().unwrap();
+    drop(writer);
+
+    let entries = WalReader::open(&path).unwrap().read_all().unwrap();
+    assert_eq!(entries.len(), 5);
+    assert!(matches!(entries[0].op, WalOp::Insert { .. }));
+    assert!(matches!(entries[1].op, WalOp::Update { row_id: 42, .. }));
+    assert!(matches!(entries[2].op, WalOp::Delete { row_id: 7, .. }));
+    assert!(matches!(entries[3].op, WalOp::Commit { txn_id: 123 }));
+    assert!(matches!(entries[4].op, WalOp::Checkpoint { up_to: 50 }));
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn vector_payload_round_trip() {
+    let path = tmp_wal_path("vector");
+    let writer = WalWriter::open(&path, 1).unwrap();
+    let vec_row = vec![Value::Int(1), Value::Vector(vec![0.1, 0.2, 0.3, 0.4])];
+    writer.append_sync(WalOp::Insert {
+        schema: "public".into(), table: "embeds".into(), row: vec_row.clone(),
+    }).unwrap();
+    drop(writer);
+
+    let entries = WalReader::open(&path).unwrap().read_all().unwrap();
+    assert_eq!(entries.len(), 1);
+    if let WalOp::Insert { row, .. } = &entries[0].op {
+        assert_eq!(row, &vec_row);
+    } else {
+        panic!("expected Insert");
+    }
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/wal/writer.rs
+++ b/native/engine/src/wal/writer.rs
@@ -1,0 +1,90 @@
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use parking_lot::Mutex;
+
+use super::entry::WalOp;
+use super::{Lsn, WalEntry};
+
+/// Append-only WAL writer. Single mutex serializes writes; group commit
+/// refinement lives in PR 8.
+pub struct WalWriter {
+    path: PathBuf,
+    inner: Mutex<BufWriter<File>>,
+    next_lsn: AtomicU64,
+}
+
+impl WalWriter {
+    /// Open or create a WAL file at `path`. Existing content is preserved
+    /// (appended to); `next_lsn` starts at 1 unless `starting_lsn` is set
+    /// by the caller after reading the existing WAL.
+    pub fn open<P: AsRef<Path>>(path: P, starting_lsn: Lsn) -> Result<Self, String> {
+        let path = path.as_ref().to_path_buf();
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .map_err(|e| format!("WAL open {:?}: {}", path, e))?;
+        Ok(Self {
+            path,
+            inner: Mutex::new(BufWriter::with_capacity(64 * 1024, file)),
+            next_lsn: AtomicU64::new(starting_lsn.max(1)),
+        })
+    }
+
+    /// Append an operation and return the assigned LSN. Does NOT fsync.
+    /// Call `flush_sync` to make writes durable.
+    pub fn append(&self, op: WalOp) -> Result<Lsn, String> {
+        let lsn = self.next_lsn.fetch_add(1, Ordering::SeqCst);
+        let payload = op.encode_payload()?;
+        let tag = op.tag();
+        let frame = encode_frame(lsn, tag, &payload);
+        let mut w = self.inner.lock();
+        w.write_all(&frame).map_err(|e| format!("WAL write: {}", e))?;
+        Ok(lsn)
+    }
+
+    /// Flush buffered writes and fsync to disk. This is the durability
+    /// boundary: after this returns, appended entries survive a crash.
+    pub fn flush_sync(&self) -> Result<(), String> {
+        let mut w = self.inner.lock();
+        w.flush().map_err(|e| format!("WAL flush: {}", e))?;
+        w.get_ref().sync_data().map_err(|e| format!("WAL fsync: {}", e))?;
+        Ok(())
+    }
+
+    /// Path of the underlying WAL file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// LSN that will be assigned to the next append.
+    pub fn peek_next_lsn(&self) -> Lsn {
+        self.next_lsn.load(Ordering::SeqCst)
+    }
+
+    /// Convenience: append + flush in one call.
+    pub fn append_sync(&self, op: WalOp) -> Result<WalEntry, String> {
+        let lsn = self.append(op.clone())?;
+        self.flush_sync()?;
+        Ok(WalEntry { lsn, op })
+    }
+}
+
+/// Encode a single WAL frame:
+/// [frame_len: u32 LE] [lsn: u64 LE] [tag: u8] [payload] [crc32: u32 LE]
+pub(super) fn encode_frame(lsn: Lsn, tag: u8, payload: &[u8]) -> Vec<u8> {
+    // frame_len covers: lsn(8) + tag(1) + payload + crc(4)
+    let frame_len: u32 = (8 + 1 + payload.len() + 4) as u32;
+    let mut buf = Vec::with_capacity(4 + frame_len as usize);
+    buf.extend_from_slice(&frame_len.to_le_bytes());
+    buf.extend_from_slice(&lsn.to_le_bytes());
+    buf.push(tag);
+    buf.extend_from_slice(payload);
+    // CRC covers lsn + tag + payload (bytes 4..end-4 of final frame)
+    let crc = crc32fast::hash(&buf[4..]);
+    buf.extend_from_slice(&crc.to_le_bytes());
+    buf
+}


### PR DESCRIPTION
## Summary

First PR in the persistence roadmap. Introduces the Write-Ahead Log module as the foundation for durable, crash-recoverable writes. The storage layer is **not yet wired into the WAL** - that's PR 3. This PR establishes the on-disk format, writer, reader, and test coverage.

## Architecture

- **Append-only file** with CRC32 per frame for torn-write detection
- **Frame format**: `[len:u32] [lsn:u64] [tag:u8] [payload] [crc32:u32]`
- **Operations**: Insert, Update, Delete, Commit, Checkpoint
- **Payload encoding**: bincode, reusing existing `Value` Serialize impl
- **Writer**: single `Mutex<BufWriter<File>>` (group commit refinement in PR 8)
- **Reader**: iterates entries, returns `None` at torn/corrupt frames so recovery safely stops at the durable prefix
- **Frame length bound-check** (64MB max) prevents OOM on garbage input (caught in testing when 0xFFFFFFFF garbage tried to allocate 4GB)

## Module structure

All files under 100 lines per the project rule:

| File | Lines | Purpose |
|---|---|---|
| `wal/mod.rs` | 31 | Public API, `Lsn` type |
| `wal/entry.rs` | 57 | `WalEntry`, `WalOp`, tag constants |
| `wal/writer.rs` | 90 | `WalWriter` with `append()` and `flush_sync()` |
| `wal/reader.rs` | 78 | `WalReader` with CRC verification |
| `wal/tests/mod.rs` | 23 | Shared helpers |
| `wal/tests/basic.rs` | 45 | Round-trip and ordering tests |
| `wal/tests/corruption.rs` | 26 | Torn-write handling |
| `wal/tests/payload.rs` | 50 | All op variants + vector payload |

## Dependencies added

- `bincode = "1.3"` - standard Rust binary serialization
- `crc32fast = "1.4"` - SIMD-accelerated CRC32

Both are small, widely used, and commonly found in Rust projects.

## Vector support

`Value::Vector` round-trips through the WAL from day one via the existing `serde` impl. This is essential for EvolvSQL's vector DB ambitions. Per-segment HNSW indexes and columnar segment files come in PRs 2-4.

## Tests

- 6 new WAL tests, 242 total (was 236)
- Single entry round-trip
- Multi-entry ordering (50 entries)
- LSN continuation from arbitrary start
- Torn-write tail treated as EOF (found the 4GB allocation bug)
- All 5 op variants round-trip
- Vector payload round-trip

## Next in the roadmap

| PR | Status | What |
|---|---|---|
| 1 | This PR | WAL foundation |
| 2 | Next | Segment file format (scalar columns) |
| 3 | | Memtable + storage hooks + WAL wire-in |
| 4 | | Per-segment HNSW |
| 5 | | Vector columns in segments |
| 6 | | Zone maps for predicate pushdown |
| 7 | | Background compaction |
| 8 | | Group commit batching |
| 9 | | Crash recovery (WAL replay) |
| 10 | | Direct I/O with io_uring (Linux) |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
