### PR TITLE
cleanup: drop redundant pk_cols_vec parameter from check_all_unique

### DIFF
--- a/native/engine/src/storage.rs
+++ b/native/engine/src/storage.rs
@@ -470,7 +470,7 @@ pub fn insert_upsert(
         match conflict_idx {
             None => {
                 check_all_unique(
-                    &working_indexes, &working_pk, &pk_cols_vec,
+                    &working_indexes, &working_pk,
                     &row, unique_checks, pk_cols,
                 )?;
                 let row_idx = working_rows.len();
@@ -608,13 +608,12 @@ fn remove_from_working_indexes(
 fn check_all_unique(
     unique_indexes: &HashMap<usize, HashMap<Value, usize>>,
     pk_index: &Option<HashMap<Vec<Value>, usize>>,
-    pk_cols: &[usize],
     row: &Row,
     unique_checks: &[(usize, String)],
-    all_pk_cols: &[usize],
+    pk_cols: &[usize],
 ) -> Result<(), String> {
-    if all_pk_cols.len() > 1 {
-        let key: Vec<Value> = all_pk_cols.iter().map(|&ci| row[ci].clone()).collect();
+    if pk_cols.len() > 1 {
+        let key: Vec<Value> = pk_cols.iter().map(|&ci| row[ci].clone()).collect();
         if let Some(pk_idx) = pk_index {
             if pk_idx.contains_key(&key) {
                 return Err("duplicate key value violates unique constraint (pkey)".into());


### PR DESCRIPTION
## Summary

\`check_all_unique\` took two arguments for the same thing: \`pk_cols_vec\` (cloned from \`table.pk_cols\`) and \`all_pk_cols\` (passed through from the caller). Only \`all_pk_cols\` was actually read inside the body — the cloned one was silently ignored, which the compiler flagged as an unused variable.

Both args hold the same PK column indices in every live call path (\`insert_upsert\`'s callers compute them from the same catalog definition the table was created with), so collapsing them is a pure refactor. Call site in \`insert_upsert\` updated accordingly.

Silences the \`unused variable: pk_cols\` warning and removes a footgun where the two parameters could accidentally diverge in a future change.

## Test plan

- [x] cargo test --lib: 352/352 passing, no regressions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
