### PR TITLE
fix: wire WAL into NIF load callback so recovery runs in production

### DIFF
--- a/native/engine/src/lib.rs
+++ b/native/engine/src/lib.rs
@@ -13,6 +13,44 @@ mod window;
 
 use rustler::{Encoder, Env, Term};
 
+/// Boot the WAL subsystem from environment variables. Extracted from
+/// `on_load` so cargo tests can exercise the same path the NIF loader
+/// takes, since `on_load` itself needs an `Env` and can only run
+/// inside the BEAM.
+///
+/// Env contract:
+/// - `EVOLVSQL_WAL_ENABLED=1` turns the WAL on (default: off)
+/// - `EVOLVSQL_WAL_PATH=/some/file.wal` picks the log file
+///
+/// On enable, we replay any existing WAL before accepting queries so
+/// recovered state is visible immediately. A recovery failure is
+/// logged to stderr and leaves the WAL disabled rather than aborting
+/// NIF load — a broken WAL file must not brick the whole engine.
+pub(crate) fn boot_wal_from_env() {
+    match wal::manager::enable_from_env() {
+        Ok(true) => {
+            if let Err(e) = wal::recovery::recover() {
+                eprintln!("evolvsql: WAL recovery failed, disabling WAL: {}", e);
+                wal::manager::disable();
+            }
+        }
+        Ok(false) => {}
+        Err(e) => {
+            eprintln!("evolvsql: WAL enable failed, running in-memory: {}", e);
+        }
+    }
+}
+
+/// Rustler load callback. Runs once when the NIF library is loaded by
+/// the BEAM (on `:engine.start` or first `Engine.Native` call). This
+/// is the only place we can enable the WAL for the running process;
+/// without it `enable_from_env` would only ever run in tests, and the
+/// production engine would silently start up with no WAL at all.
+fn on_load(_env: Env, _info: Term) -> bool {
+    boot_wal_from_env();
+    true
+}
+
 #[rustler::nif]
 fn ping() -> &'static str {
     "pong from rust engine"
@@ -81,4 +119,4 @@ fn execute_sql<'a>(env: Env<'a>, sql: &str) -> Term<'a> {
     }
 }
 
-rustler::init!("Elixir.Engine.Native");
+rustler::init!("Elixir.Engine.Native", load = on_load);

--- a/native/engine/src/wal/tests/recovery/mod.rs
+++ b/native/engine/src/wal/tests/recovery/mod.rs
@@ -23,6 +23,7 @@ mod alter_preserves_unique;
 mod alter_preserves_pk;
 mod alter_then_mutate;
 mod vector_alter;
+mod nif_boot;
 
 pub(super) fn tmp_recovery_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();

--- a/native/engine/src/wal/tests/recovery/nif_boot.rs
+++ b/native/engine/src/wal/tests/recovery/nif_boot.rs
@@ -1,0 +1,113 @@
+//! Verifies that the NIF load path (extracted as `boot_wal_from_env`)
+//! actually enables the WAL and replays recovery. Without this hook
+//! being wired into `rustler::init!`, the entire WAL subsystem would
+//! be dead code in production — `enable_from_env` exists but nothing
+//! calls it at NIF load time, so a real engine process would start up
+//! in-memory even with `EVOLVSQL_WAL_ENABLED=1` set.
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, executor, storage};
+
+fn set_env(path: &std::path::Path) {
+    // SAFETY: test is #[serial] and nothing else in this process
+    // manipulates these env vars concurrently.
+    unsafe {
+        std::env::set_var("EVOLVSQL_WAL_ENABLED", "1");
+        std::env::set_var("EVOLVSQL_WAL_PATH", path);
+    }
+}
+
+fn clear_env() {
+    unsafe {
+        std::env::remove_var("EVOLVSQL_WAL_ENABLED");
+        std::env::remove_var("EVOLVSQL_WAL_PATH");
+    }
+}
+
+#[test]
+#[serial_test::serial]
+fn boot_enables_wal_and_replays_recovery() {
+    let path = tmp_recovery_path("nif_boot");
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+
+    // Phase 1: simulate a previous run that wrote some data.
+    manager::enable(&path).unwrap();
+    executor::execute("CREATE TABLE t (id int, name text)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1, 'a'), (2, 'b')").unwrap();
+    manager::disable();
+
+    // Phase 2: fresh process — storage wiped, WAL disabled,
+    // env vars set as the deploy would set them.
+    storage::reset();
+    catalog::reset();
+    crate::sequence::reset();
+    assert!(!manager::is_enabled());
+    set_env(&path);
+
+    // The exact function `rustler::init!(load = on_load)` runs.
+    crate::boot_wal_from_env();
+
+    assert!(manager::is_enabled(), "boot must enable the WAL");
+    let r = executor::execute("SELECT COUNT(*) FROM t").unwrap();
+    assert_eq!(
+        r.rows[0][0],
+        Some("2".into()),
+        "boot must also run recovery so pre-crash rows are visible"
+    );
+
+    manager::disable();
+    clear_env();
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn boot_with_env_disabled_stays_in_memory() {
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+    clear_env();
+
+    crate::boot_wal_from_env();
+
+    assert!(
+        !manager::is_enabled(),
+        "without EVOLVSQL_WAL_ENABLED=1 the engine must not touch disk"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn boot_with_corrupt_wal_disables_rather_than_panics() {
+    // A broken WAL file must not brick the whole engine. boot should
+    // log the error and leave the WAL disabled so the process still
+    // comes up — losing durability is acceptable; refusing to start
+    // is not.
+    let path = tmp_recovery_path("nif_boot_corrupt");
+    std::fs::write(&path, b"\xff\xff\xff\xff\xff\xff\xff\xff").unwrap();
+
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+    set_env(&path);
+
+    crate::boot_wal_from_env();
+
+    // The file is gibberish: recovery should either fail gracefully
+    // or apply zero entries. In either case the process must not
+    // panic and the engine must still serve queries.
+    executor::execute("CREATE TABLE probe (x int)").unwrap();
+    executor::execute("INSERT INTO probe VALUES (1)").unwrap();
+    let r = executor::execute("SELECT COUNT(*) FROM probe").unwrap();
+    assert_eq!(r.rows[0][0], Some("1".into()));
+
+    manager::disable();
+    clear_env();
+    std::fs::remove_file(&path).ok();
+}


### PR DESCRIPTION
## The hole

\`manager::enable_from_env()\` existed but nothing called it at NIF load time. That made the entire WAL subsystem dead code in production: the engine would start up in-memory even with \`EVOLVSQL_WAL_ENABLED=1\` set, and every recovery test in the tree was exercising a path the real engine never hit.

## The fix

Add a \`rustler::init!(load = on_load)\` callback that calls a new \`boot_wal_from_env()\` helper. The helper is extracted so cargo tests can drive the same path as the NIF loader (\`on_load\` itself needs an \`Env\` and can only run inside the BEAM).

On recovery failure the callback logs to stderr and leaves the WAL disabled rather than failing NIF load. A corrupt WAL file must not brick the whole engine: losing durability is acceptable, refusing to start is not.

## Tests

Three regression tests in \`wal::tests::recovery::nif_boot\`:

- \`boot_enables_wal_and_replays_recovery\` — with env vars set and a pre-existing WAL, boot enables the writer AND replays rows so they're immediately visible.
- \`boot_with_env_disabled_stays_in_memory\` — default (no env) stays in-memory, does not touch disk.
- \`boot_with_corrupt_wal_disables_rather_than_panics\` — gibberish WAL file falls back cleanly, engine still serves queries.

All 356 lib tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
