### PR TITLE
fix: WAL durability for ALTER TABLE ADD/DROP COLUMN and RENAME

### DIFF
--- a/native/engine/src/executor/ddl_alter.rs
+++ b/native/engine/src/executor/ddl_alter.rs
@@ -1,13 +1,11 @@
 use pg_query::NodeEnum;
 
-use crate::arena::QueryArena;
 use crate::catalog::{self, Column};
 use crate::storage;
 use crate::types::TypeOid;
 
 use super::ddl::extract_type_name;
 use super::helpers::eval_const;
-use super::select::exec_select_raw;
 use super::types::QueryResult;
 
 /// Execute DROP TABLE.
@@ -53,13 +51,15 @@ pub(crate) fn exec_alter_table(alter: &pg_query::protobuf::AlterTableStmt) -> Re
                 }
             }
             let col = Column { name: col_def.colname.clone(), type_oid: TypeOid::from_name(&type_name), nullable: !col_def.is_not_null, primary_key: false, unique: false, default_expr: default_expr.clone() };
-            catalog::alter_table_add_column(schema, table_name, col)?;
+            catalog::alter_table_add_column(schema, table_name, col.clone())?;
             let default_val = match &default_expr { Some(catalog::DefaultExpr::Literal(v)) => v.clone(), _ => crate::types::Value::Null };
-            storage::alter_add_column(schema, table_name, default_val);
+            storage::alter_add_column(schema, table_name, default_val.clone());
+            crate::wal::manager::append_alter_add_column(schema, table_name, &col, &default_val)?;
         } else if cmd.subtype == AlterTableType::AtDropColumn as i32 {
             let col_idx = catalog::get_column_index(schema, table_name, &cmd.name)?;
             catalog::alter_table_drop_column(schema, table_name, &cmd.name)?;
             storage::alter_drop_column(schema, table_name, col_idx);
+            crate::wal::manager::append_alter_drop_column(schema, table_name, &cmd.name)?;
         } else { return Err(format!("unsupported ALTER TABLE subcommand: {}", cmd.subtype)); }
     }
     Ok(QueryResult { tag: "ALTER TABLE".into(), columns: vec![], rows: vec![] })
@@ -74,38 +74,11 @@ pub(crate) fn exec_rename(rename: &pg_query::protobuf::RenameStmt) -> Result<Que
     if rename.rename_type == ObjectType::ObjectTable as i32 {
         catalog::rename_table(schema, table_name, &rename.newname)?;
         storage::rename_table(schema, table_name, &rename.newname);
+        crate::wal::manager::append_rename_table(schema, table_name, &rename.newname)?;
     } else if rename.rename_type == ObjectType::ObjectColumn as i32 {
         catalog::rename_column(schema, table_name, &rename.subname, &rename.newname)?;
+        crate::wal::manager::append_rename_column(schema, table_name, &rename.subname, &rename.newname)?;
     } else { return Err("unsupported RENAME type".into()); }
     Ok(QueryResult { tag: "ALTER TABLE".into(), columns: vec![], rows: vec![] })
 }
 
-/// Execute CREATE TABLE AS SELECT.
-pub(crate) fn exec_create_table_as(ctas: &pg_query::protobuf::CreateTableAsStmt) -> Result<QueryResult, String> {
-    let into = ctas.into.as_ref().ok_or("CREATE TABLE AS missing INTO")?;
-    let rel = into.rel.as_ref().ok_or("CREATE TABLE AS missing relation")?;
-    let table_name = &rel.relname;
-    let schema = if rel.schemaname.is_empty() { "public" } else { &rel.schemaname };
-    let select_node = ctas.query.as_ref().and_then(|n| n.node.as_ref()).ok_or("CREATE TABLE AS missing query")?;
-    let NodeEnum::SelectStmt(sel) = select_node else { return Err("CREATE TABLE AS requires SELECT".into()); };
-    let mut arena = QueryArena::new();
-    let (columns, raw_rows) = exec_select_raw(sel, None, &mut arena)?;
-    let table_columns: Vec<Column> = columns.iter().map(|(name, oid)| Column { name: name.clone(), type_oid: TypeOid::from_oid(*oid), nullable: true, primary_key: false, unique: false, default_expr: None }).collect();
-    let table = crate::catalog::Table { name: table_name.clone(), schema: schema.to_string(), columns: table_columns };
-    catalog::create_table(table.clone())?;
-    storage::create_table(schema, table_name);
-    // WAL: log the table creation so recovery can recreate the schema
-    // before replaying its rows. Has to happen after catalog::create_table
-    // succeeds (so we don't log a table the catalog rejected) and before
-    // the row inserts (so the replay order matches: create then insert).
-    crate::wal::manager::append_create_table(&table)?;
-    let rows: Vec<Vec<crate::types::Value>> = raw_rows.iter().map(|row| row.iter().map(|v| v.to_value(&arena)).collect()).collect();
-    if !rows.is_empty() {
-        // insert_batch_checked logs each row to the WAL and runs
-        // constraint checks. CTAS targets have no constraints, so
-        // unique_checks and pk_cols are empty — but we still go
-        // through this path for WAL durability.
-        storage::insert_batch_checked(schema, table_name, rows, &[], &[])?;
-    }
-    Ok(QueryResult { tag: format!("SELECT {}", raw_rows.len()), columns: vec![], rows: vec![] })
-}

--- a/native/engine/src/executor/ddl_ctas.rs
+++ b/native/engine/src/executor/ddl_ctas.rs
@@ -1,0 +1,43 @@
+//! CREATE TABLE AS SELECT. Builds a table from the result columns of
+//! a SELECT and materializes rows via the checked insert path so the
+//! whole operation is durable.
+
+use pg_query::NodeEnum;
+
+use crate::arena::QueryArena;
+use crate::catalog::{self, Column};
+use crate::storage;
+use crate::types::TypeOid;
+
+use super::select::exec_select_raw;
+use super::types::QueryResult;
+
+pub(crate) fn exec_create_table_as(ctas: &pg_query::protobuf::CreateTableAsStmt) -> Result<QueryResult, String> {
+    let into = ctas.into.as_ref().ok_or("CREATE TABLE AS missing INTO")?;
+    let rel = into.rel.as_ref().ok_or("CREATE TABLE AS missing relation")?;
+    let table_name = &rel.relname;
+    let schema = if rel.schemaname.is_empty() { "public" } else { &rel.schemaname };
+    let select_node = ctas.query.as_ref().and_then(|n| n.node.as_ref()).ok_or("CREATE TABLE AS missing query")?;
+    let NodeEnum::SelectStmt(sel) = select_node else { return Err("CREATE TABLE AS requires SELECT".into()); };
+    let mut arena = QueryArena::new();
+    let (columns, raw_rows) = exec_select_raw(sel, None, &mut arena)?;
+    let table_columns: Vec<Column> = columns.iter().map(|(name, oid)| Column {
+        name: name.clone(),
+        type_oid: TypeOid::from_oid(*oid),
+        nullable: true,
+        primary_key: false,
+        unique: false,
+        default_expr: None,
+    }).collect();
+    let table = catalog::Table { name: table_name.clone(), schema: schema.to_string(), columns: table_columns };
+    catalog::create_table(table.clone())?;
+    storage::create_table(schema, table_name);
+    crate::wal::manager::append_create_table(&table)?;
+    let rows: Vec<Vec<crate::types::Value>> = raw_rows.iter()
+        .map(|row| row.iter().map(|v| v.to_value(&arena)).collect())
+        .collect();
+    if !rows.is_empty() {
+        storage::insert_batch_checked(schema, table_name, rows, &[], &[])?;
+    }
+    Ok(QueryResult { tag: format!("SELECT {}", raw_rows.len()), columns: vec![], rows: vec![] })
+}

--- a/native/engine/src/executor/mod.rs
+++ b/native/engine/src/executor/mod.rs
@@ -35,6 +35,7 @@ mod having;
 mod returning;
 mod ddl;
 mod ddl_alter;
+mod ddl_ctas;
 mod insert;
 mod insert_conflict;
 mod delete;
@@ -88,7 +89,7 @@ pub fn execute(sql: &str) -> Result<QueryResult, String> {
         NodeEnum::TransactionStmt(_) => Ok(QueryResult { tag: "OK".into(), columns: vec![], rows: vec![] }),
         NodeEnum::AlterTableStmt(alter) => ddl_alter::exec_alter_table(alter),
         NodeEnum::RenameStmt(rename) => ddl_alter::exec_rename(rename),
-        NodeEnum::CreateTableAsStmt(ctas) => ddl_alter::exec_create_table_as(ctas),
+        NodeEnum::CreateTableAsStmt(ctas) => ddl_ctas::exec_create_table_as(ctas),
         _ => Err("unsupported statement type".into()),
     }
 }

--- a/native/engine/src/wal/entry.rs
+++ b/native/engine/src/wal/entry.rs
@@ -22,6 +22,11 @@ pub struct WalEntry {
 /// UPDATE/DELETE will affect the first match. This matches PostgreSQL's
 /// semantics for tables without a unique key (the "any matching row"
 /// contract).
+/// CRITICAL: bincode serializes enum variants by positional index, so
+/// the order of variants in this enum IS the on-disk format. Never
+/// reorder existing variants or insert new ones mid-list — doing so
+/// silently remaps every WAL file ever written. Always append new
+/// variants at the end.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum WalOp {
     Insert { schema: String, table: String, row: Vec<Value> },
@@ -31,6 +36,11 @@ pub enum WalOp {
     CreateTable { table: Table },
     /// Drop a table by fully qualified name.
     DropTable { schema: String, table: String },
+    /// Marks a transaction boundary for group commit.
+    Commit { txn_id: u64 },
+    /// Marks the LSN up to which a memtable flush has persisted data.
+    /// Entries with LSN <= this are safe to truncate.
+    Checkpoint { up_to: Lsn },
     /// ALTER TABLE ADD COLUMN. fill_value is the resolved default used
     /// to backfill existing rows; logging it avoids re-evaluating
     /// non-deterministic defaults during replay.
@@ -42,11 +52,6 @@ pub enum WalOp {
     RenameTable { schema: String, old_name: String, new_name: String },
     /// ALTER TABLE RENAME COLUMN.
     RenameColumn { schema: String, table: String, old_column: String, new_column: String },
-    /// Marks a transaction boundary for group commit.
-    Commit { txn_id: u64 },
-    /// Marks the LSN up to which a memtable flush has persisted data.
-    /// Entries with LSN <= this are safe to truncate.
-    Checkpoint { up_to: Lsn },
 }
 
 // Op tag byte used in the on-disk frame. Kept stable: never renumber.

--- a/native/engine/src/wal/entry.rs
+++ b/native/engine/src/wal/entry.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::Table;
+use crate::catalog::{Column, Table};
 use crate::types::Value;
 use super::Lsn;
 
@@ -31,6 +31,17 @@ pub enum WalOp {
     CreateTable { table: Table },
     /// Drop a table by fully qualified name.
     DropTable { schema: String, table: String },
+    /// ALTER TABLE ADD COLUMN. fill_value is the resolved default used
+    /// to backfill existing rows; logging it avoids re-evaluating
+    /// non-deterministic defaults during replay.
+    AlterAddColumn { schema: String, table: String, column: Column, fill_value: Value },
+    /// ALTER TABLE DROP COLUMN, keyed by column name so replay is
+    /// robust to position shifts from prior DROPs.
+    AlterDropColumn { schema: String, table: String, column: String },
+    /// ALTER TABLE RENAME TO.
+    RenameTable { schema: String, old_name: String, new_name: String },
+    /// ALTER TABLE RENAME COLUMN.
+    RenameColumn { schema: String, table: String, old_column: String, new_column: String },
     /// Marks a transaction boundary for group commit.
     Commit { txn_id: u64 },
     /// Marks the LSN up to which a memtable flush has persisted data.
@@ -46,6 +57,10 @@ pub(super) const OP_COMMIT: u8 = 4;
 pub(super) const OP_CHECKPOINT: u8 = 5;
 pub(super) const OP_CREATE_TABLE: u8 = 6;
 pub(super) const OP_DROP_TABLE: u8 = 7;
+pub(super) const OP_ALTER_ADD_COL: u8 = 8;
+pub(super) const OP_ALTER_DROP_COL: u8 = 9;
+pub(super) const OP_RENAME_TABLE: u8 = 10;
+pub(super) const OP_RENAME_COL: u8 = 11;
 
 impl WalOp {
     pub(super) fn tag(&self) -> u8 {
@@ -57,6 +72,10 @@ impl WalOp {
             WalOp::Checkpoint { .. } => OP_CHECKPOINT,
             WalOp::CreateTable { .. } => OP_CREATE_TABLE,
             WalOp::DropTable { .. } => OP_DROP_TABLE,
+            WalOp::AlterAddColumn { .. } => OP_ALTER_ADD_COL,
+            WalOp::AlterDropColumn { .. } => OP_ALTER_DROP_COL,
+            WalOp::RenameTable { .. } => OP_RENAME_TABLE,
+            WalOp::RenameColumn { .. } => OP_RENAME_COL,
         }
     }
 

--- a/native/engine/src/wal/manager/mod.rs
+++ b/native/engine/src/wal/manager/mod.rs
@@ -13,7 +13,12 @@ mod lifecycle;
 mod ops;
 
 pub use lifecycle::{enable, enable_at_lsn, enable_from_env, disable, is_enabled, read_all, suspend_for_replay};
-pub use ops::{append_insert, append_update, append_delete, append_create_table, append_drop_table};
+pub use ops::{
+    append_insert, append_update, append_delete,
+    append_create_table, append_drop_table,
+    append_alter_add_column, append_alter_drop_column,
+    append_rename_table, append_rename_column,
+};
 
 use std::sync::Arc;
 use parking_lot::RwLock;

--- a/native/engine/src/wal/manager/ops.rs
+++ b/native/engine/src/wal/manager/ops.rs
@@ -1,4 +1,4 @@
-use crate::catalog::Table;
+use crate::catalog::{Column, Table};
 use crate::types::Value;
 
 use super::super::{Lsn, WalOp};
@@ -45,6 +45,42 @@ pub fn append_drop_table(schema: &str, table: &str) -> Result<Option<Lsn>, Strin
     append_op(WalOp::DropTable {
         schema: schema.to_string(),
         table: table.to_string(),
+    })
+}
+
+/// Append an ALTER TABLE ADD COLUMN entry. fill_value is the resolved
+/// default used to backfill existing rows at ALTER time.
+pub fn append_alter_add_column(schema: &str, table: &str, column: &Column, fill_value: &Value) -> Result<Option<Lsn>, String> {
+    append_op(WalOp::AlterAddColumn {
+        schema: schema.to_string(),
+        table: table.to_string(),
+        column: column.clone(),
+        fill_value: fill_value.clone(),
+    })
+}
+
+pub fn append_alter_drop_column(schema: &str, table: &str, column: &str) -> Result<Option<Lsn>, String> {
+    append_op(WalOp::AlterDropColumn {
+        schema: schema.to_string(),
+        table: table.to_string(),
+        column: column.to_string(),
+    })
+}
+
+pub fn append_rename_table(schema: &str, old_name: &str, new_name: &str) -> Result<Option<Lsn>, String> {
+    append_op(WalOp::RenameTable {
+        schema: schema.to_string(),
+        old_name: old_name.to_string(),
+        new_name: new_name.to_string(),
+    })
+}
+
+pub fn append_rename_column(schema: &str, table: &str, old_column: &str, new_column: &str) -> Result<Option<Lsn>, String> {
+    append_op(WalOp::RenameColumn {
+        schema: schema.to_string(),
+        table: table.to_string(),
+        old_column: old_column.to_string(),
+        new_column: new_column.to_string(),
     })
 }
 

--- a/native/engine/src/wal/recovery/apply/alter.rs
+++ b/native/engine/src/wal/recovery/apply/alter.rs
@@ -1,0 +1,40 @@
+//! Replay handlers for ALTER TABLE ops. Split out of apply.rs so the
+//! main dispatch stays under the 100-line limit.
+
+use crate::catalog;
+use crate::storage;
+
+use super::super::super::WalOp;
+
+/// Apply a single ALTER op. Returns Ok(true) if applied, Ok(false) if
+/// skipped (e.g., table missing from a partial replay), Err on
+/// unrecoverable catalog errors.
+pub(super) fn apply_alter(op: &WalOp) -> Result<bool, String> {
+    match op {
+        WalOp::AlterAddColumn { schema, table, column, fill_value } => {
+            if catalog::get_table(schema, table).is_none() { return Ok(false); }
+            catalog::alter_table_add_column(schema, table, column.clone())?;
+            storage::alter_add_column(schema, table, fill_value.clone());
+            Ok(true)
+        }
+        WalOp::AlterDropColumn { schema, table, column } => {
+            if catalog::get_table(schema, table).is_none() { return Ok(false); }
+            let idx = catalog::get_column_index(schema, table, column)?;
+            catalog::alter_table_drop_column(schema, table, column)?;
+            storage::alter_drop_column(schema, table, idx);
+            Ok(true)
+        }
+        WalOp::RenameTable { schema, old_name, new_name } => {
+            if catalog::get_table(schema, old_name).is_none() { return Ok(false); }
+            catalog::rename_table(schema, old_name, new_name)?;
+            storage::rename_table(schema, old_name, new_name);
+            Ok(true)
+        }
+        WalOp::RenameColumn { schema, table, old_column, new_column } => {
+            if catalog::get_table(schema, table).is_none() { return Ok(false); }
+            catalog::rename_column(schema, table, old_column, new_column)?;
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}

--- a/native/engine/src/wal/recovery/apply/mod.rs
+++ b/native/engine/src/wal/recovery/apply/mod.rs
@@ -4,6 +4,8 @@ use crate::types::Value;
 
 use super::super::{WalEntry, WalOp};
 
+mod alter;
+
 /// Apply a list of entries to storage. Insert uses the unchecked path
 /// since constraints were already validated when logged. Update and
 /// Delete match rows by content (robust to storage layout changes).
@@ -27,12 +29,9 @@ pub fn apply_entries(entries: &[WalEntry]) -> Result<usize, String> {
                 applied += 1;
             }
             WalOp::CreateTable { table } => {
-                // Idempotent: skip if table already exists in this
-                // session (e.g., partial replay or double-recover).
                 if catalog::get_table(&table.schema, &table.name).is_some() { continue; }
                 catalog::create_table(table.clone())?;
                 storage::create_table(&table.schema, &table.name);
-                // Re-build indexes for any columns with PK/UNIQUE constraints
                 for (i, col) in table.columns.iter().enumerate() {
                     if col.primary_key || col.unique {
                         let _ = storage::add_unique_index(&table.schema, &table.name, i);
@@ -46,6 +45,12 @@ pub fn apply_entries(entries: &[WalEntry]) -> Result<usize, String> {
                     storage::drop_table(schema, table);
                 }
                 applied += 1;
+            }
+            op @ (WalOp::AlterAddColumn { .. }
+                | WalOp::AlterDropColumn { .. }
+                | WalOp::RenameTable { .. }
+                | WalOp::RenameColumn { .. }) => {
+                if alter::apply_alter(op)? { applied += 1; }
             }
             _ => {} // Commit, Checkpoint: no-op for now
         }

--- a/native/engine/src/wal/tests/recovery/alter_columns.rs
+++ b/native/engine/src/wal/tests/recovery/alter_columns.rs
@@ -1,0 +1,61 @@
+//! Recovery for ALTER TABLE ADD/DROP COLUMN. Without logging, a crash
+//! after column changes would leave the in-memory schema ahead of the
+//! durable log and any queries on the new shape would break.
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, executor, storage};
+
+#[test]
+#[serial_test::serial]
+fn recover_alter_add_column_with_default() {
+    let path = tmp_recovery_path("alter_add");
+    catalog::reset();
+    storage::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE t (id int)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1), (2)").unwrap();
+    executor::execute("ALTER TABLE t ADD COLUMN name text DEFAULT 'unknown'").unwrap();
+    executor::execute("INSERT INTO t VALUES (3, 'carol')").unwrap();
+
+    storage::reset();
+    catalog::reset();
+    recovery::recover().unwrap();
+
+    let r = executor::execute("SELECT id, name FROM t ORDER BY id").unwrap();
+    assert_eq!(r.rows.len(), 3);
+    assert_eq!(r.rows[0][1], Some("unknown".into()));
+    assert_eq!(r.rows[1][1], Some("unknown".into()));
+    assert_eq!(r.rows[2][1], Some("carol".into()));
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_alter_drop_column() {
+    let path = tmp_recovery_path("alter_drop");
+    catalog::reset();
+    storage::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE t (id int, name text, age int)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1, 'a', 10), (2, 'b', 20)").unwrap();
+    executor::execute("ALTER TABLE t DROP COLUMN name").unwrap();
+
+    storage::reset();
+    catalog::reset();
+    recovery::recover().unwrap();
+
+    let r = executor::execute("SELECT * FROM t ORDER BY id").unwrap();
+    assert_eq!(r.rows[0].len(), 2, "name column should be gone after recovery");
+    assert_eq!(r.rows[0][0], Some("1".into()));
+    assert_eq!(r.rows[0][1], Some("10".into()));
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/wal/tests/recovery/alter_rename.rs
+++ b/native/engine/src/wal/tests/recovery/alter_rename.rs
@@ -1,0 +1,55 @@
+//! Recovery for ALTER TABLE RENAME TO / RENAME COLUMN.
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, executor, storage};
+
+#[test]
+#[serial_test::serial]
+fn recover_rename_table() {
+    let path = tmp_recovery_path("rename_tbl");
+    catalog::reset();
+    storage::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE old_name (id int)").unwrap();
+    executor::execute("INSERT INTO old_name VALUES (1), (2)").unwrap();
+    executor::execute("ALTER TABLE old_name RENAME TO new_name").unwrap();
+
+    storage::reset();
+    catalog::reset();
+    recovery::recover().unwrap();
+
+    let r = executor::execute("SELECT COUNT(*) FROM new_name").unwrap();
+    assert_eq!(r.rows[0][0], Some("2".into()));
+    assert!(executor::execute("SELECT * FROM old_name").is_err());
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_rename_column() {
+    let path = tmp_recovery_path("rename_col");
+    catalog::reset();
+    storage::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE t (id int, old_col text)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1, 'x')").unwrap();
+    executor::execute("ALTER TABLE t RENAME COLUMN old_col TO new_col").unwrap();
+
+    storage::reset();
+    catalog::reset();
+    recovery::recover().unwrap();
+
+    let r = executor::execute("SELECT new_col FROM t").unwrap();
+    assert_eq!(r.rows[0][0], Some("x".into()));
+    assert!(executor::execute("SELECT old_col FROM t").is_err());
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/wal/tests/recovery/mod.rs
+++ b/native/engine/src/wal/tests/recovery/mod.rs
@@ -9,6 +9,8 @@ mod ddl;
 mod continuation;
 mod unique_constraints;
 mod bulk_ops;
+mod alter_columns;
+mod alter_rename;
 
 pub(super) fn tmp_recovery_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();


### PR DESCRIPTION
## Summary

Fourth durability round for the persistence path. ALTER TABLE was the last known write path that mutated schema/storage without WAL logging. A crash after any ALTER would leave the in-memory schema ahead of the durable log, so on recovery the pre-alter shape would come back and queries written against the new schema would break.

## New WAL ops (tags 8 to 11)

- \`AlterAddColumn { schema, table, column, fill_value }\`
- \`AlterDropColumn { schema, table, column }\`
- \`RenameTable { schema, old_name, new_name }\`
- \`RenameColumn { schema, table, old_column, new_column }\`

ADD COLUMN logs the resolved \`fill_value\` rather than the default expression so non-deterministic defaults (\`now()\`, \`nextval()\`) do not re-evaluate to different values during replay.

## Hooks

Executor (\`ddl_alter.rs\`) appends the op after catalog and storage mutations succeed. Recovery replay lives in a new \`apply/alter.rs\` submodule so the main dispatch stays under the 100-line file limit.

## Incidental refactor

CTAS extracted from \`ddl_alter.rs\` into \`ddl_ctas.rs\` so \`ddl_alter.rs\` drops back under 100 lines after the new WAL calls.

## Tests

\`wal/tests/recovery/alter_columns.rs\`:
- \`recover_alter_add_column_with_default\`
- \`recover_alter_drop_column\`

\`wal/tests/recovery/alter_rename.rs\`:
- \`recover_rename_table\`
- \`recover_rename_column\`

## Test plan

- [x] \`cargo test --lib\`: 324 passed (up from 320)
- [x] No regressions
- [x] Every new file under 100 lines

## Context

This is the fourth durability-gap PR in this session:
- #50: UPSERT WAL logging + unique index rebuild on recovery
- #51: TRUNCATE, DELETE-no-WHERE, and CREATE TABLE AS SELECT WAL logging
- this PR: ALTER TABLE ADD/DROP/RENAME WAL logging

With this PR, every write path that touches catalog or storage is WAL-logged and recoverable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
