### PR TITLE
feat: memtable data structure (PR 3/10)

### DIFF
--- a/native/engine/src/lib.rs
+++ b/native/engine/src/lib.rs
@@ -2,6 +2,7 @@ mod arena;
 mod catalog;
 mod executor;
 mod hnsw;
+mod memtable;
 mod parser;
 mod segment;
 mod sequence;

--- a/native/engine/src/memtable/bytes.rs
+++ b/native/engine/src/memtable/bytes.rs
@@ -1,0 +1,19 @@
+use crate::types::Value;
+
+use super::table::MemRow;
+
+/// Rough byte estimate for a row, used for flush threshold decisions.
+/// Includes the fixed MemRow overhead plus variable-length payload.
+pub(super) fn estimate_row_bytes(values: &[Value]) -> usize {
+    let mut bytes = std::mem::size_of::<MemRow>();
+    for v in values {
+        bytes += match v {
+            Value::Null | Value::Bool(_) => 1,
+            Value::Int(_) | Value::Float(_) => 8,
+            Value::Text(s) => s.len(),
+            Value::Bytea(b) => b.len(),
+            Value::Vector(v) => v.len() * 4,
+        };
+    }
+    bytes
+}

--- a/native/engine/src/memtable/mod.rs
+++ b/native/engine/src/memtable/mod.rs
@@ -1,0 +1,36 @@
+//! In-memory buffer for pending writes before segment flush.
+//!
+//! The memtable holds rows that have been written to the WAL but not
+//! yet persisted to an immutable segment file. It serves three roles
+//! in the persistence architecture:
+//!
+//! 1. **Write absorption**: inserts go here after WAL append, so the
+//!    write path doesn't touch on-disk segment files on every mutation.
+//! 2. **Read visibility**: reads merge memtable rows with segment rows
+//!    so recent writes are immediately queryable (read-your-writes).
+//! 3. **Flush source**: when the memtable reaches a size threshold, its
+//!    contents are serialized to a new segment file (PR 4 wires this).
+//!
+//! Per-table memtables are held by the storage layer. Each memtable is
+//! a simple ordered vector of rows; no hash indexes yet. Point lookups
+//! still scan linearly within the memtable, which is fine for small
+//! sizes (a few MB). Larger memtables would benefit from a skiplist or
+//! b-tree, but that optimization is deferred until measurement shows
+//! the linear scan is a bottleneck.
+//!
+//! Mutability model:
+//! - `insert`/`update_at`/`delete_at` append or mutate in place
+//! - `freeze` returns an immutable snapshot for flushing (PR 4)
+//! - Flushed memtables are replaced with a fresh empty one
+//!
+//! Tombstones: deletes are recorded as a marker on the affected row so
+//! reads can still skip them. Segment flush drops tombstoned rows
+//! (PR 4).
+
+mod table;
+mod bytes;
+
+#[cfg(test)]
+mod tests;
+
+pub use table::{Memtable, MemtableStats};

--- a/native/engine/src/memtable/table.rs
+++ b/native/engine/src/memtable/table.rs
@@ -1,0 +1,99 @@
+use crate::types::Value;
+use crate::wal::Lsn;
+
+use super::bytes::estimate_row_bytes;
+
+/// An in-memory row with its WAL LSN and tombstone flag. Tombstoned
+/// rows stay in the table until a segment flush drops them.
+#[derive(Debug, Clone)]
+pub struct MemRow {
+    pub lsn: Lsn,
+    pub values: Vec<Value>,
+    pub tombstone: bool,
+}
+
+/// In-memory buffer for pending writes. Rows are stored in insertion
+/// order; linear scan for point lookups is fine at memtable sizes.
+#[derive(Debug, Default)]
+pub struct Memtable {
+    rows: Vec<MemRow>,
+    /// Approximate byte size for flush threshold decisions.
+    bytes: usize,
+}
+
+/// Snapshot of memtable metrics for flush decisions and observability.
+#[derive(Debug, Clone, Copy)]
+pub struct MemtableStats {
+    pub row_count: usize,
+    pub live_row_count: usize,
+    pub bytes: usize,
+}
+
+impl Memtable {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append a row at the given LSN. Returns the row's position
+    /// within the memtable (stable until freeze/drain).
+    pub fn insert(&mut self, lsn: Lsn, values: Vec<Value>) -> usize {
+        let idx = self.rows.len();
+        self.bytes += estimate_row_bytes(&values);
+        self.rows.push(MemRow { lsn, values, tombstone: false });
+        idx
+    }
+
+    /// Mark a row as deleted. Storage stays allocated until flush.
+    pub fn delete_at(&mut self, idx: usize, lsn: Lsn) -> Result<(), String> {
+        let row = self.rows.get_mut(idx)
+            .ok_or_else(|| format!("memtable: delete index {} out of range", idx))?;
+        row.tombstone = true;
+        row.lsn = lsn;
+        Ok(())
+    }
+
+    /// Replace a row's values in place at the given LSN. The row must
+    /// not already be tombstoned.
+    pub fn update_at(&mut self, idx: usize, lsn: Lsn, new_values: Vec<Value>) -> Result<(), String> {
+        let row = self.rows.get_mut(idx)
+            .ok_or_else(|| format!("memtable: update index {} out of range", idx))?;
+        if row.tombstone {
+            return Err(format!("memtable: cannot update tombstoned row {}", idx));
+        }
+        self.bytes = self.bytes
+            .saturating_sub(estimate_row_bytes(&row.values))
+            .saturating_add(estimate_row_bytes(&new_values));
+        row.values = new_values;
+        row.lsn = lsn;
+        Ok(())
+    }
+
+    /// Iterate live (non-tombstoned) rows in insertion order.
+    pub fn scan(&self) -> impl Iterator<Item = (usize, &[Value])> {
+        self.rows.iter().enumerate()
+            .filter(|(_, r)| !r.tombstone)
+            .map(|(i, r)| (i, r.values.as_slice()))
+    }
+
+    /// Drain all rows and reset the memtable. Used by flush after the
+    /// caller has successfully written a segment file. Returns only
+    /// live rows; tombstones are dropped.
+    pub fn drain_live(&mut self) -> Vec<Vec<Value>> {
+        let drained: Vec<Vec<Value>> = self.rows.drain(..)
+            .filter(|r| !r.tombstone)
+            .map(|r| r.values)
+            .collect();
+        self.bytes = 0;
+        drained
+    }
+
+    pub fn stats(&self) -> MemtableStats {
+        let live = self.rows.iter().filter(|r| !r.tombstone).count();
+        MemtableStats {
+            row_count: self.rows.len(),
+            live_row_count: live,
+            bytes: self.bytes,
+        }
+    }
+}
+

--- a/native/engine/src/memtable/tests/basic.rs
+++ b/native/engine/src/memtable/tests/basic.rs
@@ -1,0 +1,47 @@
+use super::super::*;
+use super::row;
+
+#[test]
+fn insert_and_scan_preserves_order() {
+    let mut mt = Memtable::new();
+    mt.insert(1, row(1, "alice"));
+    mt.insert(2, row(2, "bob"));
+    mt.insert(3, row(3, "carol"));
+
+    let scanned: Vec<(usize, Vec<_>)> = mt.scan().map(|(i, r)| (i, r.to_vec())).collect();
+    assert_eq!(scanned.len(), 3);
+    assert_eq!(scanned[0].0, 0);
+    assert_eq!(scanned[2].0, 2);
+    assert_eq!(scanned[0].1, row(1, "alice"));
+    assert_eq!(scanned[2].1, row(3, "carol"));
+}
+
+#[test]
+fn insert_returns_stable_index() {
+    let mut mt = Memtable::new();
+    assert_eq!(mt.insert(1, row(1, "a")), 0);
+    assert_eq!(mt.insert(2, row(2, "b")), 1);
+    assert_eq!(mt.insert(3, row(3, "c")), 2);
+}
+
+#[test]
+fn empty_memtable_stats() {
+    let mt = Memtable::new();
+    let s = mt.stats();
+    assert_eq!(s.row_count, 0);
+    assert_eq!(s.live_row_count, 0);
+    assert_eq!(s.bytes, 0);
+    assert_eq!(mt.scan().count(), 0);
+}
+
+#[test]
+fn stats_tracks_row_count_and_bytes() {
+    let mut mt = Memtable::new();
+    mt.insert(1, row(1, "a"));
+    mt.insert(2, row(2, "bob"));
+    let s = mt.stats();
+    assert_eq!(s.row_count, 2);
+    assert_eq!(s.live_row_count, 2);
+    // bytes > 0 without locking the exact value (depends on MemRow size)
+    assert!(s.bytes > 0);
+}

--- a/native/engine/src/memtable/tests/drain.rs
+++ b/native/engine/src/memtable/tests/drain.rs
@@ -1,0 +1,43 @@
+use super::super::*;
+use super::row;
+
+#[test]
+fn drain_live_returns_rows_without_tombstones() {
+    let mut mt = Memtable::new();
+    mt.insert(1, row(1, "a"));
+    mt.insert(2, row(2, "b"));
+    mt.insert(3, row(3, "c"));
+    mt.delete_at(1, 10).unwrap(); // tombstone row 2
+
+    let drained = mt.drain_live();
+    assert_eq!(drained.len(), 2);
+    assert_eq!(drained[0], row(1, "a"));
+    assert_eq!(drained[1], row(3, "c"));
+}
+
+#[test]
+fn drain_resets_memtable() {
+    let mut mt = Memtable::new();
+    mt.insert(1, row(1, "a"));
+    mt.insert(2, row(2, "b"));
+
+    let _ = mt.drain_live();
+
+    let s = mt.stats();
+    assert_eq!(s.row_count, 0);
+    assert_eq!(s.live_row_count, 0);
+    assert_eq!(s.bytes, 0);
+    assert_eq!(mt.scan().count(), 0);
+}
+
+#[test]
+fn drain_then_insert_starts_fresh() {
+    let mut mt = Memtable::new();
+    mt.insert(1, row(1, "a"));
+    mt.drain_live();
+
+    // New inserts start at index 0 again (drain resets the Vec)
+    assert_eq!(mt.insert(10, row(99, "new")), 0);
+    let stats = mt.stats();
+    assert_eq!(stats.row_count, 1);
+}

--- a/native/engine/src/memtable/tests/mod.rs
+++ b/native/engine/src/memtable/tests/mod.rs
@@ -1,0 +1,12 @@
+//! Memtable unit tests.
+
+use super::*;
+use crate::types::Value;
+
+mod basic;
+mod mutations;
+mod drain;
+
+pub(super) fn row(id: i64, name: &str) -> Vec<Value> {
+    vec![Value::Int(id), Value::Text(std::sync::Arc::from(name))]
+}

--- a/native/engine/src/memtable/tests/mutations.rs
+++ b/native/engine/src/memtable/tests/mutations.rs
@@ -1,0 +1,56 @@
+use super::super::*;
+use super::row;
+use crate::types::Value;
+
+#[test]
+fn delete_marks_row_as_tombstone_and_hides_from_scan() {
+    let mut mt = Memtable::new();
+    mt.insert(1, row(1, "a"));
+    mt.insert(2, row(2, "b"));
+    mt.insert(3, row(3, "c"));
+
+    mt.delete_at(1, 10).unwrap();
+
+    let visible: Vec<_> = mt.scan().map(|(_, r)| r[0].clone()).collect();
+    assert_eq!(visible, vec![Value::Int(1), Value::Int(3)]);
+
+    let s = mt.stats();
+    assert_eq!(s.row_count, 3, "tombstone kept in row_count");
+    assert_eq!(s.live_row_count, 2, "tombstone excluded from live_row_count");
+}
+
+#[test]
+fn update_replaces_values_in_place() {
+    let mut mt = Memtable::new();
+    mt.insert(1, row(1, "alice"));
+    mt.update_at(0, 2, row(1, "alice_v2")).unwrap();
+
+    let scanned: Vec<_> = mt.scan().map(|(_, r)| r.to_vec()).collect();
+    assert_eq!(scanned.len(), 1);
+    assert_eq!(scanned[0], row(1, "alice_v2"));
+}
+
+#[test]
+fn update_fails_on_tombstoned_row() {
+    let mut mt = Memtable::new();
+    mt.insert(1, row(1, "a"));
+    mt.delete_at(0, 2).unwrap();
+    let r = mt.update_at(0, 3, row(1, "b"));
+    assert!(r.is_err());
+    assert!(r.unwrap_err().contains("tombstoned"));
+}
+
+#[test]
+fn delete_out_of_range_errors() {
+    let mut mt = Memtable::new();
+    mt.insert(1, row(1, "a"));
+    let r = mt.delete_at(99, 2);
+    assert!(r.is_err());
+}
+
+#[test]
+fn update_out_of_range_errors() {
+    let mut mt = Memtable::new();
+    let r = mt.update_at(0, 1, row(1, "a"));
+    assert!(r.is_err());
+}


### PR DESCRIPTION
## Summary

Third PR in the persistence roadmap. Introduces the in-memory buffer for pending writes. This is a standalone data structure; integration with the storage layer comes in PR 4.

## Design

- Per-table memtable, each holds a `Vec<MemRow>`
- Rows tracked with their WAL LSN for recovery and flush ordering
- Deletes are tombstones (not physical removal) so index positions stay stable until drain
- Linear scan for point lookups - fine at memtable sizes (~MB)
- Byte estimate tracked for flush threshold decisions

## Public API

```rust
pub struct Memtable { /* ... */ }
pub struct MemtableStats { pub row_count: usize, pub live_row_count: usize, pub bytes: usize }

impl Memtable {
    pub fn new() -> Self;
    pub fn insert(&mut self, lsn: Lsn, values: Vec<Value>) -> usize;
    pub fn update_at(&mut self, idx: usize, lsn: Lsn, new_values: Vec<Value>) -> Result<(), String>;
    pub fn delete_at(&mut self, idx: usize, lsn: Lsn) -> Result<(), String>;
    pub fn scan(&self) -> impl Iterator<Item = (usize, &[Value])>;
    pub fn drain_live(&mut self) -> Vec<Vec<Value>>;
    pub fn stats(&self) -> MemtableStats;
}
```

## Files (all under 100 lines)

| File | Lines | Purpose |
|---|---|---|
| `memtable/mod.rs` | 36 | Module docs + public API |
| `memtable/table.rs` | 99 | `Memtable`, `MemRow`, `MemtableStats` |
| `memtable/bytes.rs` | 19 | Row byte estimation |
| `memtable/tests/{mod,basic,mutations,drain}.rs` | 12+47+56+43 | 12 unit tests |

## Tests

**basic**: insert ordering, stable indexes, empty stats, stats tracking
**mutations**: tombstone delete, update in place, tombstoned-row update error, out-of-range errors
**drain**: live-only drain, post-drain reset, fresh insert after drain

Tests: 282 total (was 270).

## Not in this PR

- Per-table memtable registry (PR 4)
- WAL wire-in: writes go WAL -> memtable (PR 4)
- Memtable flush to segment (PR 4)
- Read integration: merge memtable with segment scans (PR 4)
- Skiplist/btree index - deferred until measurement shows linear is the bottleneck
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
