### PR TITLE
feat: WAL integration with storage INSERT path (PR 4/10)

### DIFF
--- a/native/engine/src/storage.rs
+++ b/native/engine/src/storage.rs
@@ -352,6 +352,13 @@ pub fn insert_batch_checked(
         }
     }
 
+    // WAL durability: append each row to the log and fsync before
+    // committing to the in-memory store. No-op when WAL is disabled.
+    // This happens AFTER validation so we never log a row we'll reject.
+    for row in rows.iter() {
+        crate::wal::manager::append_insert(schema, name, row)?;
+    }
+
     // All validated - push all atomically and update indexes
     let base_row_id = table.rows.len();
     for (i, row) in rows.into_iter().enumerate() {

--- a/native/engine/src/wal/manager.rs
+++ b/native/engine/src/wal/manager.rs
@@ -1,0 +1,91 @@
+//! Global WAL manager: lifecycle + write hooks for the storage layer.
+//!
+//! Storage mutation paths call `append_insert` (and eventually
+//! `append_update`, `append_delete`) before committing. If no WAL is
+//! configured, the calls are no-ops and the write path is unchanged.
+//!
+//! Configuration via env vars:
+//! - `EVOLVSQL_WAL_ENABLED=1` turns WAL on
+//! - `EVOLVSQL_WAL_PATH=/path/to/wal` sets the log file location
+//!   (default: `./evolvsql.wal`)
+//!
+//! A single global WalWriter is shared across all tables. This matches
+//! PostgreSQL's approach and is simpler than per-table logs.
+
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use crate::types::Value;
+
+use super::{Lsn, WalEntry, WalOp, WalReader, WalWriter};
+
+static WAL: RwLock<Option<Arc<WalWriter>>> = RwLock::new(None);
+
+/// Enable the WAL with an explicit path. Idempotent: if called twice
+/// with the same path, the second call is a no-op.
+pub fn enable<P: AsRef<std::path::Path>>(path: P) -> Result<(), String> {
+    let mut guard = WAL.write();
+    if let Some(existing) = guard.as_ref() {
+        if existing.path() == path.as_ref() {
+            return Ok(());
+        }
+    }
+    let writer = WalWriter::open(path, 1)?;
+    *guard = Some(Arc::new(writer));
+    Ok(())
+}
+
+/// Enable the WAL from environment variables. Called at startup when
+/// `EVOLVSQL_WAL_ENABLED=1`. Returns Ok(true) if enabled, Ok(false) if
+/// the env var is off, or Err on open failure.
+pub fn enable_from_env() -> Result<bool, String> {
+    match std::env::var("EVOLVSQL_WAL_ENABLED") {
+        Ok(v) if v == "1" => {
+            let path = std::env::var("EVOLVSQL_WAL_PATH")
+                .unwrap_or_else(|_| "./evolvsql.wal".to_string());
+            enable(&path)?;
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+/// Disable the WAL and drop the writer. Does not delete the WAL file.
+/// Used by tests to reset between cases.
+pub fn disable() {
+    *WAL.write() = None;
+}
+
+/// True if the WAL is currently enabled.
+pub fn is_enabled() -> bool {
+    WAL.read().is_some()
+}
+
+/// Append an Insert entry. No-op if WAL is disabled. Fsyncs before
+/// returning so the write is durable.
+pub fn append_insert(schema: &str, table: &str, row: &[Value]) -> Result<Option<Lsn>, String> {
+    let guard = WAL.read();
+    let Some(writer) = guard.as_ref() else { return Ok(None); };
+    let op = WalOp::Insert {
+        schema: schema.to_string(),
+        table: table.to_string(),
+        row: row.to_vec(),
+    };
+    let lsn = writer.append(op)?;
+    writer.flush_sync()?;
+    Ok(Some(lsn))
+}
+
+/// Read all entries from the configured WAL file. Used for recovery.
+/// Returns an empty vec if WAL is disabled or the file doesn't exist.
+pub fn read_all() -> Result<Vec<WalEntry>, String> {
+    let guard = WAL.read();
+    let Some(writer) = guard.as_ref() else { return Ok(vec![]); };
+    let path = writer.path().to_path_buf();
+    drop(guard);
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+    WalReader::open(&path)?.read_all()
+}

--- a/native/engine/src/wal/mod.rs
+++ b/native/engine/src/wal/mod.rs
@@ -19,6 +19,7 @@
 mod entry;
 mod writer;
 mod reader;
+pub mod manager;
 
 #[cfg(test)]
 mod tests;

--- a/native/engine/src/wal/tests/manager_tests.rs
+++ b/native/engine/src/wal/tests/manager_tests.rs
@@ -1,0 +1,66 @@
+use super::super::*;
+use crate::types::Value;
+
+fn tmp_manager_path(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("evolvsql_mgr_{}_{}.log", name, std::process::id()));
+    let _ = std::fs::remove_file(&p);
+    p
+}
+
+fn int_row(id: i64) -> Vec<Value> {
+    vec![Value::Int(id)]
+}
+
+#[test]
+#[serial_test::serial]
+fn append_noop_when_disabled() {
+    manager::disable();
+    assert!(!manager::is_enabled());
+    let result = manager::append_insert("public", "t", &int_row(1)).unwrap();
+    assert_eq!(result, None, "disabled WAL should return None");
+}
+
+#[test]
+#[serial_test::serial]
+fn enable_and_append_persists_to_disk() {
+    let path = tmp_manager_path("persist");
+    manager::disable();
+    manager::enable(&path).unwrap();
+    assert!(manager::is_enabled());
+
+    let lsn = manager::append_insert("public", "t", &int_row(42)).unwrap();
+    assert_eq!(lsn, Some(1));
+
+    // Read back via the manager's read_all
+    let entries = manager::read_all().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert!(matches!(&entries[0].op, WalOp::Insert { .. }));
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn read_all_returns_empty_when_disabled() {
+    manager::disable();
+    let entries = manager::read_all().unwrap();
+    assert!(entries.is_empty());
+}
+
+#[test]
+#[serial_test::serial]
+fn multiple_appends_assigned_sequential_lsns() {
+    let path = tmp_manager_path("seq");
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    let l1 = manager::append_insert("public", "t", &int_row(1)).unwrap().unwrap();
+    let l2 = manager::append_insert("public", "t", &int_row(2)).unwrap().unwrap();
+    let l3 = manager::append_insert("public", "t", &int_row(3)).unwrap().unwrap();
+    assert_eq!((l1, l2, l3), (1, 2, 3));
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/wal/tests/mod.rs
+++ b/native/engine/src/wal/tests/mod.rs
@@ -6,6 +6,8 @@ use crate::types::Value;
 mod basic;
 mod corruption;
 mod payload;
+mod manager_tests;
+mod storage_integration;
 
 pub(super) fn tmp_wal_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();

--- a/native/engine/src/wal/tests/storage_integration.rs
+++ b/native/engine/src/wal/tests/storage_integration.rs
@@ -1,0 +1,81 @@
+//! Integration test for the WAL hook in storage::insert_batch_checked.
+//! Verifies the full flow: enable manager -> INSERT via executor ->
+//! WAL file contains the expected entries.
+
+use super::super::*;
+use crate::{catalog, executor, storage, types::Value};
+
+fn tmp_integration_path(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("evolvsql_integ_{}_{}.log", name, std::process::id()));
+    let _ = std::fs::remove_file(&p);
+    p
+}
+
+#[test]
+#[serial_test::serial]
+fn insert_batch_appends_to_wal_when_enabled() {
+    let path = tmp_integration_path("insert_batch");
+    catalog::reset();
+    storage::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE users (id int, name text)").unwrap();
+    executor::execute("INSERT INTO users VALUES (1, 'alice'), (2, 'bob')").unwrap();
+
+    let entries = manager::read_all().unwrap();
+    assert_eq!(entries.len(), 2);
+    for e in &entries {
+        match &e.op {
+            WalOp::Insert { schema, table, row } => {
+                assert_eq!(schema, "public");
+                assert_eq!(table, "users");
+                assert_eq!(row.len(), 2);
+            }
+            _ => panic!("expected Insert, got {:?}", e.op),
+        }
+    }
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn insert_without_wal_unchanged() {
+    // Sanity: existing behavior unchanged when WAL is disabled
+    catalog::reset();
+    storage::reset();
+    manager::disable();
+
+    executor::execute("CREATE TABLE u2 (id int)").unwrap();
+    executor::execute("INSERT INTO u2 VALUES (1), (2), (3)").unwrap();
+    let r = executor::execute("SELECT COUNT(*) FROM u2").unwrap();
+    assert_eq!(r.rows[0][0], Some("3".into()));
+}
+
+#[test]
+#[serial_test::serial]
+fn wal_has_row_values_including_vector() {
+    let path = tmp_integration_path("vec");
+    catalog::reset();
+    storage::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE embeds (id int, vec vector)").unwrap();
+    executor::execute("INSERT INTO embeds VALUES (1, '[0.1, 0.2, 0.3]')").unwrap();
+
+    let entries = manager::read_all().unwrap();
+    assert_eq!(entries.len(), 1);
+    if let WalOp::Insert { row, .. } = &entries[0].op {
+        assert!(matches!(row[0], Value::Int(1)));
+        assert!(matches!(row[1], Value::Vector(_)));
+    } else {
+        panic!("expected Insert");
+    }
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}


### PR DESCRIPTION
## Summary

Wires the WAL into `storage::insert_batch_checked`. Writes go to the log and fsync **before** committing to the in-memory store. No-op when WAL is disabled (default), so existing tests and behavior are unchanged.

This is the first PR that produces actual durability: with `EVOLVSQL_WAL_ENABLED=1`, an INSERT is persisted to disk before the client sees OK.

## `wal::manager` module

Global `WalWriter` singleton with idempotent enable/disable and env-var auto-config:

```rust
pub fn enable(path) -> Result<(), String>;
pub fn enable_from_env() -> Result<bool, String>;  // EVOLVSQL_WAL_ENABLED=1
pub fn disable();
pub fn is_enabled() -> bool;
pub fn append_insert(schema, table, row) -> Result<Option<Lsn>, String>;
pub fn read_all() -> Result<Vec<WalEntry>, String>;
```

Implemented with `RwLock<Option<Arc<WalWriter>>>` for cheap fast-path reads when enabled.

## Storage hook

One block added to `insert_batch_checked` at the post-validation, pre-commit point:

```rust
for row in rows.iter() {
    crate::wal::manager::append_insert(schema, name, row)?;
}
```

**Ordering matters:**
1. Validate all rows (constraints, types) — reject early
2. Append to WAL + fsync — write is now durable
3. Commit to in-memory store + indexes

If a crash happens between step 2 and step 3, the WAL has extra entries that never made it to storage. Recovery will replay them cleanly because they already passed constraint checks.

## Tests (7 new)

**manager_tests.rs** (4):
- `append_noop_when_disabled` - disabled WAL returns `None`
- `enable_and_append_persists_to_disk` - full round-trip
- `read_all_returns_empty_when_disabled` - safe to call without config
- `multiple_appends_assigned_sequential_lsns` - LSN monotonicity

**storage_integration.rs** (3):
- `insert_batch_appends_to_wal_when_enabled` - executor -> storage -> WAL flow
- `insert_without_wal_unchanged` - sanity that WAL off doesn't break anything
- `wal_has_row_values_including_vector` - `Value::Vector` round-trips through the full path

Tests: 289 total (was 282).

## Not in this PR

- UPDATE/DELETE hooks - need row_id semantics first
- Startup recovery (replay WAL into storage) - PR 5
- Memtable integration - PR 5 (comes with recovery since both need LSN tracking)
- Flush triggered by memtable size - PR 6+
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
