### PR TITLE
fix: WAL recovery advances SERIAL sequences past replayed rows

### DIFF
--- a/native/engine/src/catalog.rs
+++ b/native/engine/src/catalog.rs
@@ -93,6 +93,16 @@ pub fn list_tables(schema: &str) -> Vec<Table> {
         .collect()
 }
 
+/// Every table in the catalog regardless of schema. Recovery paths
+/// that walk all tables (e.g. advancing SERIAL sequences after WAL
+/// replay) must use this, not list_tables("public"): hardcoding the
+/// public schema would leave non-public sequences stuck at 0 and
+/// the next nextval would collide with replayed rows.
+pub fn list_all_tables() -> Vec<Table> {
+    let cat = CATALOG.read();
+    cat.tables.values().cloned().collect()
+}
+
 pub fn alter_table_add_column(schema: &str, table_name: &str, col: Column) -> Result<(), String> {
     let mut cat = CATALOG.write();
     let key = fqn(schema, table_name);

--- a/native/engine/src/wal/recovery/apply/mod.rs
+++ b/native/engine/src/wal/recovery/apply/mod.rs
@@ -5,6 +5,7 @@ use crate::types::Value;
 use super::super::{WalEntry, WalOp};
 
 mod alter;
+mod sequences;
 
 /// Apply a list of entries to storage. Insert uses the unchecked path
 /// since constraints were already validated when logged. Update and
@@ -37,6 +38,7 @@ pub fn apply_entries(entries: &[WalEntry]) -> Result<usize, String> {
                         let _ = storage::add_unique_index(&table.schema, &table.name, i);
                     }
                 }
+                sequences::recreate_for_table(table);
                 applied += 1;
             }
             WalOp::DropTable { schema, table } => {
@@ -55,6 +57,11 @@ pub fn apply_entries(entries: &[WalEntry]) -> Result<usize, String> {
             _ => {} // Commit, Checkpoint: no-op for now
         }
     }
+    // After replay, walk every catalog table and advance any SERIAL
+    // sequence past the max value present in storage. This handles
+    // both inserts that used nextval and inserts that supplied an
+    // explicit higher id.
+    sequences::advance_all_to_max();
     Ok(applied)
 }
 

--- a/native/engine/src/wal/recovery/apply/sequences.rs
+++ b/native/engine/src/wal/recovery/apply/sequences.rs
@@ -1,0 +1,64 @@
+//! Sequence (SERIAL) recovery. Sequences are not WAL-logged on every
+//! nextval — that would balloon log volume — so recovery rebuilds
+//! them from the catalog and replayed rows.
+//!
+//! Two phases:
+//! 1. recreate_for_table: at CreateTable replay, instantiate the
+//!    sequence backing each NextVal default so it exists by the time
+//!    inserts start replaying.
+//! 2. advance_all_to_max: after every WAL entry has replayed, scan
+//!    each SERIAL column's actual values and setval the sequence to
+//!    the max. This is robust to user-supplied ids higher than the
+//!    sequence ever produced.
+
+use crate::catalog::{self, DefaultExpr, Table};
+use crate::sequence;
+use crate::storage;
+use crate::types::Value;
+
+/// Parse a NextVal default's "schema.name" string into its parts.
+fn split_seq_fqn(fqn: &str) -> Option<(&str, &str)> {
+    fqn.split_once('.')
+}
+
+/// Create any sequences referenced by NextVal defaults on this table.
+/// Idempotent: drops a leftover sequence with the same name first so
+/// recovery always starts from a clean state.
+pub(super) fn recreate_for_table(table: &Table) {
+    for col in &table.columns {
+        if let Some(DefaultExpr::NextVal(fqn)) = &col.default_expr {
+            if let Some((schema, name)) = split_seq_fqn(fqn) {
+                sequence::drop_sequence(schema, name);
+                let _ = sequence::create_sequence(schema, name, 1, 1);
+            }
+        }
+    }
+}
+
+/// Walk every catalog table; for each column with a NextVal default,
+/// scan storage for the max int value and setval the sequence so the
+/// next nextval produces a non-colliding id.
+pub(super) fn advance_all_to_max() {
+    for table in catalog::list_tables("public") {
+        for (col_idx, col) in table.columns.iter().enumerate() {
+            let Some(DefaultExpr::NextVal(fqn)) = &col.default_expr else { continue; };
+            let Some((seq_schema, seq_name)) = split_seq_fqn(fqn) else { continue; };
+            let max = max_int_in_column(&table.schema, &table.name, col_idx);
+            if let Some(m) = max {
+                let _ = sequence::setval(seq_schema, seq_name, m);
+            }
+        }
+    }
+}
+
+fn max_int_in_column(schema: &str, table: &str, col_idx: usize) -> Option<i64> {
+    storage::scan_with(schema, table, |rows| {
+        let mut max: Option<i64> = None;
+        for row in rows {
+            if let Some(Value::Int(v)) = row.get(col_idx) {
+                max = Some(max.map_or(*v, |m| m.max(*v)));
+            }
+        }
+        Ok(max)
+    }).ok().flatten()
+}

--- a/native/engine/src/wal/recovery/apply/sequences.rs
+++ b/native/engine/src/wal/recovery/apply/sequences.rs
@@ -39,7 +39,7 @@ pub(super) fn recreate_for_table(table: &Table) {
 /// scan storage for the max int value and setval the sequence so the
 /// next nextval produces a non-colliding id.
 pub(super) fn advance_all_to_max() {
-    for table in catalog::list_tables("public") {
+    for table in catalog::list_all_tables() {
         for (col_idx, col) in table.columns.iter().enumerate() {
             let Some(DefaultExpr::NextVal(fqn)) = &col.default_expr else { continue; };
             let Some((seq_schema, seq_name)) = split_seq_fqn(fqn) else { continue; };

--- a/native/engine/src/wal/tests/recovery/mod.rs
+++ b/native/engine/src/wal/tests/recovery/mod.rs
@@ -11,6 +11,7 @@ mod unique_constraints;
 mod bulk_ops;
 mod alter_columns;
 mod alter_rename;
+mod sequences;
 
 pub(super) fn tmp_recovery_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();

--- a/native/engine/src/wal/tests/recovery/mod.rs
+++ b/native/engine/src/wal/tests/recovery/mod.rs
@@ -12,6 +12,7 @@ mod bulk_ops;
 mod alter_columns;
 mod alter_rename;
 mod sequences;
+mod vector_knn;
 
 pub(super) fn tmp_recovery_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();

--- a/native/engine/src/wal/tests/recovery/sequences.rs
+++ b/native/engine/src/wal/tests/recovery/sequences.rs
@@ -45,6 +45,75 @@ fn recover_serial_advances_sequence_past_existing_max() {
 
 #[test]
 #[serial_test::serial]
+fn recover_serial_across_multiple_tables() {
+    // advance_all_to_max must walk every table and advance every
+    // SERIAL column independently. A bug that only advances the last
+    // table's sequences would be caught by adding a second table.
+    let path = tmp_recovery_path("seq_multi");
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE a (id SERIAL PRIMARY KEY, v text)").unwrap();
+    executor::execute("CREATE TABLE b (id SERIAL PRIMARY KEY, v text)").unwrap();
+    executor::execute("INSERT INTO a (v) VALUES ('a1'), ('a2'), ('a3'), ('a4'), ('a5')").unwrap();
+    executor::execute("INSERT INTO b (v) VALUES ('b1'), ('b2')").unwrap();
+
+    storage::reset();
+    catalog::reset();
+    crate::sequence::reset();
+    recovery::recover().unwrap();
+
+    executor::execute("INSERT INTO a (v) VALUES ('a_new')").unwrap();
+    executor::execute("INSERT INTO b (v) VALUES ('b_new')").unwrap();
+
+    let r = executor::execute("SELECT id FROM a WHERE v = 'a_new'").unwrap();
+    let a_id = r.rows[0][0].as_deref().unwrap().parse::<i64>().unwrap();
+    assert!(a_id > 5, "table a sequence must advance past 5, got {}", a_id);
+
+    let r = executor::execute("SELECT id FROM b WHERE v = 'b_new'").unwrap();
+    let b_id = r.rows[0][0].as_deref().unwrap().parse::<i64>().unwrap();
+    assert!(b_id > 2, "table b sequence must advance past 2, got {}", b_id);
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_serial_in_non_public_schema() {
+    // Regression for Devin PR #53 finding: advance_all_to_max was
+    // hardcoded to "public", so a SERIAL column in any other schema
+    // kept its sequence stuck at 0 after recovery and the next
+    // nextval collided with replayed rows.
+    let path = tmp_recovery_path("seq_schema");
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE app.users (id SERIAL PRIMARY KEY, name text)").unwrap();
+    executor::execute("INSERT INTO app.users (name) VALUES ('a'), ('b'), ('c')").unwrap();
+
+    storage::reset();
+    catalog::reset();
+    crate::sequence::reset();
+    recovery::recover().unwrap();
+
+    executor::execute("INSERT INTO app.users (name) VALUES ('d')").unwrap();
+    let r = executor::execute("SELECT id FROM app.users WHERE name = 'd'").unwrap();
+    let id = r.rows[0][0].as_deref().unwrap().parse::<i64>().unwrap();
+    assert!(id > 3, "non-public schema sequence must advance past 3, got {}", id);
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
 fn recover_serial_with_user_supplied_higher_id() {
     // If the user inserted a row with an explicit id higher than the
     // sequence, the sequence should still advance past it on recovery

--- a/native/engine/src/wal/tests/recovery/sequences.rs
+++ b/native/engine/src/wal/tests/recovery/sequences.rs
@@ -1,0 +1,74 @@
+//! Recovery for SERIAL columns. Sequences live in their own global
+//! map and are NOT logged to the WAL on every nextval (would balloon
+//! log volume). Instead recovery rebuilds sequence state from the
+//! replayed rows: recreate the sequence at CreateTable replay, then
+//! advance it to the max value seen for the column.
+//!
+//! Without this the next live INSERT after recovery would call
+//! nextval and get 1, colliding with the existing PK.
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, executor, storage};
+
+#[test]
+#[serial_test::serial]
+fn recover_serial_advances_sequence_past_existing_max() {
+    let path = tmp_recovery_path("seq_advance");
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE t (id SERIAL PRIMARY KEY, name text)").unwrap();
+    executor::execute("INSERT INTO t (name) VALUES ('a'), ('b'), ('c')").unwrap();
+
+    storage::reset();
+    catalog::reset();
+    crate::sequence::reset();
+    recovery::recover().unwrap();
+
+    // Next insert must NOT collide with id=1,2,3 from the replayed rows.
+    executor::execute("INSERT INTO t (name) VALUES ('d')").unwrap();
+    let r = executor::execute("SELECT id FROM t WHERE name = 'd'").unwrap();
+    let id = r.rows[0][0].as_deref().unwrap().parse::<i64>().unwrap();
+    assert!(id > 3, "post-recovery sequence must produce id > 3, got {}", id);
+
+    // No PK conflict
+    let r = executor::execute("SELECT COUNT(*) FROM t").unwrap();
+    assert_eq!(r.rows[0][0], Some("4".into()));
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_serial_with_user_supplied_higher_id() {
+    // If the user inserted a row with an explicit id higher than the
+    // sequence, the sequence should still advance past it on recovery
+    // so the next nextval doesn't collide.
+    let path = tmp_recovery_path("seq_user");
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE t (id SERIAL PRIMARY KEY, name text)").unwrap();
+    executor::execute("INSERT INTO t (id, name) VALUES (100, 'big')").unwrap();
+
+    storage::reset();
+    catalog::reset();
+    crate::sequence::reset();
+    recovery::recover().unwrap();
+
+    executor::execute("INSERT INTO t (name) VALUES ('next')").unwrap();
+    let r = executor::execute("SELECT id FROM t WHERE name = 'next'").unwrap();
+    let id = r.rows[0][0].as_deref().unwrap().parse::<i64>().unwrap();
+    assert!(id > 100, "sequence must advance past user-supplied id, got {}", id);
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/wal/tests/recovery/vector_knn.rs
+++ b/native/engine/src/wal/tests/recovery/vector_knn.rs
@@ -1,0 +1,92 @@
+//! Recovery for vector KNN queries. HNSW indexes are NOT persisted to
+//! the WAL — they're lazily rebuilt from storage the first time a
+//! query needs them. This test verifies that the rebuild produces
+//! correct KNN results after a crash, not just that the raw vector
+//! bytes survive (already covered in vector.rs).
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, storage};
+
+#[test]
+#[serial_test::serial]
+fn recover_knn_query_returns_correct_nearest_neighbor() {
+    let path = tmp_recovery_path("knn");
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    crate::executor::execute("CREATE TABLE pts (id int, pos vector)").unwrap();
+    crate::executor::execute("INSERT INTO pts VALUES (1, '[0.0, 0.0]')").unwrap();
+    crate::executor::execute("INSERT INTO pts VALUES (2, '[1.0, 0.0]')").unwrap();
+    crate::executor::execute("INSERT INTO pts VALUES (3, '[0.0, 1.0]')").unwrap();
+    crate::executor::execute("INSERT INTO pts VALUES (4, '[10.0, 10.0]')").unwrap();
+
+    // Warm the HNSW index so we know it worked pre-crash.
+    let pre = crate::executor::execute(
+        "SELECT id FROM pts ORDER BY pos <-> '[0.1, 0.1]' LIMIT 2",
+    )
+    .unwrap();
+    assert_eq!(pre.rows[0][0], Some("1".into()));
+
+    // Simulate crash: wipe everything including sequence state.
+    storage::reset();
+    catalog::reset();
+    crate::sequence::reset();
+    recovery::recover().unwrap();
+
+    // HNSW must be rebuilt lazily on first KNN query, and return the
+    // same nearest neighbor. If the rebuild path is broken we'd see
+    // either a missing index error or stale row ids.
+    let post = crate::executor::execute(
+        "SELECT id FROM pts ORDER BY pos <-> '[0.1, 0.1]' LIMIT 2",
+    )
+    .unwrap();
+    assert_eq!(post.rows.len(), 2);
+    assert_eq!(post.rows[0][0], Some("1".into()));
+    assert_eq!(post.rows[1][0], Some("2".into()));
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_knn_after_delete_excludes_deleted_row() {
+    // A row deleted pre-crash must not appear in post-recovery KNN
+    // results. If the HNSW rebuild uses stale row ids, the deleted
+    // row's vector could still be returned.
+    let path = tmp_recovery_path("knn_del");
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    crate::executor::execute("CREATE TABLE pts (id int, pos vector)").unwrap();
+    crate::executor::execute("INSERT INTO pts VALUES (1, '[0.0, 0.0]')").unwrap();
+    crate::executor::execute("INSERT INTO pts VALUES (2, '[0.05, 0.05]')").unwrap();
+    crate::executor::execute("INSERT INTO pts VALUES (3, '[1.0, 1.0]')").unwrap();
+    crate::executor::execute("DELETE FROM pts WHERE id = 2").unwrap();
+
+    storage::reset();
+    catalog::reset();
+    crate::sequence::reset();
+    recovery::recover().unwrap();
+
+    let r = crate::executor::execute(
+        "SELECT id FROM pts ORDER BY pos <-> '[0.04, 0.04]' LIMIT 3",
+    )
+    .unwrap();
+    // id=2 was deleted, must not appear.
+    for row in &r.rows {
+        assert_ne!(row[0], Some("2".into()), "deleted row must not appear in KNN");
+    }
+    // Remaining rows are id=1 and id=3.
+    assert_eq!(r.rows.len(), 2);
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}


### PR DESCRIPTION
## Summary

Sequences are not WAL-logged per nextval (would balloon log volume), so after recovery the next INSERT calling nextval() would get 1, colliding with the existing PK from replayed rows.

## Fix

Two-phase sequence recovery in recovery/apply/sequences.rs:

1. **recreate_for_table**: at CreateTable replay, instantiate every sequence referenced by a NextVal default so it exists before inserts start replaying.
2. **advance_all_to_max**: after all entries have replayed, walk each SERIAL column, find the max int value in storage, and setval the sequence. Robust to user-supplied ids higher than the sequence ever produced.

## Test plan

- [x] recover_serial_advances_sequence_past_existing_max: insert 3 rows via SERIAL, wipe, recover, insert 4th, verify id > 3
- [x] recover_serial_with_user_supplied_higher_id: insert explicit id=100, wipe, recover, insert, verify id > 100
- [x] Full test suite: 327 tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
