### PR TITLE
fix: storage::create_table rejects duplicate slots instead of silently overwriting

### DIFF
--- a/native/engine/src/executor/ddl.rs
+++ b/native/engine/src/executor/ddl.rs
@@ -46,7 +46,7 @@ pub(crate) fn exec_create_table(create: &pg_query::protobuf::CreateStmt) -> Resu
         e
     })?;
     catalog::create_table(table.clone())?;
-    storage::create_table(schema, table_name);
+    storage::create_table(schema, table_name)?;
     storage::setup_table_indexes(&table)?;
     Ok(QueryResult { tag: "CREATE TABLE".into(), columns: vec![], rows: vec![] })
 }

--- a/native/engine/src/executor/ddl_ctas.rs
+++ b/native/engine/src/executor/ddl_ctas.rs
@@ -34,7 +34,7 @@ pub(crate) fn exec_create_table_as(ctas: &pg_query::protobuf::CreateTableAsStmt)
     // checked batch path, so just the CREATE TABLE step needs reordering.
     crate::wal::manager::append_create_table(&table)?;
     catalog::create_table(table.clone())?;
-    storage::create_table(schema, table_name);
+    storage::create_table(schema, table_name)?;
     let rows: Vec<Vec<crate::types::Value>> = raw_rows.iter()
         .map(|row| row.iter().map(|v| v.to_value(&arena)).collect())
         .collect();

--- a/native/engine/src/storage.rs
+++ b/native/engine/src/storage.rs
@@ -44,18 +44,35 @@ fn get_table(schema: &str, name: &str) -> Result<Arc<RwLock<TableStore>>, String
         .ok_or_else(|| format!("table \"{}.{}\" not found in storage", schema, name))
 }
 
-pub fn create_table(schema: &str, name: &str) {
+/// Register an empty storage slot for a new table. Returns Err if a
+/// slot already exists at `schema.name` instead of silently replacing
+/// it — a duplicate call would detach the existing TableStore (and
+/// every row, index, and HNSW it holds) from the public map while
+/// other threads still held Arc clones pointing at the old one,
+/// leaving behind a zombie that could never be queried. Callers are
+/// expected to have already gated on `catalog::create_table`, which
+/// rejects duplicates at the schema layer, so hitting this error
+/// means the catalog and storage maps have drifted apart — a bug
+/// worth surfacing loudly rather than papering over.
+pub fn create_table(schema: &str, name: &str) -> Result<(), String> {
     let mut store = STORE.write();
-    store.insert(
-        key(schema, name),
-        Arc::new(RwLock::new(TableStore {
-            rows: Vec::new(),
-            unique_indexes: HashMap::new(),
-            pk_cols: Vec::new(),
-            pk_index: None,
-            hnsw_index: None,
-        })),
-    );
+    use std::collections::hash_map::Entry;
+    match store.entry(key(schema, name)) {
+        Entry::Occupied(_) => Err(format!(
+            "storage::create_table: {}.{} already exists",
+            schema, name
+        )),
+        Entry::Vacant(slot) => {
+            slot.insert(Arc::new(RwLock::new(TableStore {
+                rows: Vec::new(),
+                unique_indexes: HashMap::new(),
+                pk_cols: Vec::new(),
+                pk_index: None,
+                hnsw_index: None,
+            })));
+            Ok(())
+        }
+    }
 }
 
 /// Register a hash index for a unique/PK column. O(1) constraint checks.
@@ -975,7 +992,7 @@ mod tests {
     #[serial_test::serial]
     fn insert_and_scan() {
         reset();
-        create_table("public", "t");
+        create_table("public", "t").unwrap();
         insert(
             "public",
             "t",
@@ -997,11 +1014,40 @@ mod tests {
     #[serial_test::serial]
     fn delete_all_works() {
         reset();
-        create_table("public", "t");
+        create_table("public", "t").unwrap();
         insert("public", "t", vec![Value::Int(1)]).unwrap();
         insert("public", "t", vec![Value::Int(2)]).unwrap();
         let count = delete_all("public", "t").unwrap();
         assert_eq!(count, 2);
         assert_eq!(scan("public", "t").unwrap().len(), 0);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn create_table_rejects_duplicate() {
+        // Regression for the silent-overwrite hole. Prior behavior
+        // was HashMap::insert, which happily replaced the existing
+        // TableStore. Any rows or indexes the old store held would
+        // become orphans — still referenced by Arc clones any
+        // scan-in-flight thread had cloned, but no longer reachable
+        // from the public STORE map — so the data would look gone
+        // to everyone coming after the overwrite without producing
+        // an error. Now the second call errors out.
+        reset();
+        create_table("public", "t").unwrap();
+        insert("public", "t", vec![Value::Int(42)]).unwrap();
+
+        let err = create_table("public", "t").unwrap_err();
+        assert!(
+            err.contains("already exists"),
+            "expected 'already exists' error, got {:?}",
+            err
+        );
+
+        // The pre-existing store must still be intact — the failed
+        // second call must not have touched it.
+        let rows = scan("public", "t").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0][0], Value::Int(42));
     }
 }

--- a/native/engine/src/wal/recovery/apply/mod.rs
+++ b/native/engine/src/wal/recovery/apply/mod.rs
@@ -32,7 +32,7 @@ pub fn apply_entries(entries: &[WalEntry]) -> Result<usize, String> {
             WalOp::CreateTable { table } => {
                 if catalog::get_table(&table.schema, &table.name).is_some() { continue; }
                 catalog::create_table(table.clone())?;
-                storage::create_table(&table.schema, &table.name);
+                storage::create_table(&table.schema, &table.name)?;
                 storage::setup_table_indexes(table)?;
                 sequences::recreate_for_table(table);
                 applied += 1;


### PR DESCRIPTION
## The hole

Prior behavior was \`HashMap::insert\`, which happily replaced the existing \`TableStore\` when called twice with the same \`schema.table\`. The replaced store still lived behind any \`Arc\` clones that in-flight scan threads had picked up before the overwrite, but was no longer reachable from the public \`STORE\` map — a zombie holding rows, indexes, and HNSW state that could never be queried again.

Every production caller already gates on \`catalog::create_table\`, which rejects duplicates at the schema layer. So hitting this path means the catalog and storage maps have drifted apart — a bug worth surfacing loudly rather than papering over by silently throwing away the existing table's state.

## The fix

Return \`Err\` on duplicate via \`HashMap::entry\`, and have the three callers propagate it with \`?\`:

- \`exec_create_table\` (\`executor/ddl.rs\`)
- \`exec_create_table_as\` (\`executor/ddl_ctas.rs\`)
- \`CreateTable\` WAL replay (\`wal/recovery/apply/mod.rs\`)

## Tests

One new regression test in \`storage::tests::create_table_rejects_duplicate\`:

1. Create table \`t\` and insert a row.
2. Call \`create_table\` again for the same name.
3. Assert it returns \`Err\` containing \"already exists\".
4. Assert the pre-existing row is still readable — proves the failed call did not touch the existing store.

Updated the two pre-existing storage unit tests (\`insert_and_scan\`, \`delete_all_works\`) to \`.unwrap()\` the new \`Result\` from \`create_table\`.

All 357 lib tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
