### PR TITLE
fix: ALTER DROP COLUMN rebuilds composite pk_index instead of nulling it

### DIFF
--- a/native/engine/src/storage.rs
+++ b/native/engine/src/storage.rs
@@ -928,7 +928,22 @@ pub fn alter_drop_column(schema: &str, name: &str, col_idx: usize) {
         for c in t.pk_cols.iter_mut() {
             if *c > col_idx { *c -= 1; }
         }
-        t.pk_index = None; // force rebuild on next insert
+        // Composite PK: rebuild the tuple index from the new row slice.
+        // Setting pk_index = None (the old behavior) silently disabled
+        // duplicate-key checks in insert_batch_checked line 378, which
+        // reads `if let Some(ref pk_idx) = table.pk_index`. A None
+        // index means every check short-circuits, and two separate
+        // INSERT statements can land duplicate composite keys.
+        if t.pk_cols.len() > 1 {
+            let mut pk_idx = HashMap::new();
+            for (row_idx, row) in t.rows.iter().enumerate() {
+                let key: Vec<Value> = t.pk_cols.iter().map(|&i| row[i].clone()).collect();
+                pk_idx.insert(key, row_idx);
+            }
+            t.pk_index = Some(pk_idx);
+        } else {
+            t.pk_index = None;
+        }
         t.hnsw_index = None; // invalidate - will be lazily recreated
     }
 }

--- a/native/engine/src/wal/tests/recovery/alter_preserves_pk.rs
+++ b/native/engine/src/wal/tests/recovery/alter_preserves_pk.rs
@@ -1,0 +1,58 @@
+//! ALTER DROP COLUMN on a composite-PK table must keep the pk_index
+//! on the tuple intact. The old storage code set
+//! `t.pk_index = None` after the column removal with a hopeful
+//! `// force rebuild on next insert` comment, but insert_batch_checked
+//! only checks the pk_index if it exists (line 378). With the index
+//! None, post-drop INSERTs silently accept duplicate composite keys.
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, executor, storage};
+
+#[test]
+#[serial_test::serial]
+fn alter_drop_non_pk_column_preserves_composite_pk_live() {
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+
+    executor::execute("CREATE TABLE t (a int, b int, c int, PRIMARY KEY (a, b))").unwrap();
+    executor::execute("INSERT INTO t VALUES (1, 1, 100), (1, 2, 200)").unwrap();
+    executor::execute("ALTER TABLE t DROP COLUMN c").unwrap();
+
+    // (1, 1) is still a row — duplicate composite PK must be rejected.
+    let err = executor::execute("INSERT INTO t VALUES (1, 1)");
+    assert!(err.is_err(), "composite PK duplicate must be rejected after ALTER DROP");
+
+    // New (1, 3) is fine.
+    executor::execute("INSERT INTO t VALUES (1, 3)").unwrap();
+    let r = executor::execute("SELECT COUNT(*) FROM t").unwrap();
+    assert_eq!(r.rows[0][0], Some("3".into()));
+}
+
+#[test]
+#[serial_test::serial]
+fn alter_drop_non_pk_column_preserves_composite_pk_through_recovery() {
+    let path = tmp_recovery_path("alter_drop_comp_pk");
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+
+    executor::execute("CREATE TABLE t (a int, b int, c int, PRIMARY KEY (a, b))").unwrap();
+    executor::execute("INSERT INTO t VALUES (1, 1, 100), (1, 2, 200)").unwrap();
+    executor::execute("ALTER TABLE t DROP COLUMN c").unwrap();
+
+    storage::reset();
+    catalog::reset();
+    crate::sequence::reset();
+    recovery::recover().unwrap();
+
+    let err = executor::execute("INSERT INTO t VALUES (1, 1)");
+    assert!(err.is_err(), "post-recovery composite PK duplicate must be rejected");
+
+    manager::disable();
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/wal/tests/recovery/mod.rs
+++ b/native/engine/src/wal/tests/recovery/mod.rs
@@ -20,6 +20,7 @@ mod update_pk;
 mod alter_defaults;
 mod null_updates;
 mod alter_preserves_unique;
+mod alter_preserves_pk;
 
 pub(super) fn tmp_recovery_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();


### PR DESCRIPTION
## Summary

Second half of the \`alter_drop_column\` index-correctness problem (first half shipped in #58).

\`storage::alter_drop_column\` used to set \`t.pk_index = None\` with a comment claiming the next insert would rebuild it. It does not: \`insert_batch_checked\` at storage.rs:378 reads

\`\`\`rust
if let Some(ref pk_idx) = table.pk_index {
    if pk_idx.contains_key(&key) { /* duplicate error */ }
}
\`\`\`

A \`None\` \`pk_index\` means every composite-PK duplicate-key check silently short-circuits. Two separate INSERT statements can land identical \`(a, b)\` rows, and only the intra-statement \`batch_pk\` set would catch same-statement duplicates.

## Repro (pre-fix)

\`\`\`sql
CREATE TABLE t (a int, b int, c int, PRIMARY KEY (a, b));
INSERT INTO t VALUES (1, 1, 100), (1, 2, 200);
ALTER TABLE t DROP COLUMN c;
INSERT INTO t VALUES (1, 1);   -- silently accepted; (1,1) existed
\`\`\`

## Fix

After dropping the column and fixing up pk_cols indices, rebuild the pk_index tuple hash map from the new row slice. Single-column PK tables still go to None because that path uses unique_indexes, not pk_index.

## Tests

- \`alter_drop_non_pk_column_preserves_composite_pk_live\`: no WAL, hits the storage function directly.
- \`alter_drop_non_pk_column_preserves_composite_pk_through_recovery\`: same state via crash + WAL replay, since recovery routes through the same \`alter_drop_column\`.

Both fail demonstrably on the pre-fix code.

## Test plan

- [x] cargo test --lib: 345/345 passing.
- [x] Pre-fix: both new tests fail with the exact repro assertion.
- [x] Post-fix: all green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
