### PR TITLE
fix: WAL durability for TRUNCATE, DELETE-no-WHERE, and CREATE TABLE AS

### DIFF
--- a/native/engine/src/executor/ddl_alter.rs
+++ b/native/engine/src/executor/ddl_alter.rs
@@ -92,9 +92,20 @@ pub(crate) fn exec_create_table_as(ctas: &pg_query::protobuf::CreateTableAsStmt)
     let (columns, raw_rows) = exec_select_raw(sel, None, &mut arena)?;
     let table_columns: Vec<Column> = columns.iter().map(|(name, oid)| Column { name: name.clone(), type_oid: TypeOid::from_oid(*oid), nullable: true, primary_key: false, unique: false, default_expr: None }).collect();
     let table = crate::catalog::Table { name: table_name.clone(), schema: schema.to_string(), columns: table_columns };
-    catalog::create_table(table)?;
+    catalog::create_table(table.clone())?;
     storage::create_table(schema, table_name);
+    // WAL: log the table creation so recovery can recreate the schema
+    // before replaying its rows. Has to happen after catalog::create_table
+    // succeeds (so we don't log a table the catalog rejected) and before
+    // the row inserts (so the replay order matches: create then insert).
+    crate::wal::manager::append_create_table(&table)?;
     let rows: Vec<Vec<crate::types::Value>> = raw_rows.iter().map(|row| row.iter().map(|v| v.to_value(&arena)).collect()).collect();
-    if !rows.is_empty() { storage::insert_batch(schema, table_name, rows); }
+    if !rows.is_empty() {
+        // insert_batch_checked logs each row to the WAL and runs
+        // constraint checks. CTAS targets have no constraints, so
+        // unique_checks and pk_cols are empty — but we still go
+        // through this path for WAL durability.
+        storage::insert_batch_checked(schema, table_name, rows, &[], &[])?;
+    }
     Ok(QueryResult { tag: format!("SELECT {}", raw_rows.len()), columns: vec![], rows: vec![] })
 }

--- a/native/engine/src/storage.rs
+++ b/native/engine/src/storage.rs
@@ -123,6 +123,14 @@ where
 pub fn delete_all(schema: &str, name: &str) -> Result<u64, String> {
     let tbl = get_table(schema, name)?;
     let mut table = tbl.write();
+    // Log every row as a Delete before clearing so recovery sees the
+    // same state transition. This is the TRUNCATE / DELETE-no-WHERE
+    // path; logging row-by-row keeps the replay logic uniform with
+    // delete_where. A dedicated Truncate op would be a future
+    // optimization once log volume becomes a concern.
+    for row in table.rows.iter() {
+        crate::wal::manager::append_delete(schema, name, row)?;
+    }
     let count = table.rows.len() as u64;
     table.rows.clear();
     for idx in table.unique_indexes.values_mut() {
@@ -749,6 +757,9 @@ pub fn update_rows_checked(
 pub fn delete_all_returning(schema: &str, name: &str) -> Result<Vec<Row>, String> {
     let tbl = get_table(schema, name)?;
     let mut table = tbl.write();
+    for row in table.rows.iter() {
+        crate::wal::manager::append_delete(schema, name, row)?;
+    }
     for idx in table.unique_indexes.values_mut() {
         idx.clear();
     }

--- a/native/engine/src/wal/tests/recovery/bulk_ops.rs
+++ b/native/engine/src/wal/tests/recovery/bulk_ops.rs
@@ -1,0 +1,90 @@
+//! Recovery for bulk operations that bypassed WAL: TRUNCATE (via
+//! delete_all) and CREATE TABLE AS SELECT. Both routed to unchecked
+//! storage paths with no append calls, so a crash after either would
+//! leave the in-memory state ahead of the durable log.
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, executor, storage};
+
+#[test]
+#[serial_test::serial]
+fn recover_replays_truncate() {
+    let path = tmp_recovery_path("truncate");
+    catalog::reset();
+    storage::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE t (id int)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1), (2), (3)").unwrap();
+    executor::execute("TRUNCATE TABLE t").unwrap();
+
+    storage::reset();
+    catalog::reset();
+    recovery::recover().unwrap();
+
+    let r = executor::execute("SELECT COUNT(*) FROM t").unwrap();
+    assert_eq!(
+        r.rows[0][0], Some("0".into()),
+        "truncated rows must not reappear after recovery"
+    );
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_replays_delete_without_where() {
+    // DELETE FROM t with no WHERE also routes through delete_all. Same
+    // durability requirement as TRUNCATE.
+    let path = tmp_recovery_path("delete_all");
+    catalog::reset();
+    storage::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE t (id int, name text)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1, 'a'), (2, 'b')").unwrap();
+    executor::execute("DELETE FROM t").unwrap();
+
+    storage::reset();
+    catalog::reset();
+    recovery::recover().unwrap();
+
+    let r = executor::execute("SELECT COUNT(*) FROM t").unwrap();
+    assert_eq!(r.rows[0][0], Some("0".into()));
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_replays_create_table_as() {
+    // CTAS builds a new table from a SELECT. Without WAL hooks the
+    // new table and its rows vanish on crash, leaving the source
+    // table alone but losing the derived one.
+    let path = tmp_recovery_path("ctas");
+    catalog::reset();
+    storage::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE src (id int, v int)").unwrap();
+    executor::execute("INSERT INTO src VALUES (1, 10), (2, 20), (3, 30)").unwrap();
+    executor::execute("CREATE TABLE dst AS SELECT id, v FROM src WHERE v > 10").unwrap();
+
+    storage::reset();
+    catalog::reset();
+    recovery::recover().unwrap();
+
+    let r = executor::execute("SELECT id, v FROM dst ORDER BY id").unwrap();
+    assert_eq!(r.rows.len(), 2, "CTAS rows must survive recovery");
+    assert_eq!(r.rows[0][0], Some("2".into()));
+    assert_eq!(r.rows[1][0], Some("3".into()));
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/wal/tests/recovery/mod.rs
+++ b/native/engine/src/wal/tests/recovery/mod.rs
@@ -8,6 +8,7 @@ mod mutations;
 mod ddl;
 mod continuation;
 mod unique_constraints;
+mod bulk_ops;
 
 pub(super) fn tmp_recovery_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();


### PR DESCRIPTION
## Summary

Three more write paths that silently bypassed the WAL, found by new recovery tests. Each would lose data on crash in production.

### Bug 1: TRUNCATE / DELETE FROM (no WHERE)
\`storage::delete_all\` and \`delete_all_returning\` cleared rows without calling \`append_delete\`. A crash after TRUNCATE would restore the rows on replay. Fix: log each row as Delete before clearing.

### Bug 2: CREATE TABLE AS SELECT
\`exec_create_table_as\` skipped both WAL hooks:
- No \`append_create_table\` after catalog commit
- Row insertion went through unchecked \`insert_batch\`, which never touches WAL

Result: both the derived table and its rows vanished on crash. Fix: add the \`append_create_table\` call and route row insertion through \`insert_batch_checked\` (CTAS targets have no constraints so unique_checks/pk_cols are empty, but the path enforces uniform durability).

## New tests

\`wal/tests/recovery/bulk_ops.rs\`:
- \`recover_replays_truncate\`
- \`recover_replays_delete_without_where\`
- \`recover_replays_create_table_as\`

All three failed before the fixes, pass after.

## Test plan

- [x] \`cargo test --lib\`: 320 passed (up from 317)
- [x] No regressions across the full suite

## Context

This is the third round of durability bug finds in the past session:
- PR #50: fixed UPSERT not logging + recovery not rebuilding unique index
- This PR: fixes TRUNCATE, DELETE-no-WHERE, and CTAS

Still to investigate: ALTER TABLE ADD/DROP/RENAME COLUMN and RENAME TABLE do not log anything. These require new WAL op variants so belong in a follow-up PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/51" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
