### PR TITLE
feat: segment file format (PR 2/10) - columnar storage with zone maps

### DIFF
--- a/native/engine/src/lib.rs
+++ b/native/engine/src/lib.rs
@@ -3,6 +3,7 @@ mod catalog;
 mod executor;
 mod hnsw;
 mod parser;
+mod segment;
 mod sequence;
 mod storage;
 mod types;

--- a/native/engine/src/segment/format.rs
+++ b/native/engine/src/segment/format.rs
@@ -1,0 +1,65 @@
+use serde::{Deserialize, Serialize};
+
+use crate::types::Value;
+
+/// Magic bytes at start of every segment file, and at end of footer.
+pub const MAGIC: &[u8; 4] = b"EVSG";
+/// Segment format version. Bump on breaking layout changes.
+pub const VERSION: u16 = 1;
+
+/// Fixed-size header at byte 0 of every segment file (32 bytes).
+pub(super) const HEADER_SIZE: usize = 32;
+
+/// Per-column metadata kept in the footer. `offset` and `length` locate
+/// the column's data block in the file; `min` and `max` are the zone
+/// map values used for predicate skipping.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ColumnMeta {
+    pub name: String,
+    pub type_oid: i32,
+    pub offset: u64,
+    pub length: u64,
+    /// Smallest non-NULL value in this column, or None if all NULL.
+    pub min: Option<Value>,
+    /// Largest non-NULL value in this column, or None if all NULL.
+    pub max: Option<Value>,
+    /// Count of NULL values in this column.
+    pub null_count: u32,
+}
+
+/// Footer written at the end of the segment file. Located via
+/// `footer_offset` in the fixed header.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SegmentFooter {
+    pub columns: Vec<ColumnMeta>,
+    pub row_count: u32,
+}
+
+/// Encode the fixed-size header at byte 0 of the segment file.
+pub(super) fn encode_header(row_count: u32, col_count: u16, footer_offset: u64) -> [u8; HEADER_SIZE] {
+    let mut buf = [0u8; HEADER_SIZE];
+    buf[0..4].copy_from_slice(MAGIC);
+    buf[4..6].copy_from_slice(&VERSION.to_le_bytes());
+    // 6..8 reserved
+    buf[8..12].copy_from_slice(&row_count.to_le_bytes());
+    buf[12..14].copy_from_slice(&col_count.to_le_bytes());
+    // 14..16 reserved
+    buf[16..24].copy_from_slice(&footer_offset.to_le_bytes());
+    // 24..32 reserved
+    buf
+}
+
+/// Decode the fixed-size header. Returns (row_count, col_count, footer_offset).
+pub(super) fn decode_header(buf: &[u8; HEADER_SIZE]) -> Result<(u32, u16, u64), String> {
+    if &buf[0..4] != MAGIC {
+        return Err("segment: bad magic".into());
+    }
+    let version = u16::from_le_bytes(buf[4..6].try_into().unwrap());
+    if version != VERSION {
+        return Err(format!("segment: unsupported version {}", version));
+    }
+    let row_count = u32::from_le_bytes(buf[8..12].try_into().unwrap());
+    let col_count = u16::from_le_bytes(buf[12..14].try_into().unwrap());
+    let footer_offset = u64::from_le_bytes(buf[16..24].try_into().unwrap());
+    Ok((row_count, col_count, footer_offset))
+}

--- a/native/engine/src/segment/mod.rs
+++ b/native/engine/src/segment/mod.rs
@@ -1,0 +1,36 @@
+//! Immutable segment files: columnar storage with zone maps.
+//!
+//! A segment is a single file holding a batch of rows in columnar
+//! layout. Segments are the on-disk equivalent of the memtable and are
+//! written once, then never mutated. Old segments are superseded by
+//! compaction (PR 7), not by in-place update.
+//!
+//! File layout:
+//! ```text
+//! [header: 32 bytes]
+//!   magic("EVSG":4) version(u16) _res(u16) row_count(u32)
+//!   col_count(u16) _res(u16) footer_offset(u64) _res(u64)
+//! [column data blocks]  // each: bincoded Vec<Value> for that column
+//! [footer]              // bincoded SegmentFooter with column metadata
+//! ```
+//!
+//! Writer transposes rows into columns, encodes each column
+//! independently, records the (offset, length, min, max) per column,
+//! then writes the footer. Reader parses the header, seeks to the
+//! footer, and can then read any individual column without loading
+//! the others.
+//!
+//! Scalar columns only in this PR. Vector columns and per-segment
+//! HNSW indexes come in PRs 4 and 5.
+
+mod format;
+mod writer;
+mod reader;
+mod zone_map;
+
+#[cfg(test)]
+mod tests;
+
+pub use format::{ColumnMeta, SegmentFooter, MAGIC, VERSION};
+pub use writer::SegmentWriter;
+pub use reader::SegmentReader;

--- a/native/engine/src/segment/reader.rs
+++ b/native/engine/src/segment/reader.rs
@@ -1,0 +1,91 @@
+use std::fs::File;
+use std::io::{BufReader, Read, Seek, SeekFrom};
+use std::path::Path;
+
+use crate::types::Value;
+
+use super::format::{decode_header, ColumnMeta, SegmentFooter, HEADER_SIZE};
+
+/// Opens a segment file and exposes column-level random access.
+///
+/// The reader loads the header + footer on open (cheap, O(1) in file
+/// size) but does not read any column data until requested. This lets
+/// query execution pull only the columns it needs.
+pub struct SegmentReader {
+    file: BufReader<File>,
+    footer: SegmentFooter,
+}
+
+impl SegmentReader {
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, String> {
+        let file = File::open(path.as_ref())
+            .map_err(|e| format!("segment open: {}", e))?;
+        let mut reader = BufReader::with_capacity(64 * 1024, file);
+
+        // Read fixed header
+        let mut header = [0u8; HEADER_SIZE];
+        reader.read_exact(&mut header)
+            .map_err(|e| format!("segment read header: {}", e))?;
+        let (_row_count, _col_count, footer_offset) = decode_header(&header)?;
+
+        // Seek to footer and decode
+        reader.seek(SeekFrom::Start(footer_offset))
+            .map_err(|e| format!("segment seek footer: {}", e))?;
+        let mut footer_bytes = Vec::new();
+        reader.read_to_end(&mut footer_bytes)
+            .map_err(|e| format!("segment read footer: {}", e))?;
+        let footer: SegmentFooter = bincode::deserialize(&footer_bytes)
+            .map_err(|e| format!("segment decode footer: {}", e))?;
+
+        Ok(Self { file: reader, footer })
+    }
+
+    /// Total row count stored in this segment.
+    pub fn row_count(&self) -> u32 {
+        self.footer.row_count
+    }
+
+    /// All column metadata (schema + zone maps).
+    pub fn columns(&self) -> &[ColumnMeta] {
+        &self.footer.columns
+    }
+
+    /// Find a column by name. Case-sensitive.
+    pub fn column_meta(&self, name: &str) -> Option<&ColumnMeta> {
+        self.footer.columns.iter().find(|c| c.name == name)
+    }
+
+    /// Read a single column's values. This is the primary columnar
+    /// access path: callers scan only the columns they need.
+    pub fn read_column(&mut self, name: &str) -> Result<Vec<Value>, String> {
+        let meta = self.column_meta(name)
+            .ok_or_else(|| format!("segment: column \"{}\" not found", name))?;
+        let offset = meta.offset;
+        let length = meta.length as usize;
+        self.file.seek(SeekFrom::Start(offset))
+            .map_err(|e| format!("segment seek col: {}", e))?;
+        let mut buf = vec![0u8; length];
+        self.file.read_exact(&mut buf)
+            .map_err(|e| format!("segment read col: {}", e))?;
+        bincode::deserialize(&buf)
+            .map_err(|e| format!("segment decode col: {}", e))
+    }
+
+    /// Read all rows by reconstructing the row-oriented view. Useful
+    /// for full-table scans and tests. For production SELECTs, prefer
+    /// `read_column` to scan only needed columns.
+    pub fn read_all_rows(&mut self) -> Result<Vec<Vec<Value>>, String> {
+        let names: Vec<String> = self.footer.columns.iter().map(|c| c.name.clone()).collect();
+        let mut cols: Vec<Vec<Value>> = Vec::with_capacity(names.len());
+        for n in &names {
+            cols.push(self.read_column(n)?);
+        }
+        let row_count = self.footer.row_count as usize;
+        let mut rows = Vec::with_capacity(row_count);
+        for i in 0..row_count {
+            let row: Vec<Value> = cols.iter().map(|c| c[i].clone()).collect();
+            rows.push(row);
+        }
+        Ok(rows)
+    }
+}

--- a/native/engine/src/segment/tests/basic.rs
+++ b/native/engine/src/segment/tests/basic.rs
@@ -1,0 +1,76 @@
+use super::super::*;
+use super::{tmp_path, user_row, users_schema};
+use crate::types::Value;
+
+#[test]
+fn write_then_read_all_rows() {
+    let path = tmp_path("basic");
+    let schema = users_schema();
+    let rows = vec![
+        user_row(1, "alice"),
+        user_row(2, "bob"),
+        user_row(3, "carol"),
+    ];
+    SegmentWriter::write(&path, &schema, &rows).unwrap();
+
+    let mut reader = SegmentReader::open(&path).unwrap();
+    assert_eq!(reader.row_count(), 3);
+    let read_back = reader.read_all_rows().unwrap();
+    assert_eq!(read_back, rows);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn read_single_column_skips_others() {
+    let path = tmp_path("single_col");
+    let schema = users_schema();
+    let rows = vec![
+        user_row(10, "x"),
+        user_row(20, "y"),
+    ];
+    SegmentWriter::write(&path, &schema, &rows).unwrap();
+
+    let mut reader = SegmentReader::open(&path).unwrap();
+    let ids = reader.read_column("id").unwrap();
+    assert_eq!(ids, vec![Value::Int(10), Value::Int(20)]);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn empty_segment_roundtrip() {
+    let path = tmp_path("empty");
+    let schema = users_schema();
+    SegmentWriter::write(&path, &schema, &[]).unwrap();
+
+    let reader = SegmentReader::open(&path).unwrap();
+    assert_eq!(reader.row_count(), 0);
+    assert_eq!(reader.columns().len(), 2);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn row_arity_mismatch_errors() {
+    let path = tmp_path("arity");
+    let schema = users_schema(); // 2 columns
+    let bad_rows = vec![vec![Value::Int(1)]]; // 1 value
+    let r = SegmentWriter::write(&path, &schema, &bad_rows);
+    assert!(r.is_err());
+    assert!(r.unwrap_err().contains("arity"));
+}
+
+#[test]
+fn column_metadata_preserved() {
+    let path = tmp_path("meta");
+    let schema = users_schema();
+    let rows = vec![user_row(1, "a")];
+    SegmentWriter::write(&path, &schema, &rows).unwrap();
+
+    let reader = SegmentReader::open(&path).unwrap();
+    let cols = reader.columns();
+    assert_eq!(cols.len(), 2);
+    assert_eq!(cols[0].name, "id");
+    assert_eq!(cols[0].type_oid, 23);
+    assert_eq!(cols[1].name, "name");
+    assert_eq!(cols[1].type_oid, 25);
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/segment/tests/large.rs
+++ b/native/engine/src/segment/tests/large.rs
@@ -1,0 +1,30 @@
+use super::super::*;
+use super::{tmp_path, user_row, users_schema};
+
+/// Stress test: write many rows and verify round-trip. Exercises the
+/// bincode buffer sizing and zone map computation on a larger dataset.
+#[test]
+fn round_trip_10k_rows() {
+    let path = tmp_path("large10k");
+    let schema = users_schema();
+    let rows: Vec<Vec<crate::types::Value>> = (0..10_000)
+        .map(|i| user_row(i, &format!("user_{}", i)))
+        .collect();
+    SegmentWriter::write(&path, &schema, &rows).unwrap();
+
+    let mut reader = SegmentReader::open(&path).unwrap();
+    assert_eq!(reader.row_count(), 10_000);
+
+    // Spot-check via column read (not full row read, which is slower).
+    let ids = reader.read_column("id").unwrap();
+    assert_eq!(ids.len(), 10_000);
+    assert_eq!(ids[0], crate::types::Value::Int(0));
+    assert_eq!(ids[9_999], crate::types::Value::Int(9_999));
+
+    // Zone map should have picked up the full range.
+    let id_meta = reader.column_meta("id").unwrap();
+    assert_eq!(id_meta.min, Some(crate::types::Value::Int(0)));
+    assert_eq!(id_meta.max, Some(crate::types::Value::Int(9_999)));
+
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/segment/tests/mod.rs
+++ b/native/engine/src/segment/tests/mod.rs
@@ -1,0 +1,29 @@
+//! Segment test modules. Helpers for file paths and row construction.
+
+use super::*;
+use crate::types::Value;
+
+mod basic;
+mod zone_maps;
+mod large;
+
+pub(super) fn tmp_path(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("evolvsql_seg_{}_{}.bin", name, std::process::id()));
+    let _ = std::fs::remove_file(&p);
+    p
+}
+
+pub(super) fn users_schema() -> Vec<(String, i32)> {
+    vec![
+        ("id".into(), 23),   // int4
+        ("name".into(), 25), // text
+    ]
+}
+
+pub(super) fn user_row(id: i64, name: &str) -> Vec<Value> {
+    vec![
+        Value::Int(id),
+        Value::Text(std::sync::Arc::from(name)),
+    ]
+}

--- a/native/engine/src/segment/tests/zone_maps.rs
+++ b/native/engine/src/segment/tests/zone_maps.rs
@@ -1,0 +1,79 @@
+use super::super::*;
+use super::tmp_path;
+use crate::types::Value;
+
+fn int_schema() -> Vec<(String, i32)> {
+    vec![("x".into(), 23)]
+}
+
+#[test]
+fn zone_map_tracks_int_min_max() {
+    let path = tmp_path("int_zone");
+    let rows: Vec<Vec<Value>> = vec![
+        vec![Value::Int(42)],
+        vec![Value::Int(7)],
+        vec![Value::Int(100)],
+        vec![Value::Int(13)],
+    ];
+    SegmentWriter::write(&path, &int_schema(), &rows).unwrap();
+
+    let reader = SegmentReader::open(&path).unwrap();
+    let meta = reader.column_meta("x").unwrap();
+    assert_eq!(meta.min, Some(Value::Int(7)));
+    assert_eq!(meta.max, Some(Value::Int(100)));
+    assert_eq!(meta.null_count, 0);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn zone_map_excludes_nulls_and_counts_them() {
+    let path = tmp_path("nulls");
+    let rows: Vec<Vec<Value>> = vec![
+        vec![Value::Null],
+        vec![Value::Int(5)],
+        vec![Value::Null],
+        vec![Value::Int(10)],
+    ];
+    SegmentWriter::write(&path, &int_schema(), &rows).unwrap();
+
+    let reader = SegmentReader::open(&path).unwrap();
+    let meta = reader.column_meta("x").unwrap();
+    assert_eq!(meta.min, Some(Value::Int(5)));
+    assert_eq!(meta.max, Some(Value::Int(10)));
+    assert_eq!(meta.null_count, 2);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn zone_map_all_null_column() {
+    let path = tmp_path("all_null");
+    let rows: Vec<Vec<Value>> = vec![
+        vec![Value::Null],
+        vec![Value::Null],
+    ];
+    SegmentWriter::write(&path, &int_schema(), &rows).unwrap();
+
+    let reader = SegmentReader::open(&path).unwrap();
+    let meta = reader.column_meta("x").unwrap();
+    assert_eq!(meta.min, None);
+    assert_eq!(meta.max, None);
+    assert_eq!(meta.null_count, 2);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn zone_map_text_ordering() {
+    let path = tmp_path("text_zone");
+    let rows: Vec<Vec<Value>> = vec![
+        vec![Value::Text("charlie".into())],
+        vec![Value::Text("alice".into())],
+        vec![Value::Text("bob".into())],
+    ];
+    SegmentWriter::write(&path, &[("x".into(), 25)], &rows).unwrap();
+
+    let reader = SegmentReader::open(&path).unwrap();
+    let meta = reader.column_meta("x").unwrap();
+    assert_eq!(meta.min, Some(Value::Text("alice".into())));
+    assert_eq!(meta.max, Some(Value::Text("charlie".into())));
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/segment/writer.rs
+++ b/native/engine/src/segment/writer.rs
@@ -1,0 +1,84 @@
+use std::fs::File;
+use std::io::{BufWriter, Seek, SeekFrom, Write};
+use std::path::Path;
+
+use crate::types::Value;
+
+use super::format::{encode_header, ColumnMeta, SegmentFooter, HEADER_SIZE};
+use super::zone_map::compute_zone_map;
+
+/// Build a segment file from a batch of rows. Rows are transposed into
+/// columnar layout, each column is encoded independently with bincode,
+/// zone maps (min/max/null_count) are computed, and the footer is
+/// written at the end.
+pub struct SegmentWriter;
+
+impl SegmentWriter {
+    /// Write `rows` to `path` using `columns` as the schema. All rows
+    /// must have the same arity as `columns`.
+    pub fn write<P: AsRef<Path>>(
+        path: P,
+        columns: &[(String, i32)],
+        rows: &[Vec<Value>],
+    ) -> Result<(), String> {
+        let file = File::create(path.as_ref())
+            .map_err(|e| format!("segment create: {}", e))?;
+        let mut w = BufWriter::with_capacity(64 * 1024, file);
+
+        // Reserve header space; we'll fill it in after we know the footer offset.
+        w.write_all(&[0u8; HEADER_SIZE])
+            .map_err(|e| format!("segment header reserve: {}", e))?;
+
+        // Validate row shape before transposing.
+        for (i, row) in rows.iter().enumerate() {
+            if row.len() != columns.len() {
+                return Err(format!(
+                    "segment row {} arity {} != column count {}",
+                    i, row.len(), columns.len()
+                ));
+            }
+        }
+
+        // Transpose rows into columns and write each column block.
+        let mut col_metas = Vec::with_capacity(columns.len());
+        for (col_idx, (name, type_oid)) in columns.iter().enumerate() {
+            let col_values: Vec<Value> = rows.iter().map(|r| r[col_idx].clone()).collect();
+            let (min, max, null_count) = compute_zone_map(&col_values);
+
+            let offset = w.stream_position()
+                .map_err(|e| format!("segment stream pos: {}", e))?;
+            let encoded = bincode::serialize(&col_values)
+                .map_err(|e| format!("segment col encode: {}", e))?;
+            w.write_all(&encoded)
+                .map_err(|e| format!("segment col write: {}", e))?;
+            let length = encoded.len() as u64;
+
+            col_metas.push(ColumnMeta {
+                name: name.clone(),
+                type_oid: *type_oid,
+                offset, length, min, max, null_count,
+            });
+        }
+
+        // Write the footer at the current position.
+        let footer_offset = w.stream_position()
+            .map_err(|e| format!("segment footer pos: {}", e))?;
+        let footer = SegmentFooter { columns: col_metas, row_count: rows.len() as u32 };
+        let footer_bytes = bincode::serialize(&footer)
+            .map_err(|e| format!("segment footer encode: {}", e))?;
+        w.write_all(&footer_bytes)
+            .map_err(|e| format!("segment footer write: {}", e))?;
+
+        // Seek back and fill the header with the now-known footer_offset.
+        let header = encode_header(rows.len() as u32, columns.len() as u16, footer_offset);
+        w.seek(SeekFrom::Start(0))
+            .map_err(|e| format!("segment seek header: {}", e))?;
+        w.write_all(&header)
+            .map_err(|e| format!("segment header write: {}", e))?;
+
+        w.flush().map_err(|e| format!("segment flush: {}", e))?;
+        w.get_ref().sync_data()
+            .map_err(|e| format!("segment fsync: {}", e))?;
+        Ok(())
+    }
+}

--- a/native/engine/src/segment/zone_map.rs
+++ b/native/engine/src/segment/zone_map.rs
@@ -1,0 +1,59 @@
+use crate::types::Value;
+
+/// Compute (min, max, null_count) for a column's values. Used during
+/// segment writing to build zone maps. NULL values are excluded from
+/// min/max; if all values are NULL, both are None.
+///
+/// Vector and Bytea values have no meaningful ordering for zone maps,
+/// so their min/max are left as None (predicate skipping does not apply
+/// to them).
+pub(super) fn compute_zone_map(values: &[Value]) -> (Option<Value>, Option<Value>, u32) {
+    let mut min: Option<Value> = None;
+    let mut max: Option<Value> = None;
+    let mut null_count: u32 = 0;
+    for v in values {
+        if matches!(v, Value::Null) {
+            null_count += 1;
+            continue;
+        }
+        if !has_zone_order(v) {
+            continue;
+        }
+        if min.as_ref().is_none_or(|cur| less_than(v, cur)) {
+            min = Some(v.clone());
+        }
+        if max.as_ref().is_none_or(|cur| less_than(cur, v)) {
+            max = Some(v.clone());
+        }
+    }
+    (min, max, null_count)
+}
+
+/// Whether a value type participates in zone map min/max tracking.
+fn has_zone_order(v: &Value) -> bool {
+    matches!(v, Value::Int(_) | Value::Float(_) | Value::Text(_) | Value::Bool(_))
+}
+
+/// Strict less-than comparison for zone map tracking. Only defined for
+/// the ordered scalar types; Vector/Bytea/Null return false.
+fn less_than(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::Int(x), Value::Int(y)) => x < y,
+        (Value::Float(x), Value::Float(y)) => x < y,
+        (Value::Int(x), Value::Float(y)) => (*x as f64) < *y,
+        (Value::Float(x), Value::Int(y)) => *x < (*y as f64),
+        (Value::Text(x), Value::Text(y)) => x.as_ref() < y.as_ref(),
+        (Value::Bool(x), Value::Bool(y)) => !*x && *y,
+        _ => false,
+    }
+}
+
+/// Returns true if `value` is definitely outside [min, max]. Used by
+/// predicate pushdown: if this returns true, the segment can be
+/// skipped entirely for an equality predicate on this value.
+pub fn outside_range(value: &Value, min: &Option<Value>, max: &Option<Value>) -> bool {
+    match (min, max) {
+        (Some(lo), Some(hi)) => less_than(value, lo) || less_than(hi, value),
+        _ => false,
+    }
+}


### PR DESCRIPTION
## Summary

Second PR in the persistence roadmap. Introduces the immutable segment file format that will hold row data on disk. Segments are the on-disk equivalent of the memtable: write once, never mutate in place.

Depends on PR #40 logically (both use bincode) but doesn't depend on it in the git tree - both branches add the dependency independently.

## Layout

```
[header: 32 bytes]
  magic("EVSG":4) version(u16) _res(u16) row_count(u32)
  col_count(u16) _res(u16) footer_offset(u64) _res(u64)
[column 1 data block]
[column 2 data block]
...
[bincoded SegmentFooter with ColumnMeta list]
```

The footer contains per-column metadata with `(offset, length)` so the reader can fetch any column without loading the others. This is the point of columnar storage: scans hit only the columns they need.

## Zone maps

Each column tracks `(min, max, null_count)` computed at write time. PR 6 will use these for predicate pushdown (skip whole segments when a WHERE clause guarantees no matches). Only ordered scalar types (Int/Float/Text/Bool) participate in min/max; Vector/Bytea skip zone tracking since ordering isn't meaningful.

`outside_range` helper is exposed for predicate pushdown integration in later PRs.

## Module structure

All files under 100 lines per the project rule:

| File | Lines | Purpose |
|---|---|---|
| `segment/mod.rs` | 36 | Module declarations + documentation |
| `segment/format.rs` | 65 | Header encode/decode, `ColumnMeta`, `SegmentFooter` |
| `segment/writer.rs` | 84 | `SegmentWriter::write` transposes rows -> columns, writes header + data + footer, fsyncs |
| `segment/reader.rs` | 91 | `SegmentReader` opens, parses header/footer, exposes `read_column` and `read_all_rows` |
| `segment/zone_map.rs` | 59 | `compute_zone_map` and `outside_range` |
| `segment/tests/{mod,basic,zone_maps,large}.rs` | 29+76+79+30 | 10 unit tests |

## Tests

**basic.rs**: round-trip rows, single-column read, empty segment, row arity validation, column metadata preservation
**zone_maps.rs**: int min/max, null exclusion + null_count, all-null column, text ordering
**large.rs**: 10,000 row round-trip with zone map spot-check

Tests: 246 total (was 236). 10 new segment tests all passing.

## Dependencies

Adds `bincode = "1.3"`. Same crate used in PR #40 (WAL foundation).

## What's NOT in this PR

- Vector columns (PR 5) - `Value::Vector` already serializes fine via bincode but segments don't embed HNSW yet
- Per-segment HNSW indexes (PR 4)
- Compression (delta/RLE/dictionary) - deferred to keep PR 2 focused
- Integration with storage layer (PR 3)
- Reading via the storage scan path (PR 3+)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
