### PR TITLE
fix: UPSERT durability and unique index rebuild on recovery

### DIFF
--- a/native/engine/src/executor/tests/mod.rs
+++ b/native/engine/src/executor/tests/mod.rs
@@ -57,5 +57,6 @@ mod cte;
 mod cte_ext;
 mod upsert;
 mod upsert_ext;
+mod upsert_edge;
 mod devin_regressions;
 mod null_semantics;

--- a/native/engine/src/executor/tests/upsert_edge.rs
+++ b/native/engine/src/executor/tests/upsert_edge.rs
@@ -1,0 +1,98 @@
+//! UPSERT edge cases: NULL in unique cols, RETURNING on mixed batch,
+//! vector updates, partial SET preservation, and constraint fallback.
+
+use super::*;
+
+#[test]
+#[serial_test::serial]
+fn null_in_unique_column_does_not_conflict() {
+    // PostgreSQL semantics: NULL != NULL, so two rows with NULL in a
+    // UNIQUE column can coexist. A DO NOTHING upsert with a NULL key
+    // must insert the new row, not silently skip it.
+    setup();
+    execute("CREATE TABLE un (id int, email text UNIQUE)").unwrap();
+    execute("INSERT INTO un VALUES (1, NULL)").unwrap();
+    let r = execute(
+        "INSERT INTO un VALUES (2, NULL) ON CONFLICT DO NOTHING",
+    ).unwrap();
+    assert_eq!(r.tag, "INSERT 0 1", "NULLs should not collide");
+    let r = execute("SELECT COUNT(*) FROM un").unwrap();
+    assert_eq!(r.rows[0][0], Some("2".into()));
+}
+
+#[test]
+#[serial_test::serial]
+fn upsert_returning_reports_inserted_and_updated_rows() {
+    // Batch upsert with a mix of inserts and updates must return all
+    // rows, reflecting post-update values for conflicts and new values
+    // for inserts. Missing either case would break drivers that rely
+    // on RETURNING for id lookup.
+    setup();
+    execute("CREATE TABLE urb (id int PRIMARY KEY, val int)").unwrap();
+    execute("INSERT INTO urb VALUES (1, 10)").unwrap();
+    let r = execute(
+        "INSERT INTO urb VALUES (1, 100), (2, 200) \
+         ON CONFLICT (id) DO UPDATE SET val = EXCLUDED.val \
+         RETURNING id, val",
+    ).unwrap();
+    assert_eq!(r.rows.len(), 2);
+    // Sort by id for deterministic check
+    let mut rows = r.rows.clone();
+    rows.sort_by_key(|r| r[0].clone());
+    assert_eq!(rows[0], vec![Some("1".into()), Some("100".into())]);
+    assert_eq!(rows[1], vec![Some("2".into()), Some("200".into())]);
+}
+
+#[test]
+#[serial_test::serial]
+fn upsert_with_vector_column_round_trips() {
+    // Vector is the riskiest Value variant: Arc<Vec<f32>> with custom
+    // serialization. An upsert that updates a vector must preserve the
+    // new embedding, not the old one.
+    setup();
+    execute("CREATE TABLE uv (id int PRIMARY KEY, emb vector)").unwrap();
+    execute("INSERT INTO uv VALUES (1, '[0.1, 0.2, 0.3]')").unwrap();
+    execute(
+        "INSERT INTO uv VALUES (1, '[0.9, 0.8, 0.7]') \
+         ON CONFLICT (id) DO UPDATE SET emb = EXCLUDED.emb",
+    ).unwrap();
+    let r = execute("SELECT emb FROM uv WHERE id = 1").unwrap();
+    let s = r.rows[0][0].as_deref().unwrap();
+    assert!(s.contains("0.9"), "updated vector not reflected: {}", s);
+    assert!(!s.contains("0.1"), "old vector still present: {}", s);
+}
+
+#[test]
+#[serial_test::serial]
+fn upsert_partial_update_leaves_other_columns_intact() {
+    // A DO UPDATE that only sets one column must NOT touch the others.
+    // Naive implementations might rebuild the row from EXCLUDED and
+    // zero out unmentioned fields.
+    setup();
+    execute("CREATE TABLE up (id int PRIMARY KEY, a text, b text, c int)").unwrap();
+    execute("INSERT INTO up VALUES (1, 'x', 'y', 42)").unwrap();
+    execute(
+        "INSERT INTO up VALUES (1, 'x2', 'y2', 99) \
+         ON CONFLICT (id) DO UPDATE SET a = EXCLUDED.a",
+    ).unwrap();
+    let r = execute("SELECT a, b, c FROM up WHERE id = 1").unwrap();
+    assert_eq!(r.rows[0][0], Some("x2".into()));
+    assert_eq!(r.rows[0][1], Some("y".into()), "b must not change");
+    assert_eq!(r.rows[0][2], Some("42".into()), "c must not change");
+}
+
+#[test]
+#[serial_test::serial]
+fn upsert_do_nothing_on_unique_email_without_explicit_target() {
+    // DO NOTHING without ON CONFLICT target must still catch the
+    // conflict on ANY unique constraint (PK or UNIQUE column).
+    setup();
+    execute("CREATE TABLE ue (id int PRIMARY KEY, email text UNIQUE)").unwrap();
+    execute("INSERT INTO ue VALUES (1, 'a@b.com')").unwrap();
+    let r = execute(
+        "INSERT INTO ue VALUES (2, 'a@b.com') ON CONFLICT DO NOTHING",
+    ).unwrap();
+    assert_eq!(r.tag, "INSERT 0 0");
+    let r = execute("SELECT COUNT(*) FROM ue").unwrap();
+    assert_eq!(r.rows[0][0], Some("1".into()));
+}

--- a/native/engine/src/storage.rs
+++ b/native/engine/src/storage.rs
@@ -92,9 +92,14 @@ pub fn drop_table(schema: &str, name: &str) {
 }
 
 #[allow(dead_code)]
+/// Unchecked, non-logging insert used ONLY by recovery replay. Writes
+/// the row and also updates unique/PK indexes so that post-recovery
+/// constraint checks see the correct state. Does not touch the WAL.
 pub fn insert(schema: &str, name: &str, row: Row) -> Result<(), String> {
     let tbl = get_table(schema, name)?;
     let mut table = tbl.write();
+    let row_idx = table.rows.len();
+    add_to_indexes(&mut table, &row, row_idx);
     table.rows.push(row);
     Ok(())
 }
@@ -417,6 +422,10 @@ pub fn insert_upsert(
     let mut inserted: u64 = 0;
     let mut updated: u64 = 0;
     let mut affected_rows: Vec<Row> = Vec::new();
+    // WAL ops queued for atomic log-then-commit. DO NOTHING rows do
+    // not produce entries because they make no state change.
+    enum PendingWal { Insert(Row), Update(Row, Row) }
+    let mut pending_wal: Vec<PendingWal> = Vec::new();
 
     for row in rows {
         let conflict_idx = find_conflict_on(
@@ -426,7 +435,6 @@ pub fn insert_upsert(
 
         match conflict_idx {
             None => {
-                // Validate ALL unique constraints before inserting (not just conflict target)
                 check_all_unique(
                     &working_indexes, &working_pk, &pk_cols_vec,
                     &row, unique_checks, pk_cols,
@@ -436,14 +444,14 @@ pub fn insert_upsert(
                     &mut working_indexes, &mut working_pk, &pk_cols_vec,
                     &row, row_idx,
                 );
+                pending_wal.push(PendingWal::Insert(row.clone()));
                 affected_rows.push(row.clone());
                 working_rows.push(row);
                 inserted += 1;
             }
             Some(idx) if do_update => {
-                let existing = &working_rows[idx];
-                let new_row = updater(existing, &row)?;
-                // Remove old values from working indexes
+                let old_row = working_rows[idx].clone();
+                let new_row = updater(&old_row, &row)?;
                 remove_from_working_indexes(
                     &mut working_indexes, &mut working_pk, &pk_cols_vec,
                     &working_rows[idx], idx,
@@ -453,21 +461,32 @@ pub fn insert_upsert(
                     &mut working_indexes, &mut working_pk, &pk_cols_vec,
                     &new_row, idx,
                 );
+                pending_wal.push(PendingWal::Update(old_row, new_row.clone()));
                 affected_rows.push(new_row);
                 updated += 1;
             }
-            Some(_) => {
-                // Conflict + DO NOTHING
+            Some(_) => {}
+        }
+    }
+
+    // Log to WAL BEFORE the atomic swap so recovery can replay the
+    // same state. Each append fsyncs; a failure here aborts the upsert
+    // without touching the in-memory store.
+    for op in &pending_wal {
+        match op {
+            PendingWal::Insert(row) => {
+                crate::wal::manager::append_insert(schema, name, row)?;
+            }
+            PendingWal::Update(old_row, new_row) => {
+                crate::wal::manager::append_update(schema, name, old_row, new_row)?;
             }
         }
     }
 
-    // All rows succeeded - commit atomically
     if inserted > 0 || updated > 0 {
         table.rows = working_rows;
         table.unique_indexes = working_indexes;
         table.pk_index = working_pk;
-        // HNSW needs full rebuild since row positions matter
         if table.hnsw_index.is_some() {
             rebuild_hnsw(&mut table);
         }

--- a/native/engine/src/wal/tests/recovery/mod.rs
+++ b/native/engine/src/wal/tests/recovery/mod.rs
@@ -7,6 +7,7 @@ mod vector;
 mod mutations;
 mod ddl;
 mod continuation;
+mod unique_constraints;
 
 pub(super) fn tmp_recovery_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();

--- a/native/engine/src/wal/tests/recovery/unique_constraints.rs
+++ b/native/engine/src/wal/tests/recovery/unique_constraints.rs
@@ -1,0 +1,98 @@
+//! Recovery interactions with UNIQUE / PRIMARY KEY constraints. The
+//! unique index is rebuilt by the CreateTable replay path, so every
+//! replayed INSERT has to pass through the same uniqueness check as a
+//! live insert would. Two scenarios where naive replay breaks:
+//!
+//! 1. Insert A, delete A, insert A again: if the unique index replays
+//!    all three events without honoring the delete, the second insert
+//!    appears to violate the PK.
+//! 2. Upsert DO UPDATE: the update is logged as Update, not Insert,
+//!    so the index must be updated in place rather than re-added.
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, executor, storage};
+
+#[test]
+#[serial_test::serial]
+fn recover_insert_delete_reinsert_same_pk() {
+    let path = tmp_recovery_path("reinsert");
+    catalog::reset();
+    storage::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE t (id int PRIMARY KEY, v int)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1, 10)").unwrap();
+    executor::execute("DELETE FROM t WHERE id = 1").unwrap();
+    // Reinsert with same PK must succeed because the earlier row is gone
+    executor::execute("INSERT INTO t VALUES (1, 20)").unwrap();
+
+    storage::reset();
+    catalog::reset();
+    recovery::recover().unwrap();
+
+    let r = executor::execute("SELECT id, v FROM t").unwrap();
+    assert_eq!(r.rows.len(), 1);
+    assert_eq!(r.rows[0][0], Some("1".into()));
+    assert_eq!(r.rows[0][1], Some("20".into()));
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_upsert_do_update_survives_round_trip() {
+    // UPSERT that hits a conflict and updates must, post-recovery,
+    // still reflect the updated values. The WAL logs Insert+Update;
+    // replay must end with one row holding the new value.
+    let path = tmp_recovery_path("upsert_rec");
+    catalog::reset();
+    storage::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE t (id int PRIMARY KEY, v int)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1, 10)").unwrap();
+    executor::execute(
+        "INSERT INTO t VALUES (1, 99) ON CONFLICT (id) DO UPDATE SET v = EXCLUDED.v",
+    ).unwrap();
+
+    storage::reset();
+    catalog::reset();
+    recovery::recover().unwrap();
+
+    let r = executor::execute("SELECT id, v FROM t").unwrap();
+    assert_eq!(r.rows.len(), 1);
+    assert_eq!(r.rows[0][1], Some("99".into()));
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_preserves_unique_index_so_new_inserts_still_conflict() {
+    // After recovery, the live unique index must be populated so that
+    // a brand-new conflicting INSERT still fails. If recover() rebuilt
+    // rows without the index, the next write would silently dup.
+    let path = tmp_recovery_path("idx_live");
+    catalog::reset();
+    storage::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE t (id int PRIMARY KEY)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1), (2)").unwrap();
+
+    storage::reset();
+    catalog::reset();
+    recovery::recover().unwrap();
+
+    let r = executor::execute("INSERT INTO t VALUES (1)");
+    assert!(r.is_err(), "unique index must reject duplicate after recovery");
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}


### PR DESCRIPTION
## Summary

While writing edge-case tests for UPSERT and unique constraint recovery, two real bugs surfaced. Both are fixed here alongside the tests that caught them.

### Bug 1: UPSERT was not durable
\`insert_upsert\` never called \`append_insert\` or \`append_update\`. A successful upsert was in-memory only. On crash and recovery, the DO UPDATE effect vanished and any inserted rows along with it.

Fix: queue WAL ops inside the validation loop, fsync them all before the atomic in-memory swap. Matches the pattern used by \`update_rows_checked\`.

### Bug 2: Recovery did not populate the unique index
\`storage::insert\` (the unchecked path used by replay) pushed rows straight onto \`table.rows\` without touching \`unique_indexes\` / \`pk_index\`. After recovery the index was empty, so the next live INSERT with a duplicate PK slipped through silently.

Fix: \`storage::insert\` now calls \`add_to_indexes\` like every other write path.

## New tests (8)

**executor/tests/upsert_edge.rs**
- \`null_in_unique_column_does_not_conflict\`
- \`upsert_returning_reports_inserted_and_updated_rows\`
- \`upsert_with_vector_column_round_trips\`
- \`upsert_partial_update_leaves_other_columns_intact\`
- \`upsert_do_nothing_on_unique_email_without_explicit_target\`

**wal/tests/recovery/unique_constraints.rs**
- \`recover_insert_delete_reinsert_same_pk\`
- \`recover_upsert_do_update_survives_round_trip\` (caught bug 1)
- \`recover_preserves_unique_index_so_new_inserts_still_conflict\` (caught bug 2)

## Test plan

- [x] \`cargo test --lib\`: 317 passed (up from 309)
- [x] Both failing tests now pass
- [x] No regressions across the full suite
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
