### PR TITLE
fix: assign WAL LSN inside the writer lock so file order matches LSN order

### DIFF
--- a/native/engine/src/wal/tests/mod.rs
+++ b/native/engine/src/wal/tests/mod.rs
@@ -9,6 +9,7 @@ mod payload;
 mod manager_tests;
 mod storage_integration;
 mod recovery;
+mod writer_concurrent;
 
 pub(super) fn tmp_wal_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();

--- a/native/engine/src/wal/tests/writer_concurrent.rs
+++ b/native/engine/src/wal/tests/writer_concurrent.rs
@@ -1,0 +1,59 @@
+//! Concurrent append stress. LSN assignment used to happen via an
+//! atomic fetch_add outside the writer mutex, so a thread with a
+//! lower LSN could lose the race to the lock and write its frame
+//! AFTER a thread with a higher LSN. Recovery reads frames in file
+//! order, so out-of-order LSNs meant out-of-order replay — and a
+//! torn-write tail could silently keep a higher-LSN frame while
+//! dropping the lower-LSN one that the next thread was still
+//! writing. This test runs many concurrent appends against a shared
+//! writer and asserts:
+//!   1. LSNs are unique and contiguous (1..=N).
+//!   2. File order exactly matches LSN order.
+
+use std::sync::Arc;
+use std::thread;
+
+use super::super::*;
+use super::{insert_op, tmp_wal_path};
+
+#[test]
+fn concurrent_appends_preserve_lsn_file_order() {
+    let path = tmp_wal_path("concurrent_lsn");
+    let writer = Arc::new(WalWriter::open(&path, 1).unwrap());
+
+    const THREADS: usize = 8;
+    const PER_THREAD: usize = 64;
+
+    let mut handles = Vec::with_capacity(THREADS);
+    for t in 0..THREADS {
+        let w = Arc::clone(&writer);
+        handles.push(thread::spawn(move || {
+            let mut lsns = Vec::with_capacity(PER_THREAD);
+            for i in 0..PER_THREAD {
+                let op = insert_op((t * 1000 + i) as i64, "x");
+                lsns.push(w.append(op).unwrap());
+            }
+            lsns
+        }));
+    }
+    let mut all_lsns: Vec<Lsn> = Vec::new();
+    for h in handles {
+        all_lsns.extend(h.join().unwrap());
+    }
+    writer.flush_sync().unwrap();
+    drop(writer);
+
+    // Uniqueness + contiguity.
+    all_lsns.sort();
+    let total = (THREADS * PER_THREAD) as u64;
+    let expected: Vec<Lsn> = (1..=total).collect();
+    assert_eq!(all_lsns, expected, "LSNs must be unique and contiguous");
+
+    // File order must match LSN order.
+    let entries = WalReader::open(&path).unwrap().read_all().unwrap();
+    assert_eq!(entries.len(), total as usize);
+    for (i, e) in entries.iter().enumerate() {
+        assert_eq!(e.lsn, (i as u64) + 1, "entry {} has LSN {} (expected {})", i, e.lsn, i + 1);
+    }
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/wal/writer.rs
+++ b/native/engine/src/wal/writer.rs
@@ -36,12 +36,21 @@ impl WalWriter {
 
     /// Append an operation and return the assigned LSN. Does NOT fsync.
     /// Call `flush_sync` to make writes durable.
+    ///
+    /// LSN assignment is done INSIDE the writer lock so that the order
+    /// of LSNs always matches the order of frames in the file. An
+    /// earlier version assigned LSNs via a separate atomic before the
+    /// lock; under concurrent appends that allowed a thread with a
+    /// lower LSN to write its frame after a thread with a higher one,
+    /// which would leave recovery replaying entries out of logical
+    /// order — and, worse, a torn-write tail could drop the
+    /// lower-LSN entry while keeping the higher-LSN one durable.
     pub fn append(&self, op: WalOp) -> Result<Lsn, String> {
-        let lsn = self.next_lsn.fetch_add(1, Ordering::SeqCst);
         let payload = op.encode_payload()?;
         let tag = op.tag();
-        let frame = encode_frame(lsn, tag, &payload);
         let mut w = self.inner.lock();
+        let lsn = self.next_lsn.fetch_add(1, Ordering::SeqCst);
+        let frame = encode_frame(lsn, tag, &payload);
         w.write_all(&frame).map_err(|e| format!("WAL write: {}", e))?;
         Ok(lsn)
     }


### PR DESCRIPTION
## Summary

\`WalWriter::append\` used to \`fetch_add\` its LSN via an atomic BEFORE acquiring the writer mutex. Two concurrent appends race: thread A gets LSN 10, thread B gets LSN 11. If B wins the lock, it writes LSN 11 first and A writes LSN 10 second. Recovery reads frames in file order (reader stops at the first torn tail, no LSN sort), so replay ran entries out of logical order.

Worse: if a crash happens after B's write but before A's, recovery sees a "durable" LSN 11 frame but the LSN 10 frame is missing entirely. The next lifecycle's LSN counter is primed to \`max_lsn + 1 = 12\`, so LSN 10 becomes permanently skipped and any mutation it recorded is silently lost.

## Fix

Move the \`fetch_add\` inside the writer mutex. LSN assignment is now serialized with the frame write, so the Nth frame in the file always has LSN = \`starting_lsn + N - 1\`.

## Repro

Reverted the fix and ran the new stress test: 8 threads × 64 appends against a shared writer, assert that file order equals LSN order. Pre-fix the file's first frame had LSN 8 instead of 1 (screen-grabbed the assertion). Post-fix all 512 frames land in order.

On live EvolvSQL the per-table lock prevents this for single-table streams, but cross-table workloads and concurrent DDL + DML would trip it.

## Test plan

- [x] cargo test --lib: 349/349 passing.
- [x] Pre-fix reproduction: \`concurrent_appends_preserve_lsn_file_order\` fails with \`entry 0 has LSN 8 (expected 1)\`.
- [x] Post-fix: new stress test passes, no regressions in existing WAL tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
