### PR TITLE
test: regression coverage for bugs Devin caught but tests missed

### DIFF
--- a/native/engine/src/executor/tests/devin_regressions/aggregates.rs
+++ b/native/engine/src/executor/tests/devin_regressions/aggregates.rs
@@ -1,0 +1,34 @@
+use super::super::*;
+
+// ── PR #35: aggregate OID for SUM defaulted to text ───────────────────
+// Original test used values (250, 200) where lexicographic and numeric
+// sort agree. This version uses (5, 100) where they disagree:
+//   lex:     "100" < "5"  → "100", "5"
+//   numeric: 5 < 100      → "5", "100"
+#[test]
+#[serial_test::serial]
+fn aggregate_order_by_numeric_not_lexicographic() {
+    setup();
+    execute("CREATE TABLE s (region text, amount int)").unwrap();
+    execute("INSERT INTO s VALUES ('a', 3), ('a', 2)").unwrap(); // SUM = 5
+    execute("INSERT INTO s VALUES ('b', 60), ('b', 40)").unwrap(); // SUM = 100
+    let r = execute(
+        "SELECT region, SUM(amount) FROM s GROUP BY region ORDER BY SUM(amount) ASC",
+    )
+    .unwrap();
+    // Numeric: 5 < 100 → a first. Lexicographic would give "100" < "5" → b first.
+    assert_eq!(r.rows[0][0], Some("a".into()));
+    assert_eq!(r.rows[1][0], Some("b".into()));
+}
+
+// ── PR #35: string_agg panicked on empty groups (rows[0]) ─────────────
+#[test]
+#[serial_test::serial]
+fn string_agg_empty_table() {
+    setup();
+    execute("CREATE TABLE sae (name text)").unwrap();
+    // No rows inserted - should return NULL, not panic
+    let r = execute("SELECT STRING_AGG(name, ',') FROM sae").unwrap();
+    assert_eq!(r.rows.len(), 1);
+    assert_eq!(r.rows[0][0], None);
+}

--- a/native/engine/src/executor/tests/devin_regressions/misc.rs
+++ b/native/engine/src/executor/tests/devin_regressions/misc.rs
@@ -1,0 +1,51 @@
+use super::super::*;
+
+// ── PR #35: fast equality filter ignored TypeCast ─────────────────────
+// WHERE id = '5'::int on the single-table fast path extracted Text("5")
+// and compared it against Int columns. The cross-type comparison never
+// matched, silently returning 0 rows. Fixed by bailing to the slow path
+// when either side is a TypeCast.
+#[test]
+#[serial_test::serial]
+fn where_typecast_equality() {
+    setup();
+    execute("CREATE TABLE te (id int, name text)").unwrap();
+    execute("INSERT INTO te VALUES (5, 'five'), (10, 'ten')").unwrap();
+    let r = execute("SELECT name FROM te WHERE id = '5'::int").unwrap();
+    assert_eq!(r.rows.len(), 1);
+    assert_eq!(r.rows[0][0], Some("five".into()));
+}
+
+// ── PR #35: INSERT...SELECT didn't apply column defaults ──────────────
+// The VALUES path used apply_default for non-target columns but the
+// SELECT path initialized them all to NULL, breaking SERIAL columns.
+#[test]
+#[serial_test::serial]
+fn insert_select_applies_serial_default() {
+    setup();
+    execute("CREATE TABLE src_d (name text)").unwrap();
+    execute("CREATE TABLE dst_d (id serial, name text)").unwrap();
+    execute("INSERT INTO src_d VALUES ('alice'), ('bob')").unwrap();
+    execute("INSERT INTO dst_d (name) SELECT name FROM src_d").unwrap();
+    let r = execute("SELECT id, name FROM dst_d ORDER BY id").unwrap();
+    assert_eq!(r.rows.len(), 2);
+    // id should be populated by SERIAL, not NULL
+    assert!(r.rows[0][0].is_some(), "id should not be NULL");
+    assert!(r.rows[1][0].is_some(), "id should not be NULL");
+}
+
+// ── PR #35: ORDER BY ordinal rejected expression targets ──────────────
+// SELECT a + b FROM t ORDER BY 1 errored with "ORDER BY ordinal must
+// reference a column". Fixed by routing expression targets through the
+// same expression-eval path that arbitrary ORDER BY exprs use.
+#[test]
+#[serial_test::serial]
+fn order_by_ordinal_expression_target() {
+    setup();
+    execute("CREATE TABLE oe (a int, b int)").unwrap();
+    execute("INSERT INTO oe VALUES (1, 10), (2, 5), (3, 1)").unwrap();
+    let r = execute("SELECT a + b FROM oe ORDER BY 1").unwrap();
+    assert_eq!(r.rows[0][0], Some("4".into())); // 3+1
+    assert_eq!(r.rows[1][0], Some("7".into())); // 2+5
+    assert_eq!(r.rows[2][0], Some("11".into())); // 1+10
+}

--- a/native/engine/src/executor/tests/devin_regressions/mod.rs
+++ b/native/engine/src/executor/tests/devin_regressions/mod.rs
@@ -1,0 +1,11 @@
+//! Regression tests for bugs that shipped with passing tests but were
+//! caught by static review. Each test here is a direct counterexample
+//! for a test that existed and passed before the bug was fixed.
+//!
+//! Keep this directory as a forcing function: any bug caught in review
+//! should have its repro added here before merge.
+
+mod aggregates;
+mod set_ops;
+mod strings;
+mod misc;

--- a/native/engine/src/executor/tests/devin_regressions/set_ops.rs
+++ b/native/engine/src/executor/tests/devin_regressions/set_ops.rs
@@ -1,0 +1,30 @@
+use super::super::*;
+
+// ── PR #35: INTERSECT/EXCEPT didn't dedup without ALL ─────────────────
+#[test]
+#[serial_test::serial]
+fn intersect_dedups_duplicates() {
+    setup();
+    execute("CREATE TABLE idl (x int)").unwrap();
+    execute("CREATE TABLE idr (x int)").unwrap();
+    // Both sides have duplicates of 1; INTERSECT should return ONE 1.
+    execute("INSERT INTO idl VALUES (1), (1), (2)").unwrap();
+    execute("INSERT INTO idr VALUES (1), (1)").unwrap();
+    let r = execute("SELECT x FROM idl INTERSECT SELECT x FROM idr").unwrap();
+    assert_eq!(r.rows.len(), 1, "INTERSECT should dedup: got {:?}", r.rows);
+}
+
+#[test]
+#[serial_test::serial]
+fn except_dedups_duplicates() {
+    setup();
+    execute("CREATE TABLE edl (x int)").unwrap();
+    execute("CREATE TABLE edr (x int)").unwrap();
+    // Left has 1,1,2,2; right has 3. EXCEPT should return 1,2 (one each).
+    execute("INSERT INTO edl VALUES (1), (1), (2), (2)").unwrap();
+    execute("INSERT INTO edr VALUES (3)").unwrap();
+    let r = execute("SELECT x FROM edl EXCEPT SELECT x FROM edr ORDER BY x").unwrap();
+    assert_eq!(r.rows.len(), 2, "EXCEPT should dedup: got {:?}", r.rows);
+    assert_eq!(r.rows[0][0], Some("1".into()));
+    assert_eq!(r.rows[1][0], Some("2".into()));
+}

--- a/native/engine/src/executor/tests/devin_regressions/strings.rs
+++ b/native/engine/src/executor/tests/devin_regressions/strings.rs
@@ -1,0 +1,22 @@
+use super::super::*;
+
+// ── PR #35: left()/right() with negative n wrapped to huge usize ──────
+// PostgreSQL semantics: negative n means "all but the last |n| chars"
+// (for left) or "all but the first |n| chars" (for right). Our initial
+// `*i as usize` cast wrapped negative to usize::MAX, making take() return
+// the whole string.
+#[test]
+#[serial_test::serial]
+fn left_negative_n_drops_from_end() {
+    setup();
+    let r = execute("SELECT LEFT('hello', -2)").unwrap();
+    assert_eq!(r.rows[0][0], Some("hel".into()));
+}
+
+#[test]
+#[serial_test::serial]
+fn right_negative_n_drops_from_start() {
+    setup();
+    let r = execute("SELECT RIGHT('hello', -2)").unwrap();
+    assert_eq!(r.rows[0][0], Some("llo".into()));
+}

--- a/native/engine/src/executor/tests/mod.rs
+++ b/native/engine/src/executor/tests/mod.rs
@@ -57,3 +57,4 @@ mod cte;
 mod cte_ext;
 mod upsert;
 mod upsert_ext;
+mod devin_regressions;


### PR DESCRIPTION
## Summary

Adds `tests/devin_regressions/` - a directory of tests that capture bugs found in PR review where our passing test suite failed to detect the issue. Each test is a direct counterexample for a test that existed and passed before the bug was found.

This is the test audit follow-up mentioned after PR #36: we merged PR #35 with 8 Devin findings fixed, but our 236 passing tests missed all of them. This PR closes the gap for the ones that are easy to express as regression tests.

## Why a dedicated directory

The "bugs that escaped the test suite in a real review" category is rare and valuable. Putting them in their own directory:
- Makes the forcing function visible (every new review bug should add a repro here)
- Documents which existing tests had weaknesses
- Groups related failures for future audit passes

## The 9 tests

**aggregates.rs:**
- `aggregate_order_by_numeric_not_lexicographic` - uses values (5, 100) where lexicographic and numeric disagree. The original test in `misc.rs` used (250, 200) where both orderings agree, so it passed even with the SUM OID text default bug.
- `string_agg_empty_table` - would have panicked on `rows[0]` before the guard was added.

**set_ops.rs:**
- `intersect_dedups_duplicates`, `except_dedups_duplicates` - insert actual duplicates in both sides. The original INTERSECT/EXCEPT tests used unique values only, so dedup-without-ALL was never exercised.

**strings.rs:**
- `left_negative_n_drops_from_end`, `right_negative_n_drops_from_start` - PostgreSQL negative-n semantics. The `*i as usize` cast wrapped negative to `usize::MAX`, making `take()` return the whole string. No existing test used negative arguments.

**misc.rs:**
- `where_typecast_equality` - `'5'::int` in a fast-path WHERE. The fast filter extracted the inner Text("5") instead of casting, returning 0 rows against Int columns. No existing test combined WHERE + TypeCast.
- `insert_select_applies_serial_default` - SERIAL column with INSERT...SELECT. The SELECT path hardcoded NULL for non-target columns, breaking SERIAL. Only the VALUES path had a test.
- `order_by_ordinal_expression_target` - `SELECT a+b FROM t ORDER BY 1`. The ordinal resolver only accepted ColumnRef targets. No existing test combined ordinal ORDER BY with an expression target.

## Test plan

- [x] All 9 new tests pass on the current code (`cargo test devin`)
- [x] Full suite: 245 passed, 0 failed, 3 ignored (was 236)
- [x] Running the tests against a pre-fix commit reproduces each original bug (manual check)

## Next

Future PR reviews should add their own regression files here (e.g. `devin_regressions/connection_limits.rs` when PR #38's monitor/try-after finding gets a repro, but that's BEAM-side and harder to unit test).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
