### PR TITLE
test: UPDATE changing PK and UPSERT on composite PK both survive recovery

### DIFF
--- a/native/engine/src/wal/tests/recovery/mod.rs
+++ b/native/engine/src/wal/tests/recovery/mod.rs
@@ -16,6 +16,7 @@ mod vector_knn;
 mod torn_write;
 mod multi_cycle;
 mod composite_pk;
+mod update_pk;
 
 pub(super) fn tmp_recovery_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();

--- a/native/engine/src/wal/tests/recovery/update_pk.rs
+++ b/native/engine/src/wal/tests/recovery/update_pk.rs
@@ -1,0 +1,95 @@
+//! Recovery for UPDATE statements that change the primary key value.
+//! apply_update matches by row content, so the old_row in the WAL
+//! must match the in-memory state at the time of replay. If anything
+//! (rebuild_indexes, sequence advancement) observes a stale PK, the
+//! next live INSERT after recovery would collide.
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, executor, storage};
+
+#[test]
+#[serial_test::serial]
+fn recover_upsert_with_composite_pk_do_update() {
+    // UPSERT on a composite PK must route through the pk_index (not
+    // per-column unique indexes) to detect conflicts. If recovery
+    // rebuilt the wrong index shape, a post-recovery ON CONFLICT
+    // DO UPDATE could either skip a real conflict or spuriously
+    // reject a legitimate row.
+    let path = tmp_recovery_path("upsert_comp_pk");
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE t (a int, b int, v text, PRIMARY KEY (a, b))").unwrap();
+    executor::execute("INSERT INTO t VALUES (1, 1, 'x'), (1, 2, 'y')").unwrap();
+    // This UPSERT must update row (1,1) to 'x_updated' because (1,1) exists.
+    executor::execute(
+        "INSERT INTO t VALUES (1, 1, 'x_updated') ON CONFLICT (a, b) DO UPDATE SET v = EXCLUDED.v",
+    )
+    .unwrap();
+
+    storage::reset();
+    catalog::reset();
+    crate::sequence::reset();
+    recovery::recover().unwrap();
+
+    let r = executor::execute("SELECT v FROM t WHERE a = 1 AND b = 1").unwrap();
+    assert_eq!(r.rows[0][0], Some("x_updated".into()));
+
+    // Post-recovery UPSERT must still see composite conflicts: a new
+    // row with (1, 2) conflicts and should update, not duplicate.
+    executor::execute(
+        "INSERT INTO t VALUES (1, 2, 'y_updated') ON CONFLICT (a, b) DO UPDATE SET v = EXCLUDED.v",
+    )
+    .unwrap();
+
+    let r = executor::execute("SELECT COUNT(*) FROM t").unwrap();
+    assert_eq!(r.rows[0][0], Some("2".into()));
+    let r = executor::execute("SELECT v FROM t WHERE a = 1 AND b = 2").unwrap();
+    assert_eq!(r.rows[0][0], Some("y_updated".into()));
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_update_that_changes_primary_key() {
+    let path = tmp_recovery_path("update_pk");
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE t (id int PRIMARY KEY, name text)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')").unwrap();
+    executor::execute("UPDATE t SET id = 99 WHERE id = 2").unwrap();
+
+    storage::reset();
+    catalog::reset();
+    crate::sequence::reset();
+    recovery::recover().unwrap();
+
+    // Row with new PK must exist, old PK must not.
+    let r = executor::execute("SELECT name FROM t WHERE id = 99").unwrap();
+    assert_eq!(r.rows.len(), 1);
+    assert_eq!(r.rows[0][0], Some("b".into()));
+    let r = executor::execute("SELECT COUNT(*) FROM t WHERE id = 2").unwrap();
+    assert_eq!(r.rows[0][0], Some("0".into()));
+
+    // Post-recovery PK index must reflect the new value: inserting a
+    // row with id=99 must be rejected, id=2 must succeed.
+    let err = executor::execute("INSERT INTO t VALUES (99, 'dup')");
+    assert!(err.is_err(), "rebuilt PK index must reject id=99");
+    executor::execute("INSERT INTO t VALUES (2, 'reused')").unwrap();
+
+    let r = executor::execute("SELECT COUNT(*) FROM t").unwrap();
+    assert_eq!(r.rows[0][0], Some("4".into()));
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}


### PR DESCRIPTION
## Summary

Two recovery tests that exercise the index rebuild path landed in #55 (storage::setup_table_indexes). Both pass without additional engine changes, locking in the correctness of the composite PK fix.

## Tests

- **recover_update_that_changes_primary_key**: UPDATE sets id from 2 to 99 on a single-column PK table. Post-recovery the old PK must be free (insert id=2 succeeds) and the new PK must be taken (insert id=99 rejected). Verifies apply_update + rebuild_indexes keep the unique index consistent with the new row contents.
- **recover_upsert_with_composite_pk_do_update**: UPSERT ON CONFLICT (a, b) DO UPDATE SET ... runs once before the crash and once after recovery. Post-recovery the composite conflict detection must still route through the pk_index on the tuple, otherwise the second UPSERT would spuriously insert instead of update.

## Test plan

- [x] cargo test --lib wal::tests::recovery: all passing, no regressions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
