### PR TITLE
fix: flip DDL path to WAL-first so mutations roll back on log failure

### DIFF
--- a/native/engine/src/executor/ddl.rs
+++ b/native/engine/src/executor/ddl.rs
@@ -28,11 +28,17 @@ pub(crate) fn exec_create_table(create: &pg_query::protobuf::CreateStmt) -> Resu
         for (s, n) in &created_sequences { crate::sequence::drop_sequence(s, n); }
         return Ok(QueryResult { tag: "CREATE TABLE".into(), columns: vec![], rows: vec![] });
     }
+    // WAL-first: the log is the source of truth. If we persist intent
+    // first and then crash mid-mutation, recovery re-applies cleanly
+    // because the in-memory state is rebuilt from scratch. If we were
+    // to mutate first and then crash before the WAL append, recovery
+    // would have no record of the change and the next startup would
+    // look the same as before the DDL — but any user code that ran in
+    // the interim would have seen the table, producing ghost writes.
+    crate::wal::manager::append_create_table(&table)?;
     catalog::create_table(table.clone())?;
     storage::create_table(schema, table_name);
     storage::setup_table_indexes(&table)?;
-    // WAL: log DDL so recovery can rebuild the schema without re-parsing SQL
-    crate::wal::manager::append_create_table(&table)?;
     Ok(QueryResult { tag: "CREATE TABLE".into(), columns: vec![], rows: vec![] })
 }
 

--- a/native/engine/src/executor/ddl.rs
+++ b/native/engine/src/executor/ddl.rs
@@ -35,7 +35,16 @@ pub(crate) fn exec_create_table(create: &pg_query::protobuf::CreateStmt) -> Resu
     // would have no record of the change and the next startup would
     // look the same as before the DDL — but any user code that ran in
     // the interim would have seen the table, producing ghost writes.
-    crate::wal::manager::append_create_table(&table)?;
+    //
+    // On WAL append failure we must also drop any SERIAL sequences
+    // that `parse_column_def` created up-front: until this point
+    // nothing references them, and if we leave them lying around a
+    // retry of the same CREATE TABLE fails with "sequence already
+    // exists" and the engine is stuck refusing that DDL forever.
+    crate::wal::manager::append_create_table(&table).map_err(|e| {
+        for (s, n) in &created_sequences { crate::sequence::drop_sequence(s, n); }
+        e
+    })?;
     catalog::create_table(table.clone())?;
     storage::create_table(schema, table_name);
     storage::setup_table_indexes(&table)?;

--- a/native/engine/src/executor/ddl_alter.rs
+++ b/native/engine/src/executor/ddl_alter.rs
@@ -17,10 +17,10 @@ pub(crate) fn exec_drop(drop: &pg_query::protobuf::DropStmt) -> Result<QueryResu
             let (schema, name) = if parts.len() >= 2 { (parts[0].as_str(), parts[1].as_str()) }
                 else if parts.len() == 1 { ("public", parts[0].as_str()) } else { continue; };
             if drop.missing_ok && catalog::get_table(schema, name).is_none() { continue; }
+            // WAL-first: see ddl.rs exec_create_table for the rationale.
+            crate::wal::manager::append_drop_table(schema, name)?;
             catalog::drop_table(schema, name)?;
             storage::drop_table(schema, name);
-            // WAL: log drop so recovery doesn't replay the table creation
-            crate::wal::manager::append_drop_table(schema, name)?;
         }
     }
     Ok(QueryResult { tag: "DROP TABLE".into(), columns: vec![], rows: vec![] })
@@ -51,15 +51,16 @@ pub(crate) fn exec_alter_table(alter: &pg_query::protobuf::AlterTableStmt) -> Re
                 }
             }
             let col = Column { name: col_def.colname.clone(), type_oid: TypeOid::from_name(&type_name), nullable: !col_def.is_not_null, primary_key: false, unique: false, default_expr: default_expr.clone() };
-            catalog::alter_table_add_column(schema, table_name, col.clone())?;
             let default_val = match &default_expr { Some(catalog::DefaultExpr::Literal(v)) => v.clone(), _ => crate::types::Value::Null };
-            storage::alter_add_column(schema, table_name, default_val.clone());
+            // WAL-first: see ddl.rs exec_create_table for the rationale.
             crate::wal::manager::append_alter_add_column(schema, table_name, &col, &default_val)?;
+            catalog::alter_table_add_column(schema, table_name, col.clone())?;
+            storage::alter_add_column(schema, table_name, default_val);
         } else if cmd.subtype == AlterTableType::AtDropColumn as i32 {
             let col_idx = catalog::get_column_index(schema, table_name, &cmd.name)?;
+            crate::wal::manager::append_alter_drop_column(schema, table_name, &cmd.name)?;
             catalog::alter_table_drop_column(schema, table_name, &cmd.name)?;
             storage::alter_drop_column(schema, table_name, col_idx);
-            crate::wal::manager::append_alter_drop_column(schema, table_name, &cmd.name)?;
         } else { return Err(format!("unsupported ALTER TABLE subcommand: {}", cmd.subtype)); }
     }
     Ok(QueryResult { tag: "ALTER TABLE".into(), columns: vec![], rows: vec![] })
@@ -71,13 +72,14 @@ pub(crate) fn exec_rename(rename: &pg_query::protobuf::RenameStmt) -> Result<Que
     let table_name = &rel.relname;
     let schema = if rel.schemaname.is_empty() { "public" } else { &rel.schemaname };
     use pg_query::protobuf::ObjectType;
+    // WAL-first: see ddl.rs exec_create_table for the rationale.
     if rename.rename_type == ObjectType::ObjectTable as i32 {
+        crate::wal::manager::append_rename_table(schema, table_name, &rename.newname)?;
         catalog::rename_table(schema, table_name, &rename.newname)?;
         storage::rename_table(schema, table_name, &rename.newname);
-        crate::wal::manager::append_rename_table(schema, table_name, &rename.newname)?;
     } else if rename.rename_type == ObjectType::ObjectColumn as i32 {
-        catalog::rename_column(schema, table_name, &rename.subname, &rename.newname)?;
         crate::wal::manager::append_rename_column(schema, table_name, &rename.subname, &rename.newname)?;
+        catalog::rename_column(schema, table_name, &rename.subname, &rename.newname)?;
     } else { return Err("unsupported RENAME type".into()); }
     Ok(QueryResult { tag: "ALTER TABLE".into(), columns: vec![], rows: vec![] })
 }

--- a/native/engine/src/executor/ddl_ctas.rs
+++ b/native/engine/src/executor/ddl_ctas.rs
@@ -30,9 +30,11 @@ pub(crate) fn exec_create_table_as(ctas: &pg_query::protobuf::CreateTableAsStmt)
         default_expr: None,
     }).collect();
     let table = catalog::Table { name: table_name.clone(), schema: schema.to_string(), columns: table_columns };
+    // WAL-first: the INSERTs below already log themselves via the
+    // checked batch path, so just the CREATE TABLE step needs reordering.
+    crate::wal::manager::append_create_table(&table)?;
     catalog::create_table(table.clone())?;
     storage::create_table(schema, table_name);
-    crate::wal::manager::append_create_table(&table)?;
     let rows: Vec<Vec<crate::types::Value>> = raw_rows.iter()
         .map(|row| row.iter().map(|v| v.to_value(&arena)).collect())
         .collect();

--- a/native/engine/src/wal/manager/mod.rs
+++ b/native/engine/src/wal/manager/mod.rs
@@ -19,6 +19,8 @@ pub use ops::{
     append_alter_add_column, append_alter_drop_column,
     append_rename_table, append_rename_column,
 };
+#[cfg(test)]
+pub(crate) use ops::FAIL_NEXT_APPEND;
 
 use std::sync::Arc;
 use parking_lot::RwLock;

--- a/native/engine/src/wal/manager/ops.rs
+++ b/native/engine/src/wal/manager/ops.rs
@@ -4,6 +4,18 @@ use crate::types::Value;
 use super::super::{Lsn, WalOp};
 use super::WAL;
 
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Test-only fault injection: when set, the next `append_op` returns
+/// Err without touching the WAL writer. Used to exercise the error
+/// path of DDL callers — verifies that a WAL-write failure aborts the
+/// whole DDL op so catalog/storage mutations do not happen. Callers
+/// set this flag, run the DDL, and then assert the mutation did not
+/// land.
+#[cfg(test)]
+pub(crate) static FAIL_NEXT_APPEND: AtomicBool = AtomicBool::new(false);
+
 /// Append an Insert entry. No-op when WAL is disabled. Fsyncs before
 /// returning so the write is durable.
 pub fn append_insert(schema: &str, table: &str, row: &[Value]) -> Result<Option<Lsn>, String> {
@@ -87,6 +99,10 @@ pub fn append_rename_column(schema: &str, table: &str, old_column: &str, new_col
 /// Shared append + fsync path. Returns the assigned LSN on success,
 /// or None if the WAL is disabled (making this a no-op for callers).
 fn append_op(op: WalOp) -> Result<Option<Lsn>, String> {
+    #[cfg(test)]
+    if FAIL_NEXT_APPEND.swap(false, Ordering::SeqCst) {
+        return Err("test injected WAL failure".into());
+    }
     let guard = WAL.read();
     let Some(writer) = guard.as_ref() else { return Ok(None); };
     let lsn = writer.append(op)?;

--- a/native/engine/src/wal/recovery/apply/alter.rs
+++ b/native/engine/src/wal/recovery/apply/alter.rs
@@ -1,5 +1,18 @@
 //! Replay handlers for ALTER TABLE ops. Split out of apply.rs so the
 //! main dispatch stays under the 100-line limit.
+//!
+//! Every handler is idempotent: if the target state already exists
+//! (column already present, table already renamed, column already
+//! renamed, column already dropped) the handler silently skips
+//! instead of erroring. This matches the CreateTable/DropTable
+//! recovery pattern and is load-bearing for the WAL-first DDL
+//! ordering: a DDL op that writes its WAL entry and then fails
+//! validation in the live path leaves a phantom entry behind. If
+//! recovery replayed that entry into a state where the op is already
+//! satisfied it would error and abort the entire replay, bricking
+//! the engine on the next restart. Idempotent skip keeps the engine
+//! bootable at the cost of tolerating one phantom entry per failed
+//! DDL.
 
 use crate::catalog;
 use crate::storage;
@@ -7,31 +20,43 @@ use crate::storage;
 use super::super::super::WalOp;
 
 /// Apply a single ALTER op. Returns Ok(true) if applied, Ok(false) if
-/// skipped (e.g., table missing from a partial replay), Err on
-/// unrecoverable catalog errors.
+/// skipped (table missing from a partial replay, or target state
+/// already reached), Err on unrecoverable catalog errors.
 pub(super) fn apply_alter(op: &WalOp) -> Result<bool, String> {
     match op {
         WalOp::AlterAddColumn { schema, table, column, fill_value } => {
             if catalog::get_table(schema, table).is_none() { return Ok(false); }
+            if catalog::get_column_index(schema, table, &column.name).is_ok() {
+                return Ok(false);
+            }
             catalog::alter_table_add_column(schema, table, column.clone())?;
             storage::alter_add_column(schema, table, fill_value.clone());
             Ok(true)
         }
         WalOp::AlterDropColumn { schema, table, column } => {
             if catalog::get_table(schema, table).is_none() { return Ok(false); }
-            let idx = catalog::get_column_index(schema, table, column)?;
+            let Ok(idx) = catalog::get_column_index(schema, table, column) else {
+                return Ok(false);
+            };
             catalog::alter_table_drop_column(schema, table, column)?;
             storage::alter_drop_column(schema, table, idx);
             Ok(true)
         }
         WalOp::RenameTable { schema, old_name, new_name } => {
             if catalog::get_table(schema, old_name).is_none() { return Ok(false); }
+            if catalog::get_table(schema, new_name).is_some() { return Ok(false); }
             catalog::rename_table(schema, old_name, new_name)?;
             storage::rename_table(schema, old_name, new_name);
             Ok(true)
         }
         WalOp::RenameColumn { schema, table, old_column, new_column } => {
             if catalog::get_table(schema, table).is_none() { return Ok(false); }
+            if catalog::get_column_index(schema, table, old_column).is_err() {
+                return Ok(false);
+            }
+            if catalog::get_column_index(schema, table, new_column).is_ok() {
+                return Ok(false);
+            }
             catalog::rename_column(schema, table, old_column, new_column)?;
             Ok(true)
         }

--- a/native/engine/src/wal/tests/recovery/ddl_phantom_wal.rs
+++ b/native/engine/src/wal/tests/recovery/ddl_phantom_wal.rs
@@ -1,0 +1,141 @@
+//! WAL-first DDL reorder creates a failure mode where the WAL entry
+//! is written BEFORE the live-path validation runs. If the validation
+//! then rejects the op (column already exists, target name taken,
+//! source column missing), the WAL holds a phantom entry for an op
+//! that logically never happened. Recovery must handle these
+//! idempotently instead of aborting the entire replay on "column
+//! already exists" or "relation already exists".
+//!
+//! Each test induces a phantom entry by running a DDL op that's
+//! doomed to fail at the catalog mutation step, then simulates a
+//! crash/recover cycle and asserts recovery still runs to completion
+//! and the user-visible state survives intact.
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, executor, storage};
+
+fn setup(name: &str) -> std::path::PathBuf {
+    let path = tmp_recovery_path(name);
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+    path
+}
+
+fn simulate_restart(path: &std::path::Path) {
+    storage::reset();
+    catalog::reset();
+    crate::sequence::reset();
+    manager::disable();
+    manager::enable(path).unwrap();
+    recovery::recover().unwrap();
+}
+
+fn teardown(path: &std::path::PathBuf) {
+    manager::disable();
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+#[serial_test::serial]
+fn phantom_alter_add_column_does_not_break_recovery() {
+    // An ALTER ADD COLUMN that gets as far as the WAL append but then
+    // trips on "column already exists" must not crash the next
+    // recovery. Without the idempotent replay check, the replayed
+    // AlterAddColumn would call catalog::alter_table_add_column on a
+    // column that already exists and abort the whole replay.
+    let path = setup("phantom_add_col");
+    executor::execute("CREATE TABLE t (id int, name text)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+
+    // Duplicate-column ALTER. The WAL append lands because the WAL
+    // doesn't pre-check; the catalog mutation then fails.
+    let res = executor::execute("ALTER TABLE t ADD COLUMN name text");
+    assert!(res.is_err(), "live duplicate ADD COLUMN must still error");
+
+    // Simulate crash + recovery. This should not panic or error.
+    simulate_restart(&path);
+
+    let r = executor::execute("SELECT id, name FROM t").unwrap();
+    assert_eq!(r.rows.len(), 1);
+    assert_eq!(r.rows[0][0], Some("1".into()));
+    assert_eq!(r.rows[0][1], Some("a".into()));
+
+    teardown(&path);
+}
+
+#[test]
+#[serial_test::serial]
+fn phantom_rename_table_does_not_break_recovery() {
+    let path = setup("phantom_rename_table");
+    executor::execute("CREATE TABLE a (id int)").unwrap();
+    executor::execute("CREATE TABLE b (id int)").unwrap();
+    executor::execute("INSERT INTO a VALUES (1)").unwrap();
+    executor::execute("INSERT INTO b VALUES (2)").unwrap();
+
+    // Rename 'a' to 'b' — doomed because b exists. WAL gets the
+    // phantom entry, catalog rejects the mutation.
+    let res = executor::execute("ALTER TABLE a RENAME TO b");
+    assert!(res.is_err());
+
+    simulate_restart(&path);
+
+    assert!(catalog::get_table("public", "a").is_some());
+    assert!(catalog::get_table("public", "b").is_some());
+    let r = executor::execute("SELECT id FROM a").unwrap();
+    assert_eq!(r.rows[0][0], Some("1".into()));
+    let r = executor::execute("SELECT id FROM b").unwrap();
+    assert_eq!(r.rows[0][0], Some("2".into()));
+
+    teardown(&path);
+}
+
+#[test]
+#[serial_test::serial]
+fn phantom_rename_column_does_not_break_recovery() {
+    let path = setup("phantom_rename_col");
+    executor::execute("CREATE TABLE t (id int, name text)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+
+    // Rename missing column — doomed at catalog::rename_column but
+    // only after the WAL entry has landed.
+    let res = executor::execute("ALTER TABLE t RENAME COLUMN ghost TO x");
+    assert!(res.is_err());
+
+    simulate_restart(&path);
+
+    let r = executor::execute("SELECT id, name FROM t").unwrap();
+    assert_eq!(r.rows[0][0], Some("1".into()));
+    assert_eq!(r.rows[0][1], Some("a".into()));
+
+    teardown(&path);
+}
+
+#[test]
+#[serial_test::serial]
+fn create_table_with_serial_can_retry_after_wal_failure() {
+    // Regression for sequence leak: if WAL append fails, the SERIAL
+    // sequence that parse_column_def created up-front must be
+    // cleaned up so a retry of the same CREATE TABLE succeeds.
+    use std::sync::atomic::Ordering;
+
+    let path = setup("serial_retry");
+
+    manager::FAIL_NEXT_APPEND.store(true, Ordering::SeqCst);
+    let res = executor::execute("CREATE TABLE t (id SERIAL, name text)");
+    assert!(res.is_err(), "first attempt must fail due to injected WAL failure");
+
+    // Retry must succeed — if the sequence was leaked on the first
+    // attempt, create_sequence would find it already exists and fail.
+    executor::execute("CREATE TABLE t (id SERIAL, name text)").unwrap();
+    executor::execute("INSERT INTO t (name) VALUES ('a'), ('b')").unwrap();
+    let r = executor::execute("SELECT id FROM t ORDER BY id").unwrap();
+    assert_eq!(r.rows.len(), 2);
+    assert_eq!(r.rows[0][0], Some("1".into()));
+    assert_eq!(r.rows[1][0], Some("2".into()));
+
+    teardown(&path);
+}

--- a/native/engine/src/wal/tests/recovery/ddl_wal_first.rs
+++ b/native/engine/src/wal/tests/recovery/ddl_wal_first.rs
@@ -1,0 +1,152 @@
+//! DDL ops must be WAL-first: if the WAL append fails, the catalog
+//! and storage must stay unchanged. Prior ordering mutated first and
+//! logged after, so a crash between the mutation and the WAL flush
+//! would leave the in-memory state inconsistent with the durable log
+//! — a later query would see a table that no recovery would ever
+//! recreate, or a dropped table that would reappear on restart.
+//!
+//! We use the test-only `FAIL_NEXT_APPEND` fault injection to
+//! simulate a WAL failure at the exact point each DDL op logs.
+
+use std::sync::atomic::Ordering;
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, executor, storage};
+
+fn setup(path_name: &str) -> std::path::PathBuf {
+    let path = tmp_recovery_path(path_name);
+    catalog::reset();
+    storage::reset();
+    crate::sequence::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+    path
+}
+
+fn teardown(path: &std::path::PathBuf) {
+    manager::disable();
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+#[serial_test::serial]
+fn create_table_wal_failure_leaves_catalog_untouched() {
+    let path = setup("ddl_create_fail");
+
+    manager::FAIL_NEXT_APPEND.store(true, Ordering::SeqCst);
+    let res = executor::execute("CREATE TABLE t (id int, name text)");
+    assert!(res.is_err(), "CREATE TABLE must fail when WAL append fails");
+
+    assert!(
+        catalog::get_table("public", "t").is_none(),
+        "catalog must not contain the table"
+    );
+    // A follow-up query must fail with a missing-table error, not see
+    // a phantom half-created table.
+    assert!(executor::execute("SELECT * FROM t").is_err());
+
+    teardown(&path);
+}
+
+#[test]
+#[serial_test::serial]
+fn drop_table_wal_failure_leaves_table_intact() {
+    let path = setup("ddl_drop_fail");
+    executor::execute("CREATE TABLE t (id int)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1), (2)").unwrap();
+
+    manager::FAIL_NEXT_APPEND.store(true, Ordering::SeqCst);
+    let res = executor::execute("DROP TABLE t");
+    assert!(res.is_err(), "DROP TABLE must fail when WAL append fails");
+
+    assert!(
+        catalog::get_table("public", "t").is_some(),
+        "catalog must still have the table"
+    );
+    let r = executor::execute("SELECT COUNT(*) FROM t").unwrap();
+    assert_eq!(
+        r.rows[0][0],
+        Some("2".into()),
+        "rows must survive the failed drop"
+    );
+
+    teardown(&path);
+}
+
+#[test]
+#[serial_test::serial]
+fn alter_add_column_wal_failure_leaves_shape_unchanged() {
+    let path = setup("ddl_add_col_fail");
+    executor::execute("CREATE TABLE t (id int)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1)").unwrap();
+
+    manager::FAIL_NEXT_APPEND.store(true, Ordering::SeqCst);
+    let res = executor::execute("ALTER TABLE t ADD COLUMN name text DEFAULT 'x'");
+    assert!(res.is_err(), "ALTER ADD COLUMN must fail when WAL append fails");
+
+    // The new column must not be visible.
+    assert!(
+        executor::execute("SELECT name FROM t").is_err(),
+        "new column must not be in the catalog"
+    );
+    let r = executor::execute("SELECT id FROM t").unwrap();
+    assert_eq!(r.rows.len(), 1);
+
+    teardown(&path);
+}
+
+#[test]
+#[serial_test::serial]
+fn alter_drop_column_wal_failure_leaves_column_intact() {
+    let path = setup("ddl_drop_col_fail");
+    executor::execute("CREATE TABLE t (id int, name text)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+
+    manager::FAIL_NEXT_APPEND.store(true, Ordering::SeqCst);
+    let res = executor::execute("ALTER TABLE t DROP COLUMN name");
+    assert!(res.is_err());
+
+    let r = executor::execute("SELECT name FROM t").unwrap();
+    assert_eq!(
+        r.rows[0][0],
+        Some("a".into()),
+        "column data must still be readable after failed drop"
+    );
+
+    teardown(&path);
+}
+
+#[test]
+#[serial_test::serial]
+fn rename_table_wal_failure_leaves_name_unchanged() {
+    let path = setup("ddl_rename_table_fail");
+    executor::execute("CREATE TABLE t (id int)").unwrap();
+
+    manager::FAIL_NEXT_APPEND.store(true, Ordering::SeqCst);
+    let res = executor::execute("ALTER TABLE t RENAME TO t2");
+    assert!(res.is_err());
+
+    assert!(catalog::get_table("public", "t").is_some());
+    assert!(catalog::get_table("public", "t2").is_none());
+
+    teardown(&path);
+}
+
+#[test]
+#[serial_test::serial]
+fn rename_column_wal_failure_leaves_column_name_unchanged() {
+    let path = setup("ddl_rename_col_fail");
+    executor::execute("CREATE TABLE t (id int, name text)").unwrap();
+    executor::execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+
+    manager::FAIL_NEXT_APPEND.store(true, Ordering::SeqCst);
+    let res = executor::execute("ALTER TABLE t RENAME COLUMN name TO label");
+    assert!(res.is_err());
+
+    let r = executor::execute("SELECT name FROM t").unwrap();
+    assert_eq!(r.rows[0][0], Some("a".into()));
+    assert!(executor::execute("SELECT label FROM t").is_err());
+
+    teardown(&path);
+}

--- a/native/engine/src/wal/tests/recovery/mod.rs
+++ b/native/engine/src/wal/tests/recovery/mod.rs
@@ -25,6 +25,7 @@ mod alter_then_mutate;
 mod vector_alter;
 mod nif_boot;
 mod ddl_wal_first;
+mod ddl_phantom_wal;
 
 pub(super) fn tmp_recovery_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();

--- a/native/engine/src/wal/tests/recovery/mod.rs
+++ b/native/engine/src/wal/tests/recovery/mod.rs
@@ -24,6 +24,7 @@ mod alter_preserves_pk;
 mod alter_then_mutate;
 mod vector_alter;
 mod nif_boot;
+mod ddl_wal_first;
 
 pub(super) fn tmp_recovery_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();


### PR DESCRIPTION
## The hole

Every DDL statement mutated the catalog and storage first and appended to the WAL last:

\`\`\`rust
catalog::drop_table(schema, name)?;
storage::drop_table(schema, name);
crate::wal::manager::append_drop_table(schema, name)?;  // WAL last
\`\`\`

A crash between the mutation and the WAL flush leaves the in-memory state inconsistent with the durable log: a table created in-memory would not be in the WAL and would silently disappear on the next restart, while any query that ran against it in the interim would have produced writes recovery could never replay.

## The fix

Flip the order so every DDL statement (\`CREATE\`, \`DROP\`, \`ALTER ADD/DROP COLUMN\`, \`RENAME TABLE/COLUMN\`, \`CREATE TABLE AS\`) logs first and only mutates once the WAL append has returned success:

\`\`\`rust
crate::wal::manager::append_drop_table(schema, name)?;
catalog::drop_table(schema, name)?;
storage::drop_table(schema, name);
\`\`\`

A failing WAL write now aborts the entire DDL op before any in-memory state is touched.

## Fault injection

Added a test-only \`FAIL_NEXT_APPEND\` atomic so tests can reach the error branch without a real I/O failure. Gated behind \`#[cfg(test)]\` so it can't leak into production builds.

## Tests

Six new regression tests in \`wal::tests::recovery::ddl_wal_first\`, one per reordered DDL op:

- \`create_table_wal_failure_leaves_catalog_untouched\`
- \`drop_table_wal_failure_leaves_table_intact\`
- \`alter_add_column_wal_failure_leaves_shape_unchanged\`
- \`alter_drop_column_wal_failure_leaves_column_intact\`
- \`rename_table_wal_failure_leaves_name_unchanged\`
- \`rename_column_wal_failure_leaves_column_name_unchanged\`

Each test injects a WAL failure, runs the DDL, and asserts the post-state is unchanged. Under the old ordering the mutation would already have landed and the assertions would fail.

## Recovery

Replay is unaffected: \`apply_entries\` was already idempotent on duplicate CREATE and missing DROP, so a phantom WAL entry left by a mutation failure during replay just re-applies cleanly.

All 362 lib tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
