### PR TITLE
fix: zone map min/max excludes NaN so it can't poison the accumulator

### DIFF
--- a/native/engine/src/segment/tests/mod.rs
+++ b/native/engine/src/segment/tests/mod.rs
@@ -7,6 +7,7 @@ mod basic;
 mod zone_maps;
 mod large;
 mod edge_types;
+mod zone_map_nan;
 
 pub(super) fn tmp_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();

--- a/native/engine/src/segment/tests/zone_map_nan.rs
+++ b/native/engine/src/segment/tests/zone_map_nan.rs
@@ -1,0 +1,42 @@
+//! NaN poisoning in zone map min/max tracking. Float comparisons
+//! with NaN return false in both directions, so once NaN lands in
+//! the `min` or `max` slot the accumulator is stuck there and every
+//! subsequent real Float is silently ignored. Predicate pushdown
+//! built on top of these zone maps would then wrongly mark the
+//! segment as "outside range" for a legitimate query.
+
+use super::super::*;
+use super::tmp_path;
+use crate::types::Value;
+
+#[test]
+fn zone_map_ignores_nan_and_tracks_real_floats() {
+    let path = tmp_path("nan_zm");
+    let schema = vec![("x".into(), 701)]; // float8 OID
+
+    // NaN appears first; the tracker must not let it become the
+    // running min/max because every real follow-up value would then
+    // fail the `less_than` check against NaN.
+    let rows: Vec<Vec<Value>> = vec![
+        vec![Value::Float(f64::NAN)],
+        vec![Value::Float(2.0)],
+        vec![Value::Float(-5.0)],
+        vec![Value::Float(10.0)],
+    ];
+    SegmentWriter::write(&path, &schema, &rows).unwrap();
+
+    let mut reader = SegmentReader::open(&path).unwrap();
+    let meta = reader.column_meta("x").unwrap();
+    assert_eq!(
+        meta.min,
+        Some(Value::Float(-5.0)),
+        "min must be the smallest real value, not poisoned by NaN"
+    );
+    assert_eq!(
+        meta.max,
+        Some(Value::Float(10.0)),
+        "max must be the largest real value, not poisoned by NaN"
+    );
+
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/segment/zone_map.rs
+++ b/native/engine/src/segment/zone_map.rs
@@ -30,8 +30,16 @@ pub(super) fn compute_zone_map(values: &[Value]) -> (Option<Value>, Option<Value
 }
 
 /// Whether a value type participates in zone map min/max tracking.
+/// NaN floats are deliberately excluded: every NaN comparison via
+/// `less_than` returns false, so allowing a NaN into the accumulator
+/// would freeze it at NaN forever and silently drop every real
+/// follow-up value (min/max would both be stuck on NaN).
 fn has_zone_order(v: &Value) -> bool {
-    matches!(v, Value::Int(_) | Value::Float(_) | Value::Text(_) | Value::Bool(_))
+    match v {
+        Value::Int(_) | Value::Text(_) | Value::Bool(_) => true,
+        Value::Float(f) => !f.is_nan(),
+        _ => false,
+    }
 }
 
 /// Strict less-than comparison for zone map tracking. Only defined for


### PR DESCRIPTION
## Summary

\`compute_zone_map\` used \`less_than\` for incremental min/max tracking. \`less_than\` for \`Float\` uses ordinary \`<\`, which returns false for every NaN comparison in both directions. That gave the accumulator a subtle but fatal failure mode.

## Repro (pre-fix)

\`\`\`
rows:       [NaN, 2.0, -5.0, 10.0]
first pass: min=None → is_none_or(...) = true → min=Some(NaN)
second:     less_than(2.0, NaN) = 2.0 < NaN = false → no update
third:      less_than(-5.0, NaN) = false → no update
fourth:     less_than(10.0, NaN) = false → no update
\`\`\`

Every real value after the NaN was silently dropped, and the final zone map reported min=Some(NaN), max=Some(NaN). Predicate pushdown sitting on top (\`outside_range\` via \`less_than\`) would then falsely conclude every legitimate query's target is outside the range, skipping segments that actually contain matching rows.

## Fix

Reject NaN floats at the \`has_zone_order\` gate so they never enter the accumulator. NaN joins Null, Vector, and Bytea as "not ordered for zone maps". Null count still doesn't include NaN (NaN is a valid value, just unordered).

Segment flush isn't wired into live storage yet, so this was a latent bug rather than a live one — but fixing it before the path is enabled avoids a silent pushdown miss at the worst moment.

## Tests

- \`zone_map_ignores_nan_and_tracks_real_floats\`: demonstrably fails on the pre-fix code (min: Some(Float(NaN)) vs expected Some(Float(-5.0))).

## Test plan

- [x] cargo test --lib: 353/353 passing.
- [x] Pre-fix reproduction: new test fails with the NaN poison.
- [x] Post-fix: new test passes, existing segment/edge_types tests unaffected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
