### PR TITLE
feat: WAL DDL logging (PR 7/10) - self-bootstrapping recovery

### DIFF
--- a/native/engine/src/executor/ddl.rs
+++ b/native/engine/src/executor/ddl.rs
@@ -31,6 +31,8 @@ pub(crate) fn exec_create_table(create: &pg_query::protobuf::CreateStmt) -> Resu
     catalog::create_table(table.clone())?;
     storage::create_table(schema, table_name);
     setup_indexes(&table, schema, table_name)?;
+    // WAL: log DDL so recovery can rebuild the schema without re-parsing SQL
+    crate::wal::manager::append_create_table(&table)?;
     Ok(QueryResult { tag: "CREATE TABLE".into(), columns: vec![], rows: vec![] })
 }
 

--- a/native/engine/src/executor/ddl_alter.rs
+++ b/native/engine/src/executor/ddl_alter.rs
@@ -21,6 +21,8 @@ pub(crate) fn exec_drop(drop: &pg_query::protobuf::DropStmt) -> Result<QueryResu
             if drop.missing_ok && catalog::get_table(schema, name).is_none() { continue; }
             catalog::drop_table(schema, name)?;
             storage::drop_table(schema, name);
+            // WAL: log drop so recovery doesn't replay the table creation
+            crate::wal::manager::append_drop_table(schema, name)?;
         }
     }
     Ok(QueryResult { tag: "DROP TABLE".into(), columns: vec![], rows: vec![] })

--- a/native/engine/src/wal/entry.rs
+++ b/native/engine/src/wal/entry.rs
@@ -1,10 +1,11 @@
 use serde::{Deserialize, Serialize};
 
+use crate::catalog::Table;
 use crate::types::Value;
 use super::Lsn;
 
 /// A single WAL entry: a log sequence number + the operation it records.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct WalEntry {
     pub lsn: Lsn,
     pub op: WalOp,
@@ -21,11 +22,15 @@ pub struct WalEntry {
 /// UPDATE/DELETE will affect the first match. This matches PostgreSQL's
 /// semantics for tables without a unique key (the "any matching row"
 /// contract).
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum WalOp {
     Insert { schema: String, table: String, row: Vec<Value> },
     Update { schema: String, table: String, old_row: Vec<Value>, new_row: Vec<Value> },
     Delete { schema: String, table: String, old_row: Vec<Value> },
+    /// Full table definition. Replay constructs the table via catalog + storage.
+    CreateTable { table: Table },
+    /// Drop a table by fully qualified name.
+    DropTable { schema: String, table: String },
     /// Marks a transaction boundary for group commit.
     Commit { txn_id: u64 },
     /// Marks the LSN up to which a memtable flush has persisted data.
@@ -39,6 +44,8 @@ pub(super) const OP_UPDATE: u8 = 2;
 pub(super) const OP_DELETE: u8 = 3;
 pub(super) const OP_COMMIT: u8 = 4;
 pub(super) const OP_CHECKPOINT: u8 = 5;
+pub(super) const OP_CREATE_TABLE: u8 = 6;
+pub(super) const OP_DROP_TABLE: u8 = 7;
 
 impl WalOp {
     pub(super) fn tag(&self) -> u8 {
@@ -48,6 +55,8 @@ impl WalOp {
             WalOp::Delete { .. } => OP_DELETE,
             WalOp::Commit { .. } => OP_COMMIT,
             WalOp::Checkpoint { .. } => OP_CHECKPOINT,
+            WalOp::CreateTable { .. } => OP_CREATE_TABLE,
+            WalOp::DropTable { .. } => OP_DROP_TABLE,
         }
     }
 

--- a/native/engine/src/wal/manager/mod.rs
+++ b/native/engine/src/wal/manager/mod.rs
@@ -13,7 +13,7 @@ mod lifecycle;
 mod ops;
 
 pub use lifecycle::{enable, enable_at_lsn, enable_from_env, disable, is_enabled, read_all, suspend_for_replay};
-pub use ops::{append_insert, append_update, append_delete};
+pub use ops::{append_insert, append_update, append_delete, append_create_table, append_drop_table};
 
 use std::sync::Arc;
 use parking_lot::RwLock;

--- a/native/engine/src/wal/manager/ops.rs
+++ b/native/engine/src/wal/manager/ops.rs
@@ -1,3 +1,4 @@
+use crate::catalog::Table;
 use crate::types::Value;
 
 use super::super::{Lsn, WalOp};
@@ -30,6 +31,20 @@ pub fn append_delete(schema: &str, table: &str, old_row: &[Value]) -> Result<Opt
         schema: schema.to_string(),
         table: table.to_string(),
         old_row: old_row.to_vec(),
+    })
+}
+
+/// Append a CreateTable entry. The full table definition is serialized
+/// so recovery can recreate catalog + storage state without re-parsing SQL.
+pub fn append_create_table(table: &Table) -> Result<Option<Lsn>, String> {
+    append_op(WalOp::CreateTable { table: table.clone() })
+}
+
+/// Append a DropTable entry.
+pub fn append_drop_table(schema: &str, table: &str) -> Result<Option<Lsn>, String> {
+    append_op(WalOp::DropTable {
+        schema: schema.to_string(),
+        table: table.to_string(),
     })
 }
 

--- a/native/engine/src/wal/recovery/apply.rs
+++ b/native/engine/src/wal/recovery/apply.rs
@@ -26,6 +26,27 @@ pub fn apply_entries(entries: &[WalEntry]) -> Result<usize, String> {
                 apply_delete(schema, table, old_row)?;
                 applied += 1;
             }
+            WalOp::CreateTable { table } => {
+                // Idempotent: skip if table already exists in this
+                // session (e.g., partial replay or double-recover).
+                if catalog::get_table(&table.schema, &table.name).is_some() { continue; }
+                catalog::create_table(table.clone())?;
+                storage::create_table(&table.schema, &table.name);
+                // Re-build indexes for any columns with PK/UNIQUE constraints
+                for (i, col) in table.columns.iter().enumerate() {
+                    if col.primary_key || col.unique {
+                        let _ = storage::add_unique_index(&table.schema, &table.name, i);
+                    }
+                }
+                applied += 1;
+            }
+            WalOp::DropTable { schema, table } => {
+                if catalog::get_table(schema, table).is_some() {
+                    catalog::drop_table(schema, table)?;
+                    storage::drop_table(schema, table);
+                }
+                applied += 1;
+            }
             _ => {} // Commit, Checkpoint: no-op for now
         }
     }

--- a/native/engine/src/wal/tests/basic.rs
+++ b/native/engine/src/wal/tests/basic.rs
@@ -12,7 +12,14 @@ fn append_and_read_single_entry() {
     let entries = WalReader::open(&path).unwrap().read_all().unwrap();
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].lsn, 1);
-    assert_eq!(entries[0].op, insert_op(1, "alice"));
+    match &entries[0].op {
+        WalOp::Insert { schema, table, row } => {
+            assert_eq!(schema, "public");
+            assert_eq!(table, "users");
+            assert_eq!(row.len(), 2);
+        }
+        _ => panic!("expected Insert op"),
+    }
     std::fs::remove_file(&path).ok();
 }
 

--- a/native/engine/src/wal/tests/recovery/ddl.rs
+++ b/native/engine/src/wal/tests/recovery/ddl.rs
@@ -1,0 +1,65 @@
+//! Recovery tests for DDL operations. After PR 7, CreateTable and
+//! DropTable entries are logged, so recovery can rebuild the entire
+//! catalog without any external SQL.
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, executor, storage};
+
+#[test]
+#[serial_test::serial]
+fn recover_from_empty_catalog_rebuilds_everything() {
+    let path = tmp_recovery_path("full_rebuild");
+    catalog::reset();
+    storage::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    // Create multiple tables with data
+    executor::execute("CREATE TABLE users (id int, name text)").unwrap();
+    executor::execute("CREATE TABLE orders (id int, amount int)").unwrap();
+    executor::execute("INSERT INTO users VALUES (1, 'alice'), (2, 'bob')").unwrap();
+    executor::execute("INSERT INTO orders VALUES (10, 100), (20, 200)").unwrap();
+
+    // Total wipe: catalog AND storage
+    catalog::reset();
+    storage::reset();
+
+    // Recovery alone should rebuild both tables and all rows
+    let applied = recovery::recover().unwrap();
+    assert_eq!(applied, 6, "2 CreateTable + 4 Inserts");
+
+    let users = executor::execute("SELECT * FROM users ORDER BY id").unwrap();
+    assert_eq!(users.rows.len(), 2);
+    let orders = executor::execute("SELECT * FROM orders ORDER BY id").unwrap();
+    assert_eq!(orders.rows.len(), 2);
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_replays_drop_table() {
+    let path = tmp_recovery_path("drop");
+    catalog::reset();
+    storage::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE doomed (id int)").unwrap();
+    executor::execute("INSERT INTO doomed VALUES (1), (2)").unwrap();
+    executor::execute("DROP TABLE doomed").unwrap();
+
+    catalog::reset();
+    storage::reset();
+
+    // Recover: the DROP should leave the table gone even though
+    // we had earlier CREATE and INSERT entries
+    recovery::recover().unwrap();
+    let r = executor::execute("SELECT * FROM doomed");
+    assert!(r.is_err(), "doomed table should not exist after recovery");
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/wal/tests/recovery/errors.rs
+++ b/native/engine/src/wal/tests/recovery/errors.rs
@@ -13,23 +13,29 @@ fn recover_errors_when_wal_disabled() {
 
 #[test]
 #[serial_test::serial]
-fn recover_skips_entries_for_missing_tables() {
-    let path = tmp_recovery_path("missing");
+fn recover_recreates_tables_from_ddl_log() {
+    // With DDL logging (PR 7), recovery rebuilds the catalog from
+    // the WAL's CreateTable entries. No external CREATE needed.
+    let path = tmp_recovery_path("ddl");
     catalog::reset();
     storage::reset();
     manager::disable();
     manager::enable(&path).unwrap();
 
-    executor::execute("CREATE TABLE a (id int)").unwrap();
-    executor::execute("INSERT INTO a VALUES (1), (2)").unwrap();
+    executor::execute("CREATE TABLE a (id int, name text)").unwrap();
+    executor::execute("INSERT INTO a VALUES (1, 'x'), (2, 'y')").unwrap();
 
-    // Simulate restart without recreating table A
+    // Simulate restart: clear everything including catalog
     storage::reset();
     catalog::reset();
-    executor::execute("CREATE TABLE b (id int)").unwrap();
 
+    // Recovery should recreate table a AND apply the inserts
     let applied = recovery::recover().unwrap();
-    assert_eq!(applied, 0, "entries for missing table should be skipped");
+    assert_eq!(applied, 3, "1 CreateTable + 2 Inserts");
+
+    let r = executor::execute("SELECT id, name FROM a ORDER BY id").unwrap();
+    assert_eq!(r.rows.len(), 2);
+    assert_eq!(r.rows[0][1], Some("x".into()));
 
     manager::disable();
     std::fs::remove_file(&path).ok();

--- a/native/engine/src/wal/tests/recovery/mod.rs
+++ b/native/engine/src/wal/tests/recovery/mod.rs
@@ -5,6 +5,7 @@ mod basic;
 mod errors;
 mod vector;
 mod mutations;
+mod ddl;
 
 pub(super) fn tmp_recovery_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();

--- a/native/engine/src/wal/tests/storage_integration.rs
+++ b/native/engine/src/wal/tests/storage_integration.rs
@@ -25,17 +25,11 @@ fn insert_batch_appends_to_wal_when_enabled() {
     executor::execute("INSERT INTO users VALUES (1, 'alice'), (2, 'bob')").unwrap();
 
     let entries = manager::read_all().unwrap();
-    assert_eq!(entries.len(), 2);
-    for e in &entries {
-        match &e.op {
-            WalOp::Insert { schema, table, row } => {
-                assert_eq!(schema, "public");
-                assert_eq!(table, "users");
-                assert_eq!(row.len(), 2);
-            }
-            _ => panic!("expected Insert, got {:?}", e.op),
-        }
-    }
+    // 1 CreateTable + 2 Inserts
+    assert_eq!(entries.len(), 3);
+    assert!(matches!(&entries[0].op, WalOp::CreateTable { .. }));
+    let inserts: Vec<_> = entries.iter().filter(|e| matches!(e.op, WalOp::Insert { .. })).collect();
+    assert_eq!(inserts.len(), 2);
 
     manager::disable();
     std::fs::remove_file(&path).ok();
@@ -68,8 +62,11 @@ fn wal_has_row_values_including_vector() {
     executor::execute("INSERT INTO embeds VALUES (1, '[0.1, 0.2, 0.3]')").unwrap();
 
     let entries = manager::read_all().unwrap();
-    assert_eq!(entries.len(), 1);
-    if let WalOp::Insert { row, .. } = &entries[0].op {
+    // 1 CreateTable + 1 Insert
+    assert_eq!(entries.len(), 2);
+    let insert_entry = entries.iter().find(|e| matches!(e.op, WalOp::Insert { .. }))
+        .expect("insert entry missing");
+    if let WalOp::Insert { row, .. } = &insert_entry.op {
         assert!(matches!(row[0], Value::Int(1)));
         assert!(matches!(row[1], Value::Vector(_)));
     } else {


### PR DESCRIPTION
## Summary

CREATE TABLE and DROP TABLE are now logged to the WAL. Recovery can rebuild the entire catalog and data from an empty state - no external SQL needed anymore.

This is the PR that makes persistence actually complete. Before this, recovery needed the caller to pre-populate the catalog (useless in practice). After this, a crash + restart sequence is:

```
1. Process starts with empty catalog and storage
2. wal::manager::enable_from_env() opens the WAL file
3. wal::recovery::recover() replays all entries:
   - Creates tables from CreateTable entries
   - Applies Insert/Update/Delete entries
   - Drops tables marked by DropTable entries
4. Process is ready to serve queries with the exact pre-crash state
```

## WalOp additions

```rust
CreateTable { table: catalog::Table }
DropTable { schema: String, table: String }
```

Reuses the existing `catalog::Table` serde impl (no new serialization code needed). `Table` doesn't implement `PartialEq` though, so `WalOp` and `WalEntry` lost their `PartialEq` derive. Tests using `assert_eq!` on `WalOp` were updated to use pattern matching.

## Storage and executor hooks

- `ddl::exec_create_table`: `append_create_table` after catalog commit
- `ddl_alter::exec_drop`: `append_drop_table` after catalog drop
- `recovery/apply.rs`: `CreateTable` recreates the table with indexes, `DropTable` drops it. Both are idempotent (skip if already matches desired state).

## Tests

**New** (`recovery/ddl.rs`):
- `recover_from_empty_catalog_rebuilds_everything` - 2 tables, 4 rows across them, total wipe, recovery rebuilds everything. **This is the self-bootstrapping proof.**
- `recover_replays_drop_table` - CREATE + INSERT + DROP sequence, wipe, recovery honors the final DROP

**Updated** (`recovery/errors.rs`):
- `recover_skips_entries_for_missing_tables` replaced with `recover_recreates_tables_from_ddl_log` - tables are now recreated instead of skipped

**Updated** (`storage_integration.rs`, `basic.rs`): expected entry counts now include `CreateTable` entries

Tests: 298 total (was 296).

## Remaining durability gaps (later PRs)

- ALTER TABLE ADD/DROP COLUMN not yet logged
- Sequences (SERIAL) not logged - SERIAL columns recover but the sequence state is lost. `nextval()` after recovery starts from 1.
- Indexes beyond PK/UNIQUE not logged
- HNSW vector indexes rebuilt on table access, not replayed
- Memtable flush and WAL truncation - PR 8

## Persistence roadmap: 7 of 10 PRs merged

| PR | Status | What |
|---|---|---|
| #40 | merged | WAL foundation |
| #42 | merged | Segment format |
| #44 | merged | Memtable |
| #45 | merged | INSERT hook |
| #46 | merged | Startup recovery |
| #47 | merged | UPDATE/DELETE hooks |
| #48 | this PR | **DDL logging** |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
