### PR TITLE
test: three-valued logic and NULL edge case coverage

### DIFF
--- a/native/engine/src/executor/tests/mod.rs
+++ b/native/engine/src/executor/tests/mod.rs
@@ -58,3 +58,4 @@ mod cte_ext;
 mod upsert;
 mod upsert_ext;
 mod devin_regressions;
+mod null_semantics;

--- a/native/engine/src/executor/tests/null_semantics/aggregates.rs
+++ b/native/engine/src/executor/tests/null_semantics/aggregates.rs
@@ -1,0 +1,36 @@
+use super::super::*;
+
+// ── Aggregates on all-NULL columns ────────────────────────────────────
+// Distinguished from "empty table" cases: the table has rows, but the
+// aggregated column is all NULL. SUM/AVG should return NULL, COUNT(col)
+// should return 0 (NOT NULL - COUNT never returns NULL except from
+// COUNT(col) on an empty table where it would be 0 anyway).
+#[test]
+#[serial_test::serial]
+fn sum_all_null_is_null() {
+    setup();
+    execute("CREATE TABLE san (x int)").unwrap();
+    execute("INSERT INTO san VALUES (NULL), (NULL)").unwrap();
+    let r = execute("SELECT SUM(x) FROM san").unwrap();
+    assert_eq!(r.rows[0][0], None, "SUM of all NULLs should be NULL");
+}
+
+#[test]
+#[serial_test::serial]
+fn avg_all_null_is_null() {
+    setup();
+    execute("CREATE TABLE aan (x int)").unwrap();
+    execute("INSERT INTO aan VALUES (NULL), (NULL)").unwrap();
+    let r = execute("SELECT AVG(x) FROM aan").unwrap();
+    assert_eq!(r.rows[0][0], None, "AVG of all NULLs should be NULL");
+}
+
+#[test]
+#[serial_test::serial]
+fn count_all_null_column_is_zero() {
+    setup();
+    execute("CREATE TABLE can (x int)").unwrap();
+    execute("INSERT INTO can VALUES (NULL), (NULL)").unwrap();
+    let r = execute("SELECT COUNT(x) FROM can").unwrap();
+    assert_eq!(r.rows[0][0], Some("0".into()), "COUNT(col) of all NULLs should be 0");
+}

--- a/native/engine/src/executor/tests/null_semantics/bool_logic.rs
+++ b/native/engine/src/executor/tests/null_semantics/bool_logic.rs
@@ -1,0 +1,44 @@
+use super::super::*;
+
+// ── Three-valued AND/OR ───────────────────────────────────────────────
+// Truth table for WHERE:
+//   TRUE  AND NULL = NULL  -> filtered
+//   FALSE AND NULL = FALSE -> filtered
+//   TRUE  OR  NULL = TRUE  -> kept
+//   FALSE OR  NULL = NULL  -> filtered
+//
+// These tests verify short-circuit behavior: OR returns early on TRUE,
+// AND returns early on FALSE, regardless of NULL operands.
+
+#[test]
+#[serial_test::serial]
+fn true_or_null_is_true() {
+    setup();
+    execute("CREATE TABLE tv (x int, y int)").unwrap();
+    execute("INSERT INTO tv VALUES (1, NULL)").unwrap();
+    // (x = 1) is TRUE, (y = 5) is NULL. TRUE OR NULL = TRUE -> row kept.
+    let r = execute("SELECT x FROM tv WHERE x = 1 OR y = 5").unwrap();
+    assert_eq!(r.rows.len(), 1);
+}
+
+#[test]
+#[serial_test::serial]
+fn false_and_null_is_false() {
+    setup();
+    execute("CREATE TABLE fv (x int, y int)").unwrap();
+    execute("INSERT INTO fv VALUES (1, NULL)").unwrap();
+    // (x = 2) is FALSE. FALSE AND anything = FALSE -> row filtered.
+    let r = execute("SELECT x FROM fv WHERE x = 2 AND y = 5").unwrap();
+    assert_eq!(r.rows.len(), 0);
+}
+
+#[test]
+#[serial_test::serial]
+fn true_and_null_is_null_filters_row() {
+    setup();
+    execute("CREATE TABLE tn (x int, y int)").unwrap();
+    execute("INSERT INTO tn VALUES (1, NULL)").unwrap();
+    // (x = 1) is TRUE, (y = 5) is NULL. TRUE AND NULL = NULL -> filtered.
+    let r = execute("SELECT x FROM tn WHERE x = 1 AND y = 5").unwrap();
+    assert_eq!(r.rows.len(), 0);
+}

--- a/native/engine/src/executor/tests/null_semantics/grouping.rs
+++ b/native/engine/src/executor/tests/null_semantics/grouping.rs
@@ -1,0 +1,22 @@
+use super::super::*;
+
+// ── GROUP BY on NULL ──────────────────────────────────────────────────
+// PostgreSQL: NULLs are considered equal for GROUP BY, so they form a
+// single group. This is the one place NULL = NULL is TRUE (alongside
+// DISTINCT and set operations).
+#[test]
+#[serial_test::serial]
+fn group_by_groups_nulls_together() {
+    setup();
+    execute("CREATE TABLE gbn (category text, val int)").unwrap();
+    execute("INSERT INTO gbn VALUES ('a', 1)").unwrap();
+    execute("INSERT INTO gbn VALUES (NULL, 2)").unwrap();
+    execute("INSERT INTO gbn VALUES (NULL, 3)").unwrap();
+    execute("INSERT INTO gbn VALUES ('a', 4)").unwrap();
+    let r = execute("SELECT category, COUNT(*) FROM gbn GROUP BY category").unwrap();
+    assert_eq!(r.rows.len(), 2, "Two groups: 'a' and NULL");
+    // Find the NULL group - it should have count 2
+    let null_group = r.rows.iter().find(|row| row[0].is_none())
+        .expect("NULL group missing from GROUP BY result");
+    assert_eq!(null_group[1], Some("2".into()));
+}

--- a/native/engine/src/executor/tests/null_semantics/in_not_in.rs
+++ b/native/engine/src/executor/tests/null_semantics/in_not_in.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+
+// ── NOT IN with NULL in the list ──────────────────────────────────────
+// PostgreSQL: `x NOT IN (1, 2, NULL)` returns NULL when x doesn't match.
+// NULL in WHERE filters the row out. So the whole query returns 0 rows.
+#[test]
+#[serial_test::serial]
+fn not_in_null_in_list_filters_row() {
+    setup();
+    execute("CREATE TABLE nin (x int)").unwrap();
+    execute("INSERT INTO nin VALUES (5), (10), (15)").unwrap();
+    let r = execute("SELECT x FROM nin WHERE x NOT IN (1, 2, NULL)").unwrap();
+    assert_eq!(r.rows.len(), 0, "NOT IN with NULL should filter all rows");
+}
+
+// IN with NULL in the list returns TRUE if a non-NULL match exists.
+#[test]
+#[serial_test::serial]
+fn in_null_in_list_still_matches_known_values() {
+    setup();
+    execute("CREATE TABLE iin (x int)").unwrap();
+    execute("INSERT INTO iin VALUES (5), (10)").unwrap();
+    let r = execute("SELECT x FROM iin WHERE x IN (5, NULL)").unwrap();
+    // 5 matches -> TRUE. 10 doesn't match any non-NULL -> NULL -> filtered.
+    assert_eq!(r.rows.len(), 1);
+    assert_eq!(r.rows[0][0], Some("5".into()));
+}

--- a/native/engine/src/executor/tests/null_semantics/mod.rs
+++ b/native/engine/src/executor/tests/null_semantics/mod.rs
@@ -1,0 +1,11 @@
+//! Three-valued logic and NULL edge case tests.
+//!
+//! PostgreSQL uses SQL's three-valued logic (TRUE/FALSE/NULL). These
+//! tests cover the non-obvious cases where intuition disagrees with
+//! the spec. Missing coverage here has historically been the source
+//! of correctness bugs.
+
+mod in_not_in;
+mod aggregates;
+mod grouping;
+mod bool_logic;


### PR DESCRIPTION
## Summary

Adds `tests/null_semantics/` covering cases where SQL's three-valued logic catches out intuition. These are PostgreSQL pitfalls that the existing suite didn't test directly.

All 9 tests pass against the current code, so this PR closes a documentation/coverage gap rather than fixing bugs. The three-valued logic implementation was already correct - we just had no tests locking that in.

## The 9 tests

**in_not_in.rs**:
- `not_in_null_in_list_filters_row` - `x NOT IN (1, 2, NULL)` returns NULL (filters the row), not TRUE. Classic NOT IN trap.
- `in_null_in_list_still_matches_known_values` - `IN` finds non-NULL matches normally; non-matching rows return NULL and filter out.

**aggregates.rs**:
- `sum_all_null_is_null` - SUM over all-NULL values -> NULL (not 0)
- `avg_all_null_is_null` - AVG over all-NULL values -> NULL
- `count_all_null_column_is_zero` - COUNT(col) skips NULLs -> 0 (not NULL)

Distinct from the existing "empty table" tests: the table has rows but the aggregated column is all NULL.

**grouping.rs**:
- `group_by_groups_nulls_together` - NULLs form a single group in GROUP BY. One of the few places `NULL = NULL` is TRUE (alongside DISTINCT and set operations).

**bool_logic.rs**:
- `true_or_null_is_true` - short-circuit OR keeps the row
- `false_and_null_is_false` - short-circuit AND filters the row
- `true_and_null_is_null_filters_row` - no short-circuit, result is NULL, row is filtered

## Why a separate directory

`tests/null_semantics/` sits alongside `tests/devin_regressions/` as a category for cross-feature correctness coverage. Three-valued logic touches WHERE, HAVING, JOIN ON, IN, EXISTS, aggregates, GROUP BY - it's not tied to any one feature file, so a dedicated home makes the category visible.

## Test plan

- [x] All 9 new tests pass (`cargo test null_semantics`)
- [x] Full suite: 245 passed (was 236)
- [x] No file exceeds 100 lines
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
