### PR TITLE
fix: CREATE TABLE cleans up SERIAL sequences on any step failure, not just WAL

### DIFF
--- a/native/engine/src/executor/ddl.rs
+++ b/native/engine/src/executor/ddl.rs
@@ -28,26 +28,30 @@ pub(crate) fn exec_create_table(create: &pg_query::protobuf::CreateStmt) -> Resu
         for (s, n) in &created_sequences { crate::sequence::drop_sequence(s, n); }
         return Ok(QueryResult { tag: "CREATE TABLE".into(), columns: vec![], rows: vec![] });
     }
-    // WAL-first: the log is the source of truth. If we persist intent
-    // first and then crash mid-mutation, recovery re-applies cleanly
-    // because the in-memory state is rebuilt from scratch. If we were
-    // to mutate first and then crash before the WAL append, recovery
-    // would have no record of the change and the next startup would
-    // look the same as before the DDL — but any user code that ran in
-    // the interim would have seen the table, producing ghost writes.
+    // WAL-first: the log is the source of truth. Persist intent
+    // first and then mutate in-memory state, so that a mid-mutation
+    // crash replays cleanly from the WAL.
     //
-    // On WAL append failure we must also drop any SERIAL sequences
-    // that `parse_column_def` created up-front: until this point
-    // nothing references them, and if we leave them lying around a
-    // retry of the same CREATE TABLE fails with "sequence already
-    // exists" and the engine is stuck refusing that DDL forever.
-    crate::wal::manager::append_create_table(&table).map_err(|e| {
+    // Drop the SERIAL sequences if ANY step after their up-front
+    // creation fails: WAL append, catalog, storage, or index
+    // build. The catalog/storage paths can fail in practice when a
+    // racing thread creates the same table under a different
+    // definition (catalog returns "relation already exists" even
+    // though we already wrote the SERIAL sequence). Without this
+    // cleanup the orphan sequence accumulates in the process and
+    // any later re-attempt at the same table name + SERIAL column
+    // fails with "sequence already exists" forever.
+    let result = (|| -> Result<(), String> {
+        crate::wal::manager::append_create_table(&table)?;
+        catalog::create_table(table.clone())?;
+        storage::create_table(schema, table_name)?;
+        storage::setup_table_indexes(&table)?;
+        Ok(())
+    })();
+    if let Err(e) = result {
         for (s, n) in &created_sequences { crate::sequence::drop_sequence(s, n); }
-        e
-    })?;
-    catalog::create_table(table.clone())?;
-    storage::create_table(schema, table_name)?;
-    storage::setup_table_indexes(&table)?;
+        return Err(e);
+    }
     Ok(QueryResult { tag: "CREATE TABLE".into(), columns: vec![], rows: vec![] })
 }
 

--- a/native/engine/src/wal/tests/recovery/mod.rs
+++ b/native/engine/src/wal/tests/recovery/mod.rs
@@ -26,6 +26,7 @@ mod vector_alter;
 mod nif_boot;
 mod ddl_wal_first;
 mod ddl_phantom_wal;
+mod serial_cleanup;
 
 pub(super) fn tmp_recovery_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();

--- a/native/engine/src/wal/tests/recovery/serial_cleanup.rs
+++ b/native/engine/src/wal/tests/recovery/serial_cleanup.rs
@@ -1,0 +1,96 @@
+//! Sequence cleanup for partial CREATE TABLE failures. `parse_column_def`
+//! eagerly creates the SERIAL sequence before any of the WAL / catalog /
+//! storage steps run. Every failure mode after that point has to drop
+//! the sequence again, or a running server accumulates orphans and
+//! later re-attempts of the same DDL fail with "sequence already
+//! exists" forever.
+//!
+//! The live-path failures to cover:
+//! - WAL append fails (FAIL_NEXT_APPEND)
+//! - catalog::create_table fails (racing thread already created the
+//!   table under a different definition)
+//! - storage::create_table fails (storage and catalog drifted — a bug,
+//!   but the cleanup path still needs to fire)
+//! - setup_table_indexes fails (a constraint error at index build)
+
+use std::sync::atomic::Ordering;
+
+use super::super::super::*;
+use super::tmp_recovery_path;
+use crate::{catalog, executor, sequence, storage};
+
+fn setup(name: &str) -> std::path::PathBuf {
+    let path = tmp_recovery_path(name);
+    catalog::reset();
+    storage::reset();
+    sequence::reset();
+    manager::disable();
+    manager::enable(&path).unwrap();
+    path
+}
+
+fn teardown(path: &std::path::PathBuf) {
+    manager::disable();
+    let _ = std::fs::remove_file(path);
+}
+
+fn seq_exists(schema: &str, name: &str) -> bool {
+    // `currval` is a pure read, unlike `nextval`, so it doesn't
+    // mutate the sequence we're probing for existence.
+    sequence::currval(schema, name).is_ok()
+}
+
+#[test]
+#[serial_test::serial]
+fn wal_failure_cleans_up_serial_sequence() {
+    // Baseline: WAL append failure. Already covered elsewhere but
+    // pinned here with a direct assertion on the sequence.
+    let path = setup("serial_wal_fail");
+
+    manager::FAIL_NEXT_APPEND.store(true, Ordering::SeqCst);
+    let res = executor::execute("CREATE TABLE t (id SERIAL, name text)");
+    assert!(res.is_err());
+
+    // The sequence must be gone, not merely dormant.
+    assert!(
+        !seq_exists("public", "t_id_seq"),
+        "WAL-failure path must drop the SERIAL sequence"
+    );
+
+    teardown(&path);
+}
+
+#[test]
+#[serial_test::serial]
+fn catalog_conflict_cleans_up_serial_sequence() {
+    // Racing definition scenario. Another caller creates table `t`
+    // without SERIAL; ours tries to create `t` with SERIAL. The WAL
+    // append lands (WAL does not pre-check catalog state), then
+    // catalog::create_table rejects with "relation already exists".
+    // The SERIAL sequence we created in parse_column_def must be
+    // dropped, not leaked.
+    let path = setup("serial_catalog_conflict");
+
+    executor::execute("CREATE TABLE t (id int)").unwrap();
+    assert!(!seq_exists("public", "t_id_seq"));
+
+    let res = executor::execute("CREATE TABLE t (id SERIAL, name text)");
+    assert!(
+        res.is_err(),
+        "conflicting definition must fail at catalog::create_table"
+    );
+    assert!(
+        !seq_exists("public", "t_id_seq"),
+        "orphan sequence survived a failed CREATE TABLE — recent retry of \
+         the same DDL would fail with 'already exists' forever"
+    );
+
+    // And the retry path (drop + recreate with SERIAL) must succeed.
+    executor::execute("DROP TABLE t").unwrap();
+    executor::execute("CREATE TABLE t (id SERIAL, name text)").unwrap();
+    executor::execute("INSERT INTO t (name) VALUES ('a')").unwrap();
+    let r = executor::execute("SELECT id FROM t").unwrap();
+    assert_eq!(r.rows[0][0], Some("1".into()));
+
+    teardown(&path);
+}


### PR DESCRIPTION
## The hole

The prior \`map_err\` on \`append_create_table\` only cleaned up the up-front SERIAL sequence when the **WAL** write failed. Every post-WAL step — \`catalog::create_table\`, \`storage::create_table\`, \`setup_table_indexes\` — could also fail and leak the sequence.

The realistic trigger is a racing definition:

1. Thread A: \`CREATE TABLE t (id int)\` — succeeds
2. Thread B: \`CREATE TABLE t (id SERIAL, name text)\`
   - \`parse_column_def\` creates sequence \`public.t_id_seq\`
   - WAL append lands (WAL does not pre-check catalog state)
   - \`catalog::create_table\` returns \`relation \"t\" already exists\`
   - B's return \`Err\` — but \`public.t_id_seq\` stays orphaned in the process forever
3. Any later re-attempt at a table with that SERIAL column name fails with \`sequence already exists\`.

## The fix

Wrap the four post-parse steps in an immediately-invoked closure and run the \`drop_sequence\` cleanup on any error from the block. Pre-parse error paths (\`parse_column_def\` and the \`if_not_exists\` fast-path) already cleaned up and are untouched.

## Tests

Two new regression tests in \`wal::tests::recovery::serial_cleanup\`:

- **\`wal_failure_cleans_up_serial_sequence\`** — pins the WAL-failure path via \`FAIL_NEXT_APPEND\` and a direct \`currval\` probe that \`public.t_id_seq\` is gone.
- **\`catalog_conflict_cleans_up_serial_sequence\`** — induces the racing definition via two sequential CREATE statements and asserts the sequence is gone after the conflict. **Verified to fail without the fix** (assertion message: \`orphan sequence survived a failed CREATE TABLE\`) and pass with it.

All 375 lib tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jagritgumber/evolvsql/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
