### PR TITLE
test: harden persistence path with 11 corruption + edge-case tests

### DIFF
--- a/native/engine/src/memtable/tests/mod.rs
+++ b/native/engine/src/memtable/tests/mod.rs
@@ -6,6 +6,7 @@ use crate::types::Value;
 mod basic;
 mod mutations;
 mod drain;
+mod stability;
 
 pub(super) fn row(id: i64, name: &str) -> Vec<Value> {
     vec![Value::Int(id), Value::Text(std::sync::Arc::from(name))]

--- a/native/engine/src/memtable/tests/stability.rs
+++ b/native/engine/src/memtable/tests/stability.rs
@@ -1,0 +1,67 @@
+//! Tombstones must not shift indices of surviving rows. If delete ever
+//! caused a live row to move, subsequent update_at/delete_at calls
+//! would hit the wrong row and silently corrupt data. These tests lock
+//! that invariant in place.
+
+use super::super::*;
+use super::row;
+use crate::types::Value;
+
+#[test]
+fn indices_are_stable_across_deletes_and_updates() {
+    let mut mt = Memtable::new();
+    let i0 = mt.insert(1, row(10, "a"));
+    let i1 = mt.insert(2, row(20, "b"));
+    let i2 = mt.insert(3, row(30, "c"));
+    let i3 = mt.insert(4, row(40, "d"));
+    assert_eq!((i0, i1, i2, i3), (0, 1, 2, 3));
+
+    // Delete the middle row, then update a later one. The update MUST
+    // still target the original index — not shift down to fill the hole.
+    mt.delete_at(i1, 10).unwrap();
+    mt.update_at(i2, 11, row(99, "c_v2")).unwrap();
+
+    // Scan returns (index, row). Check that i2 was the row that changed
+    // and i0/i3 are untouched.
+    let visible: Vec<(usize, Vec<Value>)> =
+        mt.scan().map(|(i, r)| (i, r.to_vec())).collect();
+    assert_eq!(visible.len(), 3);
+    assert_eq!(visible[0], (0, row(10, "a")));
+    assert_eq!(visible[1], (2, row(99, "c_v2")));
+    assert_eq!(visible[2], (3, row(40, "d")));
+}
+
+#[test]
+fn inserts_after_delete_keep_appending() {
+    // After a delete, the next insert gets the next sequential index.
+    // We don't reuse the tombstoned slot. Reuse would break any
+    // executor that cached an index from a prior scan.
+    let mut mt = Memtable::new();
+    mt.insert(1, row(1, "a"));
+    mt.insert(2, row(2, "b"));
+    mt.delete_at(0, 3).unwrap();
+
+    let new_idx = mt.insert(4, row(3, "c"));
+    assert_eq!(new_idx, 2, "new insert must not reuse tombstoned slot 0");
+
+    let stats = mt.stats();
+    assert_eq!(stats.row_count, 3);
+    assert_eq!(stats.live_row_count, 2);
+}
+
+#[test]
+fn drain_compacts_tombstones_and_resets_indices() {
+    let mut mt = Memtable::new();
+    mt.insert(1, row(1, "a"));
+    mt.insert(2, row(2, "b"));
+    mt.insert(3, row(3, "c"));
+    mt.delete_at(0, 10).unwrap();
+    mt.delete_at(2, 11).unwrap();
+
+    let drained = mt.drain_live();
+    assert_eq!(drained, vec![row(2, "b")]);
+
+    // Post-drain, the index space restarts at 0.
+    let new_idx = mt.insert(12, row(99, "z"));
+    assert_eq!(new_idx, 0);
+}

--- a/native/engine/src/segment/tests/edge_types.rs
+++ b/native/engine/src/segment/tests/edge_types.rs
@@ -1,0 +1,76 @@
+//! Segment round-trip for edge column types (bool, float) and sizes
+//! (single row). Catches bincode/zone-map bugs that only show up on
+//! non-int/non-text columns.
+
+use super::super::*;
+use super::tmp_path;
+use crate::types::Value;
+
+#[test]
+fn bool_column_roundtrip_and_zone_map() {
+    let path = tmp_path("bool");
+    let schema = vec![("flag".into(), 16)]; // bool OID
+    let rows: Vec<Vec<Value>> = vec![
+        vec![Value::Bool(true)],
+        vec![Value::Bool(false)],
+        vec![Value::Bool(true)],
+    ];
+    SegmentWriter::write(&path, &schema, &rows).unwrap();
+
+    let mut reader = SegmentReader::open(&path).unwrap();
+    let back = reader.read_all_rows().unwrap();
+    assert_eq!(back, rows);
+
+    // Zone map on bool: min=false, max=true
+    let meta = reader.column_meta("flag").unwrap();
+    assert_eq!(meta.min, Some(Value::Bool(false)));
+    assert_eq!(meta.max, Some(Value::Bool(true)));
+    assert_eq!(meta.null_count, 0);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn float_column_roundtrip_and_zone_map() {
+    let path = tmp_path("float");
+    let schema = vec![("x".into(), 701)]; // float8 OID
+    let rows: Vec<Vec<Value>> = vec![
+        vec![Value::Float(3.14)],
+        vec![Value::Float(-1.5)],
+        vec![Value::Float(100.0)],
+        vec![Value::Float(0.0)],
+    ];
+    SegmentWriter::write(&path, &schema, &rows).unwrap();
+
+    let mut reader = SegmentReader::open(&path).unwrap();
+    let back = reader.read_all_rows().unwrap();
+    assert_eq!(back, rows);
+
+    let meta = reader.column_meta("x").unwrap();
+    assert_eq!(meta.min, Some(Value::Float(-1.5)));
+    assert_eq!(meta.max, Some(Value::Float(100.0)));
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn single_row_segment_is_valid() {
+    // Degenerate case: one row. The writer still has to produce a
+    // valid header + footer, and zone-map min/max must collapse to
+    // the same value rather than panic on an empty accumulator.
+    let path = tmp_path("one_row");
+    let schema = vec![("id".into(), 23), ("name".into(), 25)];
+    let rows: Vec<Vec<Value>> = vec![vec![
+        Value::Int(42),
+        Value::Text(std::sync::Arc::from("solo")),
+    ]];
+    SegmentWriter::write(&path, &schema, &rows).unwrap();
+
+    let mut reader = SegmentReader::open(&path).unwrap();
+    assert_eq!(reader.row_count(), 1);
+    let back = reader.read_all_rows().unwrap();
+    assert_eq!(back, rows);
+
+    let id_meta = reader.column_meta("id").unwrap();
+    assert_eq!(id_meta.min, Some(Value::Int(42)));
+    assert_eq!(id_meta.max, Some(Value::Int(42)));
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/segment/tests/mod.rs
+++ b/native/engine/src/segment/tests/mod.rs
@@ -6,6 +6,7 @@ use crate::types::Value;
 mod basic;
 mod zone_maps;
 mod large;
+mod edge_types;
 
 pub(super) fn tmp_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();

--- a/native/engine/src/wal/tests/corruption.rs
+++ b/native/engine/src/wal/tests/corruption.rs
@@ -1,5 +1,5 @@
-use std::fs::OpenOptions;
-use std::io::Write;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
 
 use super::super::*;
 use super::{insert_op, tmp_wal_path};
@@ -22,5 +22,70 @@ fn corrupt_tail_treated_as_eof() {
     assert_eq!(entries.len(), 2);
     assert_eq!(entries[0].lsn, 1);
     assert_eq!(entries[1].lsn, 2);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn mid_file_bit_flip_stops_at_damaged_frame() {
+    // Write three entries, then flip a byte inside the second frame's
+    // payload. The reader should return entry 1, then treat frame 2 as
+    // the end of the durable log (CRC mismatch). Entry 3 is unreachable
+    // even though it's well-formed: WAL is a linear scan, not random
+    // access, so damage in the middle truncates everything after it.
+    let path = tmp_wal_path("bitflip");
+    let writer = WalWriter::open(&path, 1).unwrap();
+    writer.append_sync(insert_op(1, "a")).unwrap();
+    writer.append_sync(insert_op(2, "b")).unwrap();
+    writer.append_sync(insert_op(3, "c")).unwrap();
+    drop(writer);
+
+    // Read first frame_len to locate frame 2
+    let mut f = OpenOptions::new().read(true).write(true).open(&path).unwrap();
+    let mut len_buf = [0u8; 4];
+    f.read_exact(&mut len_buf).unwrap();
+    let frame1_len = u32::from_le_bytes(len_buf) as u64;
+    // Flip a byte inside frame 2's payload region (skip the len + lsn
+    // + tag to land in the payload). Offset: 4 (frame1 len prefix) +
+    // frame1_len (frame1 body) + 4 (frame2 len prefix) + 8 (lsn) + 1 (tag).
+    let flip_offset = 4 + frame1_len + 4 + 8 + 1;
+    f.seek(SeekFrom::Start(flip_offset)).unwrap();
+    let mut b = [0u8; 1];
+    f.read_exact(&mut b).unwrap();
+    f.seek(SeekFrom::Start(flip_offset)).unwrap();
+    f.write_all(&[b[0] ^ 0xFF]).unwrap();
+    drop(f);
+
+    let entries = WalReader::open(&path).unwrap().read_all().unwrap();
+    assert_eq!(entries.len(), 1, "reader must stop at the corrupt frame");
+    assert_eq!(entries[0].lsn, 1);
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn empty_wal_file_reads_zero_entries() {
+    let path = tmp_wal_path("empty");
+    File::create(&path).unwrap();
+    let entries = WalReader::open(&path).unwrap().read_all().unwrap();
+    assert!(entries.is_empty());
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn truncated_header_is_not_an_error() {
+    // A crash between fsync calls can leave the file with fewer than
+    // 4 bytes of a new frame. That is indistinguishable from clean EOF
+    // and must not surface as an error: recovery's contract is "return
+    // everything durable, stop at damage."
+    let path = tmp_wal_path("trunc_hdr");
+    let writer = WalWriter::open(&path, 1).unwrap();
+    writer.append_sync(insert_op(1, "a")).unwrap();
+    drop(writer);
+
+    let mut f = OpenOptions::new().append(true).open(&path).unwrap();
+    f.write_all(&[0x12, 0x34]).unwrap(); // 2 bytes, not a full len header
+    drop(f);
+
+    let entries = WalReader::open(&path).unwrap().read_all().unwrap();
+    assert_eq!(entries.len(), 1);
     std::fs::remove_file(&path).ok();
 }

--- a/native/engine/src/wal/tests/recovery/continuation.rs
+++ b/native/engine/src/wal/tests/recovery/continuation.rs
@@ -1,0 +1,84 @@
+//! LSN continuation and idempotence: a recovered database must keep
+//! writing to the same WAL file with monotonically increasing LSNs, and
+//! replaying the same WAL file twice must produce the same state.
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, executor, storage};
+
+#[test]
+#[serial_test::serial]
+fn post_recovery_writes_get_monotonic_lsns() {
+    let path = tmp_recovery_path("lsn_cont");
+    catalog::reset();
+    storage::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE t (id int)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1), (2)").unwrap();
+
+    // Capture pre-crash WAL state
+    let pre = manager::read_all().unwrap();
+    let max_pre_lsn = pre.iter().map(|e| e.lsn).max().unwrap();
+
+    // Crash + recover
+    storage::reset();
+    catalog::reset();
+    recovery::recover().unwrap();
+
+    // Post-recovery insert must log with LSN strictly greater than any
+    // pre-recovery entry. Without enable_at_lsn this would collide.
+    executor::execute("INSERT INTO t VALUES (3)").unwrap();
+
+    let post = manager::read_all().unwrap();
+    let new_entries: Vec<_> = post.iter().filter(|e| e.lsn > max_pre_lsn).collect();
+    assert!(
+        !new_entries.is_empty(),
+        "no new WAL entries written after recovery"
+    );
+    for e in &new_entries {
+        assert!(e.lsn > max_pre_lsn, "LSN collision: {} <= {}", e.lsn, max_pre_lsn);
+    }
+
+    let r = executor::execute("SELECT id FROM t ORDER BY id").unwrap();
+    assert_eq!(r.rows.len(), 3);
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_twice_from_same_wal_produces_same_state() {
+    // Recovery must be a pure function of the WAL file: two runs with
+    // the same input produce the same end state. Anything else means
+    // replay has hidden side effects that break crash-safety.
+    let path = tmp_recovery_path("idempotent");
+    catalog::reset();
+    storage::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE t (id int, name text)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')").unwrap();
+    executor::execute("DELETE FROM t WHERE id = 2").unwrap();
+
+    // First recovery
+    storage::reset();
+    catalog::reset();
+    let first = recovery::recover().unwrap();
+    let r1 = executor::execute("SELECT id, name FROM t ORDER BY id").unwrap();
+
+    // Second recovery from the same file
+    storage::reset();
+    catalog::reset();
+    let second = recovery::recover().unwrap();
+    let r2 = executor::execute("SELECT id, name FROM t ORDER BY id").unwrap();
+
+    assert_eq!(first, second, "applied-entry count must be stable");
+    assert_eq!(r1.rows, r2.rows, "recovered rows must be identical");
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/wal/tests/recovery/mod.rs
+++ b/native/engine/src/wal/tests/recovery/mod.rs
@@ -6,6 +6,7 @@ mod errors;
 mod vector;
 mod mutations;
 mod ddl;
+mod continuation;
 
 pub(super) fn tmp_recovery_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();


### PR DESCRIPTION
## Summary

Adds 11 tests that fill gaps in the persistence path coverage:

- **WAL corruption**: mid-file bit flip (reader stops at damage), empty file, truncated header
- **Recovery continuation**: post-recovery writes get monotonic LSNs; recover() twice produces identical state
- **Segment edge types**: bool round-trip + zone map, float round-trip + zone map, single-row segment
- **Memtable stability**: indices stable across deletes/updates, no slot reuse on insert-after-delete, drain compacts tombstones

## Why

The persistence sequence (PRs 1 to 7) shipped with ~60 WAL/segment/memtable tests but most exercised the happy path. These tests target failure modes that would silently corrupt data in production:

- WAL mid-file corruption was untested. If a CRC mismatch ever returned an error instead of truncating, recovery would fail loudly on any real crash.
- LSN continuation after recovery was untested. A bug in enable_at_lsn would cause collisions between replayed and new entries, overwriting durable data.
- Memtable tombstone index stability was untested. Any future optimization that shifts rows on delete would break update_at/delete_at silently.

## Test plan

- [x] cargo test --lib: 309 passed (up from 298)
- [x] Each new test file is under 100 lines
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
