### PR TITLE
test: WAL round-trip for Value variants via ALTER defaults and NULL updates

### DIFF
--- a/native/engine/src/wal/tests/recovery/alter_defaults.rs
+++ b/native/engine/src/wal/tests/recovery/alter_defaults.rs
@@ -1,0 +1,87 @@
+//! ALTER ADD COLUMN with varied default value types. The WAL entry
+//! stores the resolved default as a Value in fill_value, so bincode
+//! must serialize every Value variant correctly. A bug in any
+//! variant's Serialize impl would surface as a decode error or wrong
+//! value on recovery.
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, executor, storage};
+
+fn setup(name: &str) -> std::path::PathBuf {
+    let path = tmp_recovery_path(name);
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+    path
+}
+
+fn wipe_and_recover() {
+    storage::reset();
+    catalog::reset();
+    crate::sequence::reset();
+    recovery::recover().unwrap();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_alter_add_int_default() {
+    let path = setup("alter_int");
+    executor::execute("CREATE TABLE t (id int)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1)").unwrap();
+    executor::execute("ALTER TABLE t ADD COLUMN score int DEFAULT 42").unwrap();
+    wipe_and_recover();
+    let r = executor::execute("SELECT score FROM t WHERE id = 1").unwrap();
+    assert_eq!(r.rows[0][0], Some("42".into()));
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_alter_add_bool_default() {
+    let path = setup("alter_bool");
+    executor::execute("CREATE TABLE t (id int)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1)").unwrap();
+    executor::execute("ALTER TABLE t ADD COLUMN active bool DEFAULT true").unwrap();
+    wipe_and_recover();
+    let r = executor::execute("SELECT active FROM t WHERE id = 1").unwrap();
+    assert_eq!(r.rows[0][0], Some("t".into()));
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_alter_add_null_default() {
+    // ALTER ADD COLUMN without a DEFAULT must set existing rows to
+    // NULL, and NULL must survive bincode round-trip.
+    let path = setup("alter_null");
+    executor::execute("CREATE TABLE t (id int)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1), (2)").unwrap();
+    executor::execute("ALTER TABLE t ADD COLUMN note text").unwrap();
+    wipe_and_recover();
+    let r = executor::execute("SELECT note FROM t WHERE id = 1").unwrap();
+    assert_eq!(r.rows[0][0], None);
+    let r = executor::execute("SELECT COUNT(*) FROM t WHERE note IS NULL").unwrap();
+    assert_eq!(r.rows[0][0], Some("2".into()));
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_alter_add_float_default() {
+    let path = setup("alter_float");
+    executor::execute("CREATE TABLE t (id int)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1)").unwrap();
+    executor::execute("ALTER TABLE t ADD COLUMN ratio float DEFAULT 3.14").unwrap();
+    wipe_and_recover();
+    let r = executor::execute("SELECT ratio FROM t WHERE id = 1").unwrap();
+    let got: f64 = r.rows[0][0].as_deref().unwrap().parse().unwrap();
+    assert!((got - 3.14).abs() < 1e-9, "got {}", got);
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/wal/tests/recovery/mod.rs
+++ b/native/engine/src/wal/tests/recovery/mod.rs
@@ -17,6 +17,8 @@ mod torn_write;
 mod multi_cycle;
 mod composite_pk;
 mod update_pk;
+mod alter_defaults;
+mod null_updates;
 
 pub(super) fn tmp_recovery_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();

--- a/native/engine/src/wal/tests/recovery/null_updates.rs
+++ b/native/engine/src/wal/tests/recovery/null_updates.rs
@@ -1,0 +1,53 @@
+//! UPDATE recovery when rows cross the NULL boundary. apply_update
+//! matches rows by content, so both directions (value -> NULL and
+//! NULL -> value) need the serialized old_row and new_row to
+//! faithfully round-trip Value::Null.
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, executor, storage};
+
+fn setup(name: &str) -> std::path::PathBuf {
+    let path = tmp_recovery_path(name);
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+    path
+}
+
+fn wipe_and_recover() {
+    storage::reset();
+    catalog::reset();
+    crate::sequence::reset();
+    recovery::recover().unwrap();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_update_sets_column_to_null() {
+    let path = setup("update_null");
+    executor::execute("CREATE TABLE t (id int, name text)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1, 'alice')").unwrap();
+    executor::execute("UPDATE t SET name = NULL WHERE id = 1").unwrap();
+    wipe_and_recover();
+    let r = executor::execute("SELECT name FROM t WHERE id = 1").unwrap();
+    assert_eq!(r.rows[0][0], None);
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn recover_update_from_null_to_value() {
+    let path = setup("update_from_null");
+    executor::execute("CREATE TABLE t (id int, name text)").unwrap();
+    executor::execute("INSERT INTO t (id) VALUES (1)").unwrap();
+    executor::execute("UPDATE t SET name = 'alice' WHERE id = 1").unwrap();
+    wipe_and_recover();
+    let r = executor::execute("SELECT name FROM t WHERE id = 1").unwrap();
+    assert_eq!(r.rows[0][0], Some("alice".into()));
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}


### PR DESCRIPTION
## Summary

Six new recovery tests exercising Value variant serialization through bincode. Both ALTER ADD COLUMN fill_value and UPDATE old_row/new_row are stored as raw Value in the WAL, so a regression in any variant's Serialize impl would silently corrupt recovery.

## Tests

**alter_defaults.rs** (ALTER ADD COLUMN with resolved default):
- recover_alter_add_int_default: Value::Int fill value
- recover_alter_add_bool_default: Value::Bool fill value
- recover_alter_add_null_default: no DEFAULT — existing rows set to Value::Null
- recover_alter_add_float_default: Value::Float fill value (1e-9 tolerance)

**null_updates.rs** (UPDATE crossing NULL boundary):
- recover_update_sets_column_to_null: UPDATE SET col = NULL
- recover_update_from_null_to_value: UPDATE a NULL back to a real value

Both files sit under 100 lines on purpose so future Value variants can be added alongside without a split.

## Test plan

- [x] cargo test --lib wal::tests::recovery: 38/38 passing, no engine changes needed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
