### PR TITLE
fix: WAL writer rolls back on flush_sync failure instead of leaking frames

### DIFF
--- a/native/engine/src/wal/manager/ops.rs
+++ b/native/engine/src/wal/manager/ops.rs
@@ -98,6 +98,14 @@ pub fn append_rename_column(schema: &str, table: &str, old_column: &str, new_col
 
 /// Shared append + fsync path. Returns the assigned LSN on success,
 /// or None if the WAL is disabled (making this a no-op for callers).
+///
+/// Goes through `append_sync` rather than the separated `append` +
+/// `flush_sync` pair so the two steps happen under a single
+/// acquisition of the writer's inner mutex. Without that, a
+/// concurrent caller's failing flush could roll back to `durable_len`
+/// and silently truncate this caller's already-appended frame,
+/// violating the durability contract even though this caller saw
+/// `Ok(...)`.
 fn append_op(op: WalOp) -> Result<Option<Lsn>, String> {
     #[cfg(test)]
     if FAIL_NEXT_APPEND.swap(false, Ordering::SeqCst) {
@@ -105,7 +113,6 @@ fn append_op(op: WalOp) -> Result<Option<Lsn>, String> {
     }
     let guard = WAL.read();
     let Some(writer) = guard.as_ref() else { return Ok(None); };
-    let lsn = writer.append(op)?;
-    writer.flush_sync()?;
-    Ok(Some(lsn))
+    let entry = writer.append_sync(op)?;
+    Ok(Some(entry.lsn))
 }

--- a/native/engine/src/wal/tests/mod.rs
+++ b/native/engine/src/wal/tests/mod.rs
@@ -10,6 +10,7 @@ mod manager_tests;
 mod storage_integration;
 mod recovery;
 mod writer_concurrent;
+mod writer_rollback;
 mod concurrent_writes;
 
 pub(super) fn tmp_wal_path(name: &str) -> std::path::PathBuf {

--- a/native/engine/src/wal/tests/writer_rollback.rs
+++ b/native/engine/src/wal/tests/writer_rollback.rs
@@ -1,0 +1,127 @@
+//! Regression tests for the durable_len / rollback behavior of the
+//! WAL writer. The pre-fix writer wrapped its File in a BufWriter:
+//! a failed `flush_sync` left the encoded frame in the buffer, and
+//! the next successful `flush_sync` (for a completely unrelated
+//! operation) would quietly commit the failed frame to disk. At the
+//! caller level that first op had returned Err and been rolled back
+//! at the SQL layer; recovery would then replay the resurrected
+//! frame and produce a phantom row / ghost write.
+
+use std::sync::atomic::Ordering;
+
+use super::super::*;
+use super::insert_op;
+
+fn tmp(name: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "evolvsql_rollback_{}_{}.log",
+        name,
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&p);
+    p
+}
+
+#[test]
+fn flush_sync_failure_drops_buffered_frame() {
+    let path = tmp("flush_fail_drops");
+    let writer = WalWriter::open(&path, 1).unwrap();
+
+    // Frame 1 — this will be lost.
+    writer.append(insert_op(1, "frame-one")).unwrap();
+    writer.fail_next_sync.store(true, Ordering::SeqCst);
+    let res = writer.flush_sync();
+    assert!(res.is_err(), "injected fsync must surface as Err");
+
+    // Frame 2 — this is what really commits. If the rollback didn't
+    // truncate frame 1, this flush_sync would make BOTH frames durable
+    // and recovery would see the lost frame come back from the dead.
+    writer.append(insert_op(2, "frame-two")).unwrap();
+    writer.flush_sync().unwrap();
+
+    drop(writer);
+    let entries = WalReader::open(&path).unwrap().read_all().unwrap();
+    assert_eq!(
+        entries.len(),
+        1,
+        "only the successfully flushed frame should be on disk"
+    );
+    // The surviving frame is the second append — the one the caller
+    // was told landed.
+    match &entries[0].op {
+        WalOp::Insert { row, .. } => {
+            assert!(
+                format!("{:?}", row).contains("frame-two"),
+                "surviving frame must be frame-two, got {:?}",
+                row
+            );
+        }
+        other => panic!("expected Insert, got {:?}", other),
+    }
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn flush_sync_failure_rewinds_next_lsn() {
+    // If the LSN counter were to keep advancing across a failed
+    // flush, the next successful append would leave a gap in the
+    // on-disk LSN sequence. Recovery's contiguity checks assume
+    // successive frames are contiguous in LSN, so a gap would look
+    // identical to a torn-write tail and recovery would stop at the
+    // gap, losing every subsequent durable frame.
+    let path = tmp("flush_fail_rewinds_lsn");
+    let writer = WalWriter::open(&path, 1).unwrap();
+
+    let first_lsn = writer.append(insert_op(1, "a")).unwrap();
+    assert_eq!(first_lsn, 1);
+    writer.fail_next_sync.store(true, Ordering::SeqCst);
+    assert!(writer.flush_sync().is_err());
+
+    // After rollback, next_lsn must be back at the start of the lost
+    // batch, not advanced past it.
+    assert_eq!(
+        writer.peek_next_lsn(),
+        1,
+        "next_lsn must rewind so retries re-use the reclaimed LSN"
+    );
+
+    let retry_lsn = writer.append(insert_op(2, "b")).unwrap();
+    assert_eq!(retry_lsn, 1, "retry after rollback must re-use LSN 1");
+    writer.flush_sync().unwrap();
+
+    drop(writer);
+    let entries = WalReader::open(&path).unwrap().read_all().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].lsn, 1);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn flush_sync_failure_keeps_prior_durable_entries() {
+    // A failed flush must NOT discard anything that had been made
+    // durable by an earlier successful flush. The truncate-back
+    // target is the last durable_len, not zero.
+    let path = tmp("flush_fail_keeps_prior");
+    let writer = WalWriter::open(&path, 1).unwrap();
+
+    writer.append_sync(insert_op(1, "keep-me")).unwrap();
+
+    writer.append(insert_op(2, "lose-me")).unwrap();
+    writer.fail_next_sync.store(true, Ordering::SeqCst);
+    assert!(writer.flush_sync().is_err());
+
+    // Counter is back at LSN 2 (the last durable was LSN 1).
+    assert_eq!(writer.peek_next_lsn(), 2);
+    writer.append_sync(insert_op(3, "and-me")).unwrap();
+
+    drop(writer);
+    let entries = WalReader::open(&path).unwrap().read_all().unwrap();
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].lsn, 1);
+    assert_eq!(entries[1].lsn, 2, "LSN slot 2 is reused by the retry");
+
+    std::fs::remove_file(&path).ok();
+}

--- a/native/engine/src/wal/tests/writer_rollback.rs
+++ b/native/engine/src/wal/tests/writer_rollback.rs
@@ -100,6 +100,65 @@ fn flush_sync_failure_rewinds_next_lsn() {
 }
 
 #[test]
+fn concurrent_append_sync_with_failing_peer_preserves_other_thread_durability() {
+    // Devin-found concurrency hole: `append` and `flush_sync` are not
+    // atomic. Without the combined `append_sync` path holding the
+    // mutex across both, the following interleaving silently loses
+    // data:
+    //
+    //   T1: append(A)        // frame A on disk, mutex released
+    //   T2: append(B)        // frame B on disk, mutex released
+    //   T1: flush_sync fails // rollback truncates BOTH frames
+    //   T2: flush_sync       // sync on empty tail, returns Ok(())
+    //
+    // T2's caller believes B is durable but it was truncated.
+    // The production path now uses `append_sync`, which holds the
+    // inner mutex across both steps. T2 cannot acquire the lock
+    // until T1's rollback has finished and returned an error, so on
+    // its own entry T2 starts from the durable tail.
+    use std::sync::Arc;
+    use std::thread;
+
+    let path = tmp("concurrent_failing_peer");
+    let writer = Arc::new(WalWriter::open(&path, 1).unwrap());
+
+    // Pre-arm one failed sync. The thread that grabs the lock first
+    // will fail; the thread that comes second must still land
+    // durably.
+    writer.fail_next_sync.store(true, Ordering::SeqCst);
+
+    let w1 = Arc::clone(&writer);
+    let w2 = Arc::clone(&writer);
+    let h1 = thread::spawn(move || w1.append_sync(insert_op(1, "first")));
+    let h2 = thread::spawn(move || w2.append_sync(insert_op(2, "second")));
+    let r1 = h1.join().unwrap();
+    let r2 = h2.join().unwrap();
+
+    assert_eq!(
+        r1.is_err() as u8 + r2.is_err() as u8,
+        1,
+        "exactly one append_sync should fail: {:?} {:?}",
+        r1,
+        r2
+    );
+    let ok_entry = match (r1, r2) {
+        (Ok(e), Err(_)) | (Err(_), Ok(e)) => e,
+        other => panic!("unexpected outcome: {:?}", other),
+    };
+
+    drop(writer);
+    let entries = WalReader::open(&path).unwrap().read_all().unwrap();
+    assert_eq!(
+        entries.len(),
+        1,
+        "the successful append_sync must land durably"
+    );
+    assert_eq!(entries[0].lsn, ok_entry.lsn);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
 fn flush_sync_failure_keeps_prior_durable_entries() {
     // A failed flush must NOT discard anything that had been made
     // durable by an earlier successful flush. The truncate-back

--- a/native/engine/src/wal/tests/writer_rollback.rs
+++ b/native/engine/src/wal/tests/writer_rollback.rs
@@ -159,6 +159,51 @@ fn concurrent_append_sync_with_failing_peer_preserves_other_thread_durability() 
 }
 
 #[test]
+fn failing_append_sync_with_prior_batched_frame_does_not_leave_lsn_gap() {
+    // Devin-found follow-up: when `append_sync` fails with prior
+    // `append` calls still un-flushed, its old rollback truncated
+    // the file but did not rewind `next_lsn`. The buffered frames
+    // were destroyed from the file but their LSNs stayed consumed,
+    // so the next write skipped past the destroyed range and
+    // produced a permanent gap that recovery mistakes for a torn
+    // tail, halting replay at the gap and losing every later frame.
+    //
+    //   1. append(A)       → lsn=1, undurable_start_lsn=Some(1)
+    //   2. append_sync(B)  → fails during sync. Old rollback
+    //                        truncated file but left next_lsn=2.
+    //   3. append_sync(C)  → would get lsn=2 under old behavior,
+    //                        leaving lsn=1 as a permanent gap.
+    //
+    // The fix routes append_sync's error paths through the full
+    // `rollback` helper, which rewinds next_lsn to the start of the
+    // destroyed batch.
+    let path = tmp("append_sync_gap");
+    let writer = WalWriter::open(&path, 1).unwrap();
+
+    let lsn_a = writer.append(insert_op(1, "a")).unwrap();
+    assert_eq!(lsn_a, 1);
+
+    writer.fail_next_sync.store(true, Ordering::SeqCst);
+    assert!(writer.append_sync(insert_op(2, "b")).is_err());
+
+    assert_eq!(
+        writer.peek_next_lsn(),
+        1,
+        "append_sync rollback must rewind past destroyed batched frames"
+    );
+
+    let entry_c = writer.append_sync(insert_op(3, "c")).unwrap();
+    assert_eq!(entry_c.lsn, 1, "retry must reclaim the reclaimed LSN");
+
+    drop(writer);
+    let entries = WalReader::open(&path).unwrap().read_all().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].lsn, 1);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
 fn append_sync_clears_undurable_marker_so_later_rollback_does_not_rewind_too_far() {
     // Devin-found: append_sync's success path used to leave
     // `undurable_start_lsn` stale. A subsequent batched append +

--- a/native/engine/src/wal/tests/writer_rollback.rs
+++ b/native/engine/src/wal/tests/writer_rollback.rs
@@ -159,6 +159,56 @@ fn concurrent_append_sync_with_failing_peer_preserves_other_thread_durability() 
 }
 
 #[test]
+fn append_sync_clears_undurable_marker_so_later_rollback_does_not_rewind_too_far() {
+    // Devin-found: append_sync's success path used to leave
+    // `undurable_start_lsn` stale. A subsequent batched append +
+    // failing flush_sync would then see the stale marker and rewind
+    // `next_lsn` past frames that were already durable, causing
+    // duplicate LSNs on the next write. Sequence:
+    //
+    //   1. append(A)          → undurable_start_lsn = Some(LSN_A)
+    //   2. append_sync(B)     → fsyncs A+B, but forgets to clear
+    //                           undurable_start_lsn
+    //   3. append(C)          → no-op on the marker (already set)
+    //   4. flush_sync fails   → rollback reads stale Some(LSN_A) and
+    //                           stores next_lsn = LSN_A, past already
+    //                           durable frames
+    //   5. append(D)          → reuses LSN_A, duplicate on disk
+    let path = tmp("append_sync_clears_marker");
+    let writer = WalWriter::open(&path, 1).unwrap();
+
+    let lsn_a = writer.append(insert_op(1, "a")).unwrap();
+    assert_eq!(lsn_a, 1);
+    let entry_b = writer.append_sync(insert_op(2, "b")).unwrap();
+    assert_eq!(entry_b.lsn, 2);
+    let lsn_c = writer.append(insert_op(3, "c")).unwrap();
+    assert_eq!(lsn_c, 3);
+    writer.fail_next_sync.store(true, Ordering::SeqCst);
+    assert!(writer.flush_sync().is_err());
+
+    // The rollback must only unwind frame C, NOT frames A and B.
+    // Without the fix, next_lsn would rewind to 1 and the retry
+    // below would reuse LSN 1, leaving two frames with LSN 1 on disk.
+    assert_eq!(
+        writer.peek_next_lsn(),
+        3,
+        "rollback must not rewind past the durable tail"
+    );
+
+    let entry_d = writer.append_sync(insert_op(4, "d")).unwrap();
+    assert_eq!(entry_d.lsn, 3);
+
+    drop(writer);
+    let entries = WalReader::open(&path).unwrap().read_all().unwrap();
+    assert_eq!(entries.len(), 3);
+    assert_eq!(entries[0].lsn, 1);
+    assert_eq!(entries[1].lsn, 2);
+    assert_eq!(entries[2].lsn, 3);
+
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
 fn flush_sync_failure_keeps_prior_durable_entries() {
     // A failed flush must NOT discard anything that had been made
     // durable by an earlier successful flush. The truncate-back

--- a/native/engine/src/wal/writer.rs
+++ b/native/engine/src/wal/writer.rs
@@ -184,6 +184,11 @@ impl WalWriter {
             .stream_position()
             .map_err(|e| format!("WAL stream_position: {}", e))?;
         state.durable_len = new_len;
+        // `sync_data` fsyncs the whole file, so any frames left over
+        // from prior `append` calls are now durable too. Clear the
+        // batch marker so a later failing `flush_sync` doesn't rewind
+        // `next_lsn` past frames that are already on disk.
+        state.undurable_start_lsn = None;
         self.next_lsn.store(lsn + 1, Ordering::SeqCst);
         Ok(WalEntry { lsn, op })
     }

--- a/native/engine/src/wal/writer.rs
+++ b/native/engine/src/wal/writer.rs
@@ -148,12 +148,56 @@ impl WalWriter {
         self.next_lsn.load(Ordering::SeqCst)
     }
 
-    /// Convenience: append + flush in one call.
+    /// Append a frame AND fsync it in a single locked section. This is
+    /// the concurrency-safe path and the one production callers must
+    /// use. The naive composition of `append` + `flush_sync` releases
+    /// the inner mutex between the two and is unsafe: thread A's
+    /// failing `flush_sync` can roll back to `durable_len`, truncating
+    /// thread B's successfully-appended-but-not-yet-flushed frame. B's
+    /// subsequent `flush_sync` would then trivially succeed (nothing
+    /// left to sync) and return Ok, silently violating its durability
+    /// contract. Holding the mutex across both steps eliminates the
+    /// interleaving entirely — no other thread can observe or be
+    /// affected by a partial state, and the rollback path only ever
+    /// sees the one frame this call wrote.
     pub fn append_sync(&self, op: WalOp) -> Result<WalEntry, String> {
-        let lsn = self.append(op.clone())?;
-        self.flush_sync()?;
+        let payload = op.encode_payload()?;
+        let tag = op.tag();
+        let mut state = self.inner.lock();
+        let lsn = self.next_lsn.load(Ordering::SeqCst);
+        let frame = encode_frame(lsn, tag, &payload);
+        if let Err(e) = state.file.write_all(&frame) {
+            single_frame_rollback(&mut state);
+            return Err(format!("WAL write: {}", e));
+        }
+        #[cfg(test)]
+        if self.fail_next_sync.swap(false, Ordering::SeqCst) {
+            single_frame_rollback(&mut state);
+            return Err("WAL fsync: test injected failure".into());
+        }
+        if let Err(e) = state.file.sync_data() {
+            single_frame_rollback(&mut state);
+            return Err(format!("WAL fsync: {}", e));
+        }
+        let new_len = state
+            .file
+            .stream_position()
+            .map_err(|e| format!("WAL stream_position: {}", e))?;
+        state.durable_len = new_len;
+        self.next_lsn.store(lsn + 1, Ordering::SeqCst);
         Ok(WalEntry { lsn, op })
     }
+}
+
+/// Rollback helper for `append_sync`'s single-frame scope. Unlike the
+/// batched `rollback`, this never touches `undurable_start_lsn` or
+/// `next_lsn`: because `append_sync` holds the mutex across the entire
+/// write+sync and advances `next_lsn` only on success, there is no
+/// cross-call LSN state to unwind. Truncating the file and resetting
+/// the cursor is enough.
+fn single_frame_rollback(state: &mut WriterState) {
+    let _ = state.file.set_len(state.durable_len);
+    let _ = state.file.seek(SeekFrom::Start(state.durable_len));
 }
 
 /// Roll the writer's state back to the last durable boundary. Called

--- a/native/engine/src/wal/writer.rs
+++ b/native/engine/src/wal/writer.rs
@@ -1,7 +1,10 @@
 use std::fs::{File, OpenOptions};
-use std::io::{BufWriter, Write};
+use std::io::{Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+
+#[cfg(test)]
+use std::sync::atomic::AtomicBool;
 
 use parking_lot::Mutex;
 
@@ -10,10 +13,36 @@ use super::{Lsn, WalEntry};
 
 /// Append-only WAL writer. Single mutex serializes writes; group commit
 /// refinement lives in PR 8.
+///
+/// Durability invariant: bytes [0, durable_len) on the underlying file
+/// are known to be fsynced to disk. On any I/O failure we truncate the
+/// file back to durable_len so a failed append or flush never becomes
+/// visible via a later successful sync. The BufWriter was removed for
+/// this reason: it silently retained buffered bytes across a failed
+/// flush_sync, which then became durable on the next successful one
+/// even though the caller had already returned the earlier frame's
+/// error to its own caller and aborted the logical operation. Recovery
+/// would then replay a frame whose user-visible work had been rolled
+/// back at the SQL layer — classic lost-update / phantom-write territory.
 pub struct WalWriter {
     path: PathBuf,
-    inner: Mutex<BufWriter<File>>,
+    inner: Mutex<WriterState>,
     next_lsn: AtomicU64,
+    #[cfg(test)]
+    pub(crate) fail_next_sync: AtomicBool,
+}
+
+struct WriterState {
+    file: File,
+    /// File length that is known to be on disk. Bytes after this are
+    /// either mid-write or waiting in the OS page cache and may be
+    /// discarded via `set_len` on failure.
+    durable_len: u64,
+    /// First LSN in the current un-flushed batch. Set on the first
+    /// successful append since the last durable boundary; cleared on
+    /// a successful flush_sync. On failure we use this to rewind
+    /// `next_lsn` so a retry starts from the durable frontier again.
+    undurable_start_lsn: Option<Lsn>,
 }
 
 impl WalWriter {
@@ -22,15 +51,33 @@ impl WalWriter {
     /// by the caller after reading the existing WAL.
     pub fn open<P: AsRef<Path>>(path: P, starting_lsn: Lsn) -> Result<Self, String> {
         let path = path.as_ref().to_path_buf();
-        let file = OpenOptions::new()
+        // Open with write (not append) so `set_len` has the access
+        // rights to truncate on rollback. On Windows, append-mode
+        // opens use FILE_APPEND_DATA which does NOT grant
+        // FILE_WRITE_DATA, so SetEndOfFile (the Rust `set_len` backend)
+        // silently fails and the rollback leaves buffered bytes in
+        // the file. With plain write we manage the write position
+        // ourselves — simple since we're the only writer and only
+        // ever append to end.
+        let mut file = OpenOptions::new()
             .create(true)
-            .append(true)
+            .write(true)
+            .read(true)
             .open(&path)
             .map_err(|e| format!("WAL open {:?}: {}", path, e))?;
+        let durable_len = file
+            .seek(SeekFrom::End(0))
+            .map_err(|e| format!("WAL seek end: {}", e))?;
         Ok(Self {
             path,
-            inner: Mutex::new(BufWriter::with_capacity(64 * 1024, file)),
+            inner: Mutex::new(WriterState {
+                file,
+                durable_len,
+                undurable_start_lsn: None,
+            }),
             next_lsn: AtomicU64::new(starting_lsn.max(1)),
+            #[cfg(test)]
+            fail_next_sync: AtomicBool::new(false),
         })
     }
 
@@ -45,22 +92,49 @@ impl WalWriter {
     /// which would leave recovery replaying entries out of logical
     /// order — and, worse, a torn-write tail could drop the
     /// lower-LSN entry while keeping the higher-LSN one durable.
+    ///
+    /// On write failure the file is truncated back to `durable_len`
+    /// and `next_lsn` rewound to the start of the current un-flushed
+    /// batch, so the caller can retry without leaving a phantom frame.
     pub fn append(&self, op: WalOp) -> Result<Lsn, String> {
         let payload = op.encode_payload()?;
         let tag = op.tag();
-        let mut w = self.inner.lock();
-        let lsn = self.next_lsn.fetch_add(1, Ordering::SeqCst);
+        let mut state = self.inner.lock();
+        let lsn = self.next_lsn.load(Ordering::SeqCst);
         let frame = encode_frame(lsn, tag, &payload);
-        w.write_all(&frame).map_err(|e| format!("WAL write: {}", e))?;
+        if let Err(e) = state.file.write_all(&frame) {
+            rollback(&mut state, &self.next_lsn);
+            return Err(format!("WAL write: {}", e));
+        }
+        if state.undurable_start_lsn.is_none() {
+            state.undurable_start_lsn = Some(lsn);
+        }
+        self.next_lsn.store(lsn + 1, Ordering::SeqCst);
         Ok(lsn)
     }
 
-    /// Flush buffered writes and fsync to disk. This is the durability
-    /// boundary: after this returns, appended entries survive a crash.
+    /// Flush any pending writes and fsync to disk. This is the
+    /// durability boundary: on success, every frame appended since the
+    /// last successful flush_sync is guaranteed on disk. On failure
+    /// those frames are discarded via a truncate-back so a later
+    /// successful flush cannot resurrect them.
     pub fn flush_sync(&self) -> Result<(), String> {
-        let mut w = self.inner.lock();
-        w.flush().map_err(|e| format!("WAL flush: {}", e))?;
-        w.get_ref().sync_data().map_err(|e| format!("WAL fsync: {}", e))?;
+        let mut state = self.inner.lock();
+        #[cfg(test)]
+        if self.fail_next_sync.swap(false, Ordering::SeqCst) {
+            rollback(&mut state, &self.next_lsn);
+            return Err("WAL fsync: test injected failure".into());
+        }
+        if let Err(e) = state.file.sync_data() {
+            rollback(&mut state, &self.next_lsn);
+            return Err(format!("WAL fsync: {}", e));
+        }
+        let len = state
+            .file
+            .stream_position()
+            .map_err(|e| format!("WAL stream_position: {}", e))?;
+        state.durable_len = len;
+        state.undurable_start_lsn = None;
         Ok(())
     }
 
@@ -79,6 +153,20 @@ impl WalWriter {
         let lsn = self.append(op.clone())?;
         self.flush_sync()?;
         Ok(WalEntry { lsn, op })
+    }
+}
+
+/// Roll the writer's state back to the last durable boundary. Called
+/// on any I/O failure so a later successful flush cannot resurrect a
+/// frame the caller was told had failed. Truncates the file, resets
+/// the write cursor to the durable tail (so the next append lands at
+/// the right offset instead of creating a hole), and rewinds
+/// `next_lsn` to the start of the un-flushed batch, if any.
+fn rollback(state: &mut WriterState, next_lsn: &AtomicU64) {
+    let _ = state.file.set_len(state.durable_len);
+    let _ = state.file.seek(SeekFrom::Start(state.durable_len));
+    if let Some(start) = state.undurable_start_lsn.take() {
+        next_lsn.store(start, Ordering::SeqCst);
     }
 }
 

--- a/native/engine/src/wal/writer.rs
+++ b/native/engine/src/wal/writer.rs
@@ -166,17 +166,23 @@ impl WalWriter {
         let mut state = self.inner.lock();
         let lsn = self.next_lsn.load(Ordering::SeqCst);
         let frame = encode_frame(lsn, tag, &payload);
+        // On failure, always use the full `rollback` — not a
+        // single-frame truncate. If a prior `append` call left
+        // un-flushed frames in the file, truncating to `durable_len`
+        // destroys them too, and without rewinding `next_lsn` the
+        // next write would skip those destroyed LSNs and produce a
+        // permanent gap recovery would treat as a torn tail.
         if let Err(e) = state.file.write_all(&frame) {
-            single_frame_rollback(&mut state);
+            rollback(&mut state, &self.next_lsn);
             return Err(format!("WAL write: {}", e));
         }
         #[cfg(test)]
         if self.fail_next_sync.swap(false, Ordering::SeqCst) {
-            single_frame_rollback(&mut state);
+            rollback(&mut state, &self.next_lsn);
             return Err("WAL fsync: test injected failure".into());
         }
         if let Err(e) = state.file.sync_data() {
-            single_frame_rollback(&mut state);
+            rollback(&mut state, &self.next_lsn);
             return Err(format!("WAL fsync: {}", e));
         }
         let new_len = state
@@ -194,23 +200,15 @@ impl WalWriter {
     }
 }
 
-/// Rollback helper for `append_sync`'s single-frame scope. Unlike the
-/// batched `rollback`, this never touches `undurable_start_lsn` or
-/// `next_lsn`: because `append_sync` holds the mutex across the entire
-/// write+sync and advances `next_lsn` only on success, there is no
-/// cross-call LSN state to unwind. Truncating the file and resetting
-/// the cursor is enough.
-fn single_frame_rollback(state: &mut WriterState) {
-    let _ = state.file.set_len(state.durable_len);
-    let _ = state.file.seek(SeekFrom::Start(state.durable_len));
-}
-
-/// Roll the writer's state back to the last durable boundary. Called
-/// on any I/O failure so a later successful flush cannot resurrect a
-/// frame the caller was told had failed. Truncates the file, resets
-/// the write cursor to the durable tail (so the next append lands at
-/// the right offset instead of creating a hole), and rewinds
-/// `next_lsn` to the start of the un-flushed batch, if any.
+/// Roll the writer's state back to the last durable boundary. Used
+/// by both `append` + `flush_sync` and `append_sync` on any I/O
+/// failure so a later successful flush cannot resurrect a frame the
+/// caller was told had failed. Truncates the file, rewinds the write
+/// cursor (so the next append lands at the right offset instead of
+/// creating a hole), and — if there was an un-flushed batch in
+/// progress — rewinds `next_lsn` to the start of that batch so
+/// retries reclaim the lost LSNs rather than skipping past them and
+/// leaving a permanent gap recovery would mistake for a torn tail.
 fn rollback(state: &mut WriterState, next_lsn: &AtomicU64) {
     let _ = state.file.set_len(state.durable_len);
     let _ = state.file.seek(SeekFrom::Start(state.durable_len));


### PR DESCRIPTION
## The hole

The writer wrapped its file in a \`BufWriter\`. A failed \`flush_sync\` left the encoded frame in the buffer, and the next successful \`flush_sync\` (for an unrelated operation) would quietly commit the failed frame to disk. At the caller level that first op had already returned \`Err\` and been rolled back at the SQL layer; recovery would then replay the resurrected frame and produce a phantom row or ghost write.

Concretely: INSERT row R1, flush_sync fails (disk full, network blip), caller aborts the transaction. INSERT row R2 later after space frees, flush_sync succeeds. Both R1 and R2 are now durable. Recovery replays both. R1 was never committed.

## The fix

Replace \`BufWriter\` with direct \`File\` I/O and track \`durable_len\` — the file length that is known to be on disk.

On any write or fsync failure:
1. Truncate the file back to \`durable_len\`
2. Seek the write cursor to the same offset
3. Rewind \`next_lsn\` to the start of the un-flushed batch

A retry after a rollback reclaims the lost LSN, so there's no gap in the on-disk LSN sequence to confuse recovery's torn-write detection.

## Windows gotcha

Had to switch \`OpenOptions\` from append-mode to write-mode. On Windows, append opens grant only \`FILE_APPEND_DATA\`, which does not include the \`FILE_WRITE_DATA\` required for \`SetEndOfFile\`, so \`set_len\` silently fails and the rollback would leave the frame in place. First test run caught this immediately: the truncated reader still saw both frames. We manage the write cursor ourselves now since we are the only writer.

## Tests

Three regression tests in \`wal::tests::writer_rollback\`:

- \`flush_sync_failure_drops_buffered_frame\` — failing flush followed by a successful flush of a different frame: only the second frame survives.
- \`flush_sync_failure_rewinds_next_lsn\` — counter rewinds so retries reclaim the lost LSN, preventing recovery from seeing a gap.
- \`flush_sync_failure_keeps_prior_durable_entries\` — rollback truncates only to the last durable boundary, not to zero.

Added a \`#[cfg(test)] fail_next_sync\` atomic so cargo tests can hit the error branch without inducing a real I/O failure. Gated behind \`#[cfg(test)]\` so it cannot leak into production builds.

All 359 lib tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
