### PR TITLE
test: recovery robustness under torn writes and multi-cycle crashes

### DIFF
--- a/native/engine/src/wal/tests/recovery/mod.rs
+++ b/native/engine/src/wal/tests/recovery/mod.rs
@@ -13,6 +13,8 @@ mod alter_columns;
 mod alter_rename;
 mod sequences;
 mod vector_knn;
+mod torn_write;
+mod multi_cycle;
 
 pub(super) fn tmp_recovery_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();

--- a/native/engine/src/wal/tests/recovery/multi_cycle.rs
+++ b/native/engine/src/wal/tests/recovery/multi_cycle.rs
@@ -1,0 +1,61 @@
+//! Multi-cycle crash recovery. Real workloads crash more than once:
+//! write -> crash -> recover -> write -> crash -> recover -> ... Each
+//! cycle must extend the WAL with monotonic LSNs and produce the same
+//! logical state as if everything had run without crashes.
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, executor, storage};
+
+#[test]
+#[serial_test::serial]
+fn recover_survives_three_crash_cycles() {
+    let path = tmp_recovery_path("multi_cycle");
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE t (id SERIAL PRIMARY KEY, v text)").unwrap();
+    executor::execute("INSERT INTO t (v) VALUES ('cycle0_a'), ('cycle0_b')").unwrap();
+
+    for cycle in 1..=3 {
+        storage::reset();
+        catalog::reset();
+        crate::sequence::reset();
+        recovery::recover().unwrap();
+
+        // Every row from every prior cycle must survive.
+        let r = executor::execute("SELECT COUNT(*) FROM t").unwrap();
+        let expected = 2 + (cycle - 1) * 2;
+        assert_eq!(
+            r.rows[0][0],
+            Some(expected.to_string()),
+            "cycle {} should see {} rows",
+            cycle,
+            expected
+        );
+
+        // Next insert must not collide with any replayed SERIAL id.
+        let v_a = format!("cycle{}_a", cycle);
+        let v_b = format!("cycle{}_b", cycle);
+        executor::execute(&format!("INSERT INTO t (v) VALUES ('{}'), ('{}')", v_a, v_b)).unwrap();
+    }
+
+    // Final recovery pass
+    storage::reset();
+    catalog::reset();
+    crate::sequence::reset();
+    recovery::recover().unwrap();
+
+    let r = executor::execute("SELECT COUNT(*) FROM t").unwrap();
+    assert_eq!(r.rows[0][0], Some("8".into()));
+
+    // SERIAL ids must all be distinct
+    let r = executor::execute("SELECT COUNT(DISTINCT id) FROM t").unwrap();
+    assert_eq!(r.rows[0][0], Some("8".into()));
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/wal/tests/recovery/torn_write.rs
+++ b/native/engine/src/wal/tests/recovery/torn_write.rs
@@ -1,0 +1,56 @@
+//! End-to-end recovery after a torn write. The reader stops at the
+//! damaged frame (corruption.rs covers that at the reader level);
+//! this module verifies that full recovery through the executor does
+//! the right thing: clean prefix restored, post-recovery LSNs stay
+//! monotonic so new writes don't collide with the truncated tail.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, executor, storage};
+
+#[test]
+#[serial_test::serial]
+fn recover_from_torn_tail_restores_clean_prefix() {
+    let path = tmp_recovery_path("torn");
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE t (id int, v text)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')").unwrap();
+
+    // Force fsync to disk, then detach the writer so we can mangle the file.
+    manager::disable();
+
+    // Append garbage bytes to simulate a crash mid-frame write.
+    let mut f = OpenOptions::new().append(true).open(&path).unwrap();
+    f.write_all(&[0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]).unwrap();
+    drop(f);
+
+    // Wipe in-memory state and recover from the torn file.
+    storage::reset();
+    catalog::reset();
+    crate::sequence::reset();
+    manager::enable(&path).unwrap();
+    let applied = recovery::recover().unwrap();
+    assert_eq!(applied, 4, "1 CreateTable + 3 Inserts must survive the torn tail");
+
+    let r = executor::execute("SELECT id, v FROM t ORDER BY id").unwrap();
+    assert_eq!(r.rows.len(), 3);
+    assert_eq!(r.rows[0][1], Some("a".into()));
+    assert_eq!(r.rows[2][1], Some("c".into()));
+
+    // Post-recovery writes must succeed and keep LSNs monotonic so
+    // they can't collide with whatever LSN the torn tail half-wrote.
+    executor::execute("INSERT INTO t VALUES (4, 'd')").unwrap();
+    let r = executor::execute("SELECT COUNT(*) FROM t").unwrap();
+    assert_eq!(r.rows[0][0], Some("4".into()));
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}


### PR DESCRIPTION
## Summary

End-to-end recovery tests covering scenarios not previously exercised: mid-frame torn writes and repeated crash/recover cycles.

## Tests

- **recover_from_torn_tail_restores_clean_prefix**: append garbage bytes past the last fsync to simulate a mid-frame crash, then run full recovery. The clean prefix must replay, torn tail must be ignored, and post-recovery writes must produce a valid row count. Corruption detection at the reader level is already covered in wal/tests/corruption.rs; this is the end-to-end version through the executor.
- **recover_survives_three_crash_cycles**: write/crash/recover loop with a SERIAL table, verifying row count grows each cycle and that sequence ids stay distinct across all cycles. Stresses the LSN continuation + sequence advancement paths in combination.

Both tests pass. No engine changes — pure test additions.

## Test plan

- [x] cargo test --lib wal::tests::recovery (29/29 passing)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
